### PR TITLE
fix recursive scan when using include/exclude filters

### DIFF
--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsCrawlerImpl.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsCrawlerImpl.java
@@ -362,7 +362,7 @@ public class FsCrawlerImpl {
                     // https://github.com/dadoonet/fscrawler/issues/1 : Filter documents
                     boolean isIndexable = FsCrawlerUtil.isIndexable(filename, fsSettings.getFs().getIncludes(), fsSettings.getFs().getExcludes());
                     logger.debug("[{}] can be indexed: [{}]", filename, isIndexable);
-                    if (isIndexable) {
+                    if (child.directory || isIndexable) {
                         if (child.file) {
                             logger.debug("  - file: {}", filename);
                             fsFiles.add(filename);


### PR DESCRIPTION
See issue #206 
With this change all subdirectories will be indexed. If this is not desirable, we could also add a separate set of include/exclude pattern settings for directories.
