### PR TITLE
Fix default values

### DIFF
--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/meta/settings/Elasticsearch.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/meta/settings/Elasticsearch.java
@@ -182,9 +182,9 @@ public class Elasticsearch {
 
     private List<Node> nodes;
     private String index;
-    private String type;
-    private int bulkSize;
-    private TimeValue flushInterval;
+    private String type = FsCrawlerUtil.INDEX_TYPE_DOC;
+    private int bulkSize = 100;
+    private TimeValue flushInterval = TimeValue.timeValueSeconds(5);
     private String username;
     @JsonIgnore
     private String password;

--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/meta/settings/Fs.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/meta/settings/Fs.java
@@ -30,16 +30,16 @@ public class Fs {
     private List<String> excludes;
     private boolean jsonSupport;
     private boolean filenameAsId;
-    private boolean addFilesize;
-    private boolean removeDeleted;
+    private boolean addFilesize = true;
+    private boolean removeDeleted = true;
     private boolean storeSource;
-    private boolean indexContent;
+    private boolean indexContent = true;
     private Percentage indexedChars;
     private boolean attributesSupport;
     private boolean rawMetadata;
     private boolean xmlSupport;
     private String checksum;
-    private boolean indexFolders;
+    private boolean indexFolders = true;
     private boolean langDetect;
 
     public static Builder builder() {

--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/meta/settings/Server.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/meta/settings/Server.java
@@ -38,11 +38,11 @@ public class Server {
     }
 
     private String hostname;
-    private int port;
+    private int port = PROTOCOL.SSH_PORT;
     private String username;
     @JsonIgnore
     private String password;
-    private String protocol;
+    private String protocol = PROTOCOL.LOCAL;
     private String pemPath;
 
     public String getHostname() {


### PR DESCRIPTION
When writing manually a job settings file like the simplest one:

```json
{
  "name": "test"
}
```

We would expect that it comes with advertised default values.
But because I missed setting some default boolean values this is actually not true.

This commit fixes the problem and add a test for this.

Closes #276