### PR TITLE
Update to elasticsearch 1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
-<!-- Licensed to David Pilato (the "Author") under one or more contributor 
-	license agreements. See the NOTICE file distributed with this work for additional 
-	information regarding copyright ownership. Author licenses this file to you 
-	under the Apache License, Version 2.0 (the "License"); you may not use this 
-	file except in compliance with the License. You may obtain a copy of the 
-	License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by 
-	applicable law or agreed to in writing, software distributed under the License 
-	is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY 
-	KIND, either express or implied. See the License for the specific language 
+<!-- Licensed to David Pilato (the "Author") under one or more contributor
+	license agreements. See the NOTICE file distributed with this work for additional
+	information regarding copyright ownership. Author licenses this file to you
+	under the Apache License, Version 2.0 (the "License"); you may not use this
+	file except in compliance with the License. You may obtain a copy of the
+	License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by
+	applicable law or agreed to in writing, software distributed under the License
+	is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+	KIND, either express or implied. See the License for the specific language
 	governing permissions and limitations under the License. -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -36,9 +36,9 @@
     </licenses>
 
     <properties>
-        <elasticsearch.version>1.0.1</elasticsearch.version>
+        <elasticsearch.version>1.2.0</elasticsearch.version>
         <tika.version>1.4</tika.version>
-        <lucene.version>4.6.1</lucene.version>
+        <lucene.version>4.8.1</lucene.version>
         <tests.output>onerror</tests.output>
         <tests.jvms>1</tests.jvms>
         <tests.shuffle>true</tests.shuffle>
@@ -309,13 +309,13 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
-            <version>1.3.RC2</version>
+            <version>1.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
-            <version>1.3.RC2</version>
+            <version>1.3</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/fr/pilato/elasticsearch/river/fs/rest/ManageRiverAction.java
+++ b/src/main/java/fr/pilato/elasticsearch/river/fs/rest/ManageRiverAction.java
@@ -19,18 +19,22 @@
 
 package fr.pilato.elasticsearch.river.fs.rest;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.rest.*;
 import org.elasticsearch.rest.RestRequest.Method;
-import org.elasticsearch.rest.action.support.RestXContentBuilder;
 
 import java.io.IOException;
 
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.ExceptionsHelper.detailedMessage;
 
 public class ManageRiverAction extends BaseRestHandler {
 
@@ -66,7 +70,7 @@ public class ManageRiverAction extends BaseRestHandler {
                     .startObject()
                     .field(new XContentBuilderString("ok"), true)
                     .endObject();
-            channel.sendResponse(new XContentRestResponse(request, RestStatus.OK, builder));
+            channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
         } catch (IOException e) {
             onFailure(channel, request, e);
         }
@@ -80,4 +84,86 @@ public class ManageRiverAction extends BaseRestHandler {
             logger.error("Failed to send failure response", e1);
         }
     }
+
+  public static class RestXContentBuilder {
+
+    public static XContentBuilder restContentBuilder(RestRequest request) throws IOException {
+      XContentType contentType = XContentType.fromRestContentType(request.param("format", request.header("Content-Type")));
+      if (contentType == null) {
+        // default to JSON
+        contentType = XContentType.JSON;
+      }
+      XContentBuilder builder = new XContentBuilder(XContentFactory.xContent(contentType),
+      new BytesStreamOutput());
+      if (request.paramAsBoolean("pretty", false)) {
+        builder.prettyPrint().lfAtEnd();
+      }
+      String casing = request.param("case");
+      if (casing != null && "camelCase".equals(casing)) {
+        builder.fieldCaseConversion(XContentBuilder.FieldCaseConversion.CAMELCASE);
+      } else {
+        // we expect all REST interfaces to write results in underscore casing, so
+        // no need for double casing
+        builder.fieldCaseConversion(XContentBuilder.FieldCaseConversion.NONE);
+      }
+      return builder;
+    }
+
+    public static XContentBuilder emptyBuilder(RestRequest request) throws IOException {
+      return restContentBuilder(request).startObject().endObject();
+    }
+
+  }
+
+  public static class XContentThrowableRestResponse extends BytesRestResponse {
+
+    public XContentThrowableRestResponse(RestRequest request, Throwable t) throws IOException {
+      this(request, ((t instanceof ElasticsearchException) ? ((ElasticsearchException) t).status() : RestStatus.INTERNAL_SERVER_ERROR), t);
+    }
+
+    public XContentThrowableRestResponse(RestRequest request, RestStatus status, Throwable t) throws IOException {
+      super(status, convert(request, status, t));
+    }
+
+    private static XContentBuilder convert(RestRequest request, RestStatus status, Throwable t) throws IOException {
+      XContentBuilder builder = RestXContentBuilder.restContentBuilder(request).startObject()
+          .field("error", detailedMessage(t))
+          .field("status", status.getStatus());
+      if (t != null && request.paramAsBoolean("error_trace", false)) {
+        builder.startObject("error_trace");
+        boolean first = true;
+        while (t != null) {
+          if (!first) {
+            builder.startObject("cause");
+          }
+          buildThrowable(t, builder);
+          if (!first) {
+            builder.endObject();
+          }
+          t = t.getCause();
+          first = false;
+        }
+        builder.endObject();
+      }
+      builder.endObject();
+      return builder;
+    }
+
+    private static void buildThrowable(Throwable t, XContentBuilder builder) throws IOException {
+      builder.field("message", t.getMessage());
+      for (StackTraceElement stElement : t.getStackTrace()) {
+        builder.startObject("at")
+        .field("class", stElement.getClassName())
+        .field("method", stElement.getMethodName());
+        if (stElement.getFileName() != null) {
+          builder.field("file", stElement.getFileName());
+        }
+        if (stElement.getLineNumber() >= 0) {
+          builder.field("line", stElement.getLineNumber());
+        }
+        builder.endObject();
+      }
+    }
+  }
+
 }

--- a/src/test/java/fr/pilato/elasticsearch/river/fs/integration/FsRiverAllParametersTest.java
+++ b/src/test/java/fr/pilato/elasticsearch/river/fs/integration/FsRiverAllParametersTest.java
@@ -21,11 +21,11 @@ package fr.pilato.elasticsearch.river.fs.integration;
 
 import fr.pilato.elasticsearch.river.fs.river.FsRiver;
 import fr.pilato.elasticsearch.river.fs.util.FsRiverUtil;
+import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.action.count.CountResponse;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.base.Predicate;
-import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -160,7 +160,7 @@ public class FsRiverAllParametersTest extends ElasticsearchIntegrationTest {
     public void tearDown() throws Exception {
         logger.info("  --> stopping rivers");
         // We need to make sure that the _river is stopped
-        wipeIndices("_river");
+        client().admin().indices().prepareDelete("_river").get();
 
         // We have to wait a little because it could throw java.lang.RuntimeException
         Thread.sleep(1000);
@@ -305,7 +305,7 @@ public class FsRiverAllParametersTest extends ElasticsearchIntegrationTest {
         // We first create a copy of a file
         File file1 = new File(fullpath + File.separator + "roottxtfile.txt");
         File file2 = new File(fullpath + File.separator + "deleted_roottxtfile.txt");
-        FileSystemUtils.copyFile(file1, file2);
+        IOUtils.copy(file1, file2);
 
         XContentBuilder river = startRiverDefinition(dir);
         startRiver("remove_deleted_enabled", endRiverDefinition(river));
@@ -335,7 +335,7 @@ public class FsRiverAllParametersTest extends ElasticsearchIntegrationTest {
         // We first create a copy of a file
         File file1 = new File(fullpath + File.separator + "roottxtfile.txt");
         File file2 = new File(fullpath + File.separator + "deleted_roottxtfile.txt");
-        FileSystemUtils.copyFile(file1, file2);
+        IOUtils.copy(file1, file2);
 
         XContentBuilder river = startRiverDefinition(dir)
                 .field("remove_deleted", false);
@@ -376,7 +376,7 @@ public class FsRiverAllParametersTest extends ElasticsearchIntegrationTest {
         // We create a copy of a file
         File file1 = new File(fullpath + File.separator + "roottxtfile.txt");
         File file2 = new File(fullpath + File.separator + "new_roottxtfile.txt");
-        FileSystemUtils.copyFile(file1, file2);
+        IOUtils.copy(file1, file2);
 
         Thread.sleep(1000);
 


### PR DESCRIPTION
Hi,

A small initial patch to upgrade fsriver to elasticsearch 1.2.0. Some classes have disappeared in recent elasticsearch distribution, such as RestXContentBuilder. We have followed the same approach than in the mongodb plugin, i.e., copy pasting the original classes into the distrib.
With respect to the unit tests, on our side some of them are failing randomly. We have tried to debug it, but without success. It looks like some problem with file timestamp or due to the random order of the execution of the tests.
