### PR TITLE
Prevent customised mappings from being overwritten

### DIFF
--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/util/FsCrawlerUtil.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/util/FsCrawlerUtil.java
@@ -355,9 +355,13 @@ public class FsCrawlerUtil extends MetaParser {
         Path targetResourceDir = configPath.resolve("_default");
 
         for (String filename : MAPPING_RESOURCES) {
-            logger.debug("Copying [{}]...", filename);
             Path target = targetResourceDir.resolve(filename);
-            copyResourceFile(CLASSPATH_RESOURCES_ROOT + filename, target);
+            if (Files.exists(target)) {
+                logger.debug("Mapping [{}] already exsits", filename);
+            } else {
+                logger.debug("Copying [{}]...", filename);
+                copyResourceFile(CLASSPATH_RESOURCES_ROOT + filename, target);
+            }
         }
     }
 


### PR DESCRIPTION
Stops overwrite of existing mappings in ~/.fscrawler/_default/ each time fscrawler is run. This is important to prevent lost changes when customising analyzers etc.

Users can revert to default by deleting customised mapping files and rerunning fscrawler as normal.
