### PR TITLE
Fixed not closed SSH connections

### DIFF
--- a/src/main/java/fr/pilato/elasticsearch/river/fs/river/FileAbstractorSSH.java
+++ b/src/main/java/fr/pilato/elasticsearch/river/fs/river/FileAbstractorSSH.java
@@ -84,6 +84,7 @@ public class FileAbstractorSSH extends FileAbstractor<ChannelSftp.LsEntry> {
     @Override
     public void close() throws Exception {
         sftp.disconnect();
+		sftp.getSession().disconnect();
     }
 
     public ChannelSftp openSSHConnection(FsRiverFeedDefinition fsdef) throws Exception {


### PR DESCRIPTION
SSH connections doesn't get closed at all. Should work now.
https://github.com/dadoonet/fsriver/issues/96