### PR TITLE
Support `filename_as_id` for any type of file

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ on sample files.
 `~` was excluded. Which means that if in your jobs, you are defining any exclusion rule, you need to add `*~*` if
 you want to get back the exact previous behavior.
 
+* If you were indexing `json` or `xml` documents with the `filename_as_id` option set, we were previously removing the
+suffix of the file name, like indexing `1.json` was indexed as `1`. With this new version, we don't remove anymore the
+suffix. So the `_id` for your document will be now `1.json`.
+
 
 # User Guide
 
@@ -671,9 +675,9 @@ You can also index many types from one single dir using two crawlers scanning th
 }
 ```
 
-##### Using filename as elasticsearch `_id`
+#### Using filename as elasticsearch `_id`
 
-Please note that the document `_id` is always generated (hash value) from the JSon filename to avoid issues with
+Please note that the document `_id` is always generated (hash value) from the filename to avoid issues with
 special characters in filename.
 You can force to use the `_id` to be the filename using `filename_as_id` attribute:
 
@@ -681,13 +685,10 @@ You can force to use the `_id` to be the filename using `filename_as_id` attribu
 {
   "name" : "test",
   "fs" : {
-    "json_support" : true,
     "filename_as_id" : true
   }
 }
 ```
-
-This option can also be used with XML files when you set `xml_support` to `true`.
 
 #### Adding file attributes
 

--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsCrawlerImpl.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsCrawlerImpl.java
@@ -594,7 +594,7 @@ public class FsCrawlerImpl {
                 // We index
                 esIndex(esClientManager.bulkProcessor(), fsSettings.getElasticsearch().getIndex(),
                         fsSettings.getElasticsearch().getType(),
-                        SignTool.sign((new File(dirname, filename)).toString()),
+                        generateIdFromFilename(filename, dirname),
                         doc);
             } finally {
                 // Let's close the stream
@@ -603,17 +603,7 @@ public class FsCrawlerImpl {
         }
 
         private String generateIdFromFilename(String filename, String filepath) throws NoSuchAlgorithmException {
-            String id;
-            if (fsSettings.getFs().isFilenameAsId()) {
-                id = filename;
-                int pos = id.lastIndexOf(".");
-                if (pos > 0) {
-                    id = id.substring(0, pos);
-                }
-            } else {
-                id = SignTool.sign((new File(filepath, filename)).toString());
-            }
-            return id;
+            return fsSettings.getFs().isFilenameAsId() ? filename : SignTool.sign((new File(filepath, filename)).toString());
         }
 
         private String read(InputStream input) throws IOException {

--- a/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerImplAllParametersIT.java
+++ b/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerImplAllParametersIT.java
@@ -507,27 +507,18 @@ public class FsCrawlerImplAllParametersIT extends AbstractITCase {
     }
 
     /**
-     * Test case for issue #7: https://github.com/dadoonet/fscrawler/issues/7 : JSON support: use filename as ID
+     * Test case for issue #7: https://github.com/dadoonet/fscrawler/issues/7 : Use filename as ID
      */
     @Test
     public void test_filename_as_id() throws Exception {
         Fs fs = startCrawlerDefinition()
-                .setJsonSupport(true)
                 .setFilenameAsId(true)
                 .build();
         startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
 
-        assertThat("Document should exists with [tweet1] id...", awaitBusy(() -> {
+        assertThat("Document should exists with [roottxtfile.txt] id...", awaitBusy(() -> {
             try {
-                return elasticsearchClient.isExistingDocument(getCrawlerName(), FsCrawlerUtil.INDEX_TYPE_DOC, "tweet1");
-            } catch (IOException e) {
-                return false;
-            }
-        }), equalTo(true));
-
-        assertThat("Document should exists with [tweet2] id...", awaitBusy(() -> {
-            try {
-                return elasticsearchClient.isExistingDocument(getCrawlerName(), FsCrawlerUtil.INDEX_TYPE_DOC, "tweet2");
+                return elasticsearchClient.isExistingDocument(getCrawlerName(), FsCrawlerUtil.INDEX_TYPE_DOC, "roottxtfile.txt");
             } catch (IOException e) {
                 return false;
             }

--- a/src/test/resources/samples/test_filename_as_id/tweet1.json
+++ b/src/test/resources/samples/test_filename_as_id/tweet1.json
@@ -1,3 +1,0 @@
-{
-    "text": "First tweet in the wall!"
-}

--- a/src/test/resources/samples/test_filename_as_id/tweet2.json
+++ b/src/test/resources/samples/test_filename_as_id/tweet2.json
@@ -1,3 +1,0 @@
-{
-    "text": "Another tweet in the wall!"
-}


### PR DESCRIPTION
Instead of supporting `filename_as_id` only for xml and json, we now support it for whatever file.
Note that it can cause some issues to the user as elasticsearch can't accept any kind of `_id`.

But it's on user's responsability to activate this option.

We can think of replacing on the fly any non valid character with a `_` for example but let's do that in another PR.

Closes #282.