### PR TITLE
add link to repo with dockerfile usage of fscrawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1595,6 +1595,9 @@ the `port`.
 To deal with images containing text, just [install Tesseract](https://github.com/tesseract-ocr/tesseract/wiki). Tesseract will be auto-detected by Tika.
 Then add an image (png, jpg, ...) into your Fscrawler [root directory](#root-directory). After the next index update, the text will be indexed and placed in "_source.content".
 
+# Using docker
+For how to use `fscrawler` with [docker](https://www.docker.com/), check [docker-fscrawler](https://github.com/shadiakiki1986/docker-fscrawler)
+
 # Developing on FS Crawler project
 
 If you are thinking of contributing on the project, which is highly appreciated, here are


### PR DESCRIPTION
Including documentation on using docker in the readme was becoming too long as I wrote it, so I just made a sample repository showing it, and I linked to the repo from the readme