### PR TITLE
Define a default exclusion list with files starting with `~`

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,9 @@ and CPU at index time. You should remove existing files in `~/.fscrawler/_defaul
 version so default mappings will be updated. If you modified manually mapping files, apply the modification you made
 on sample files.
 
-
-
+* `excludes` is now set by default for new jobs to `["~*"]`. In previous versions, any file or directory containing a
+`~` was excluded. Which means that if in your jobs, you are defining any exclusion rule, you need to add `*~*` if
+you want to get back the exact previous behavior.
 
 
 # User Guide
@@ -428,7 +429,7 @@ Here is a list of Local FS settings (under `fs.` prefix)`:
 | `fs.url`                         | `"/tmp/es"`   | [Root directory](#root-directory)                                                 |
 | `fs.update_rate`                 | `"15m"`       | [Update Rate](#update-rate)                                                       |
 | `fs.includes`                    | `null`        | [Includes and Excludes](#includes-and-excludes)                                   |
-| `fs.excludes`                    | `null`        | [Includes and Excludes](#includes-and-excludes)                                   |
+| `fs.excludes`                    | `["~*"]`      | [Includes and Excludes](#includes-and-excludes)                                   |
 | `fs.json_support`                | `false`       | [Indexing JSon docs](#indexing-json-docs)                                         |
 | `fs.xml_support`                 | `false`       | [Indexing XML docs](#indexing-xml-docs) (from 2.2)                                |
 | `fs.ignore_folders`              | `false`       | [Ignore folders](#iignore-folders) (from 2.2)                                     |
@@ -513,6 +514,7 @@ Define `fs.includes` and `fs.excludes` properties in your `~/.fscrawler/test/_se
 It also applies to directory names. So if you want to ignore `.ignore` dir, just add `.ignore` as an excluded name.
 Note that `includes` does not apply to directory names but only to filenames.
 
+By default, FS crawler will exclude files starting with `~`.
 
 #### Indexing JSon docs
 

--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/meta/settings/Fs.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/meta/settings/Fs.java
@@ -20,6 +20,7 @@
 package fr.pilato.elasticsearch.crawler.fs.meta.settings;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @SuppressWarnings("SameParameterValue")
@@ -47,7 +48,8 @@ public class Fs {
     }
 
     public static final String DEFAULT_DIR = "/tmp/es";
-    public static final Fs DEFAULT = Fs.builder().setUrl(DEFAULT_DIR).build();
+    public static final List<String> DEFAULT_EXCLUDED = Collections.singletonList("~*");
+    public static final Fs DEFAULT = Fs.builder().setUrl(DEFAULT_DIR).setExcludes(DEFAULT_EXCLUDED).build();
 
     public static class Builder {
         private String url;

--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/util/FsCrawlerUtil.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/util/FsCrawlerUtil.java
@@ -132,18 +132,6 @@ public class FsCrawlerUtil extends MetaParser {
     public static boolean isIndexable(String filename, List<String> includes, List<String> excludes) {
         logger.debug("filename = [{}], includes = [{}], excludes = [{}]", filename, includes, excludes);
 
-        // Ignore temporary files
-        if (filename.contains("~")) {
-            logger.trace("filename contains ~");
-            return false;
-        }
-
-        // No rules ? Fine, we index everything
-        if ((includes == null || includes.isEmpty()) && (excludes == null || excludes.isEmpty())) {
-            logger.trace("no rules");
-            return true;
-        }
-
         boolean excluded = isExcluded(filename, excludes);
         if (excluded) return false;
 
@@ -158,12 +146,6 @@ public class FsCrawlerUtil extends MetaParser {
      */
     public static boolean isExcluded(String filename, List<String> excludes) {
         logger.debug("filename = [{}], excludes = [{}]", filename, excludes);
-
-        // Ignore temporary files
-        if (filename.contains("~")) {
-            logger.trace("filename contains ~");
-            return true;
-        }
 
         // No rules ? Fine, we index everything
         if (excludes == null || excludes.isEmpty()) {
@@ -193,12 +175,6 @@ public class FsCrawlerUtil extends MetaParser {
      */
     public static boolean isIncluded(String filename, List<String> includes) {
         logger.debug("filename = [{}], includes = [{}]", filename, includes);
-
-        // Ignore temporary files
-        if (filename.contains("~")) {
-            logger.trace("filename contains ~");
-            return false;
-        }
 
         // No rules ? Fine, we index everything
         if (includes == null || includes.isEmpty()) {

--- a/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/unit/FsMatchFilesTest.java
+++ b/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/unit/FsMatchFilesTest.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 
+import static fr.pilato.elasticsearch.crawler.fs.meta.settings.Fs.DEFAULT_EXCLUDED;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -64,8 +65,9 @@ public class FsMatchFilesTest extends AbstractFSCrawlerTestCase {
 
     @Test
     public void default_ignored_file() {
-        assertThat(FsCrawlerUtil.isIndexable("~mydoc", new ArrayList<>(), new ArrayList<>()), is(false));
-        assertThat(FsCrawlerUtil.isIndexable("~", new ArrayList<>(), new ArrayList<>()), is(false));
-        assertThat(FsCrawlerUtil.isIndexable("adoc.doc", new ArrayList<>(), new ArrayList<>()), is(true));
+        assertThat(FsCrawlerUtil.isIndexable("~mydoc", new ArrayList<>(), DEFAULT_EXCLUDED), is(false));
+        assertThat(FsCrawlerUtil.isIndexable("~", new ArrayList<>(), DEFAULT_EXCLUDED), is(false));
+        assertThat(FsCrawlerUtil.isIndexable("adoc.doc", new ArrayList<>(), DEFAULT_EXCLUDED), is(true));
+        assertThat(FsCrawlerUtil.isIndexable("mydoc~", new ArrayList<>(), DEFAULT_EXCLUDED), is(true));
     }
 }

--- a/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/unit/meta/settings/FsSettingsParserTest.java
+++ b/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/unit/meta/settings/FsSettingsParserTest.java
@@ -20,8 +20,6 @@
 package fr.pilato.elasticsearch.crawler.fs.test.unit.meta.settings;
 
 import fr.pilato.elasticsearch.crawler.fs.FsCrawlerValidator;
-import fr.pilato.elasticsearch.crawler.fs.meta.job.FsJob;
-import fr.pilato.elasticsearch.crawler.fs.meta.job.FsJobParser;
 import fr.pilato.elasticsearch.crawler.fs.meta.settings.Elasticsearch;
 import fr.pilato.elasticsearch.crawler.fs.meta.settings.Fs;
 import fr.pilato.elasticsearch.crawler.fs.meta.settings.FsSettings;
@@ -36,7 +34,7 @@ import org.junit.Test;
 import java.io.IOException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.notNullValue;
@@ -122,7 +120,7 @@ public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
         assertThat(settings.getFs(), notNullValue());
         assertThat(settings.getFs().getChecksum(), nullValue());
         assertThat(settings.getFs().getIncludes(), nullValue());
-        assertThat(settings.getFs().getExcludes(), nullValue());
+        assertThat(settings.getFs().getExcludes(), contains("~*"));
         assertThat(settings.getFs().getIndexedChars(), nullValue());
         assertThat(settings.getFs().getUpdateRate(), is(TimeValue.timeValueMinutes(15)));
         assertThat(settings.getFs().getUrl(), is("/tmp/es"));


### PR DESCRIPTION
Until now we were hard coding what is needed to excluded as known temporary files.
This commit makes that more flexible by defining a default exclusion list which can be overriden and
only defaults to files starting with `~` instead of files containing `~`.

So `excludes` is now set by default for new jobs to `["~*"]`. In previous versions, any file or directory containing a
`~` was excluded. Which means that if in your jobs, you are defining any exclusion rule, you need to add `*~*` if
you want to get back the exact previous behavior.

Closes #291.