### PR TITLE
move file extension code from TikaDocParser to FsCrawlerImpl

### DIFF
--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsCrawlerImpl.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsCrawlerImpl.java
@@ -536,6 +536,7 @@ public class FsCrawlerImpl {
                                long filesize) throws Exception {
             final String filename = fileAbstractModel.name;
             final LocalDateTime lastmodified = fileAbstractModel.lastModifiedDate;
+	    final String extension = fileAbstractModel.extension;
             final long size = fileAbstractModel.size;
 
             logger.debug("fetching content from [{}],[{}]", dirname, filename);
@@ -550,6 +551,7 @@ public class FsCrawlerImpl {
                     doc.getFile().setLastModified(lastmodified);
                     doc.getFile().setIndexingDate(LocalDateTime.now());
                     doc.getFile().setUrl("file://" + (new File(dirname, filename)).toString());
+                    doc.getFile().setExtension(extension);
                     if (fsSettings.getFs().isAddFilesize()) {
                         doc.getFile().setFilesize(size);
                     }

--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsCrawlerImpl.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsCrawlerImpl.java
@@ -536,7 +536,7 @@ public class FsCrawlerImpl {
                                long filesize) throws Exception {
             final String filename = fileAbstractModel.name;
             final LocalDateTime lastmodified = fileAbstractModel.lastModifiedDate;
-	    final String extension = fileAbstractModel.extension;
+            final String extension = fileAbstractModel.extension;
             final long size = fileAbstractModel.size;
 
             logger.debug("fetching content from [{}],[{}]", dirname, filename);

--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/fileabstractor/FileAbstractModel.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/fileabstractor/FileAbstractModel.java
@@ -52,6 +52,7 @@ public class FileAbstractModel {
     public long size;
     public String owner;
     public String group;
+    public String extension;
 
     @Override
     public String toString() {
@@ -63,6 +64,7 @@ public class FileAbstractModel {
                 ", path='" + path + '\'' +
                 ", owner='" + owner + '\'' +
                 ", group='" + group + '\'' +
+                ", extension='" + extension + '\'' +
                 ", fullpath='" + fullpath + '\'' +
                 ", size=" + size +
                 '}';

--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/fileabstractor/FileAbstractorFile.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/fileabstractor/FileAbstractorFile.java
@@ -45,11 +45,7 @@ public class FileAbstractorFile extends FileAbstractor<File> {
         model.directory = !model.file;
         model.lastModifiedDate = LocalDateTime.ofInstant(Instant.ofEpochMilli(file.lastModified()), ZoneId.systemDefault());
         model.creationDate = FsCrawlerUtil.getCreationTime(file);
-        try {
-            model.extension = FsCrawlerUtil.getFileExtension(file);
-        } catch (Exception e) {
-            logger.warn("Error unable to get File Extension: {}", e.getMessage());
-        }
+        model.extension = FsCrawlerUtil.getFileExtension(file);
         model.path = path;
         model.fullpath = file.getAbsolutePath();
         model.size = file.length();

--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/fileabstractor/FileAbstractorFile.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/fileabstractor/FileAbstractorFile.java
@@ -45,7 +45,11 @@ public class FileAbstractorFile extends FileAbstractor<File> {
         model.directory = !model.file;
         model.lastModifiedDate = LocalDateTime.ofInstant(Instant.ofEpochMilli(file.lastModified()), ZoneId.systemDefault());
         model.creationDate = FsCrawlerUtil.getCreationTime(file);
-        model.extension = FsCrawlerUtil.getFileExtension(file);
+        try {
+            model.extension = FsCrawlerUtil.getFileExtension(file);
+        } catch (Exception e) {
+            logger.warn("Error unable to get File Extension: {}", e.getMessage());
+        }
         model.path = path;
         model.fullpath = file.getAbsolutePath();
         model.size = file.length();

--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/fileabstractor/FileAbstractorFile.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/fileabstractor/FileAbstractorFile.java
@@ -45,6 +45,7 @@ public class FileAbstractorFile extends FileAbstractor<File> {
         model.directory = !model.file;
         model.lastModifiedDate = LocalDateTime.ofInstant(Instant.ofEpochMilli(file.lastModified()), ZoneId.systemDefault());
         model.creationDate = FsCrawlerUtil.getCreationTime(file);
+        model.extension = FsCrawlerUtil.getFileExtension(file);
         model.path = path;
         model.fullpath = file.getAbsolutePath();
         model.size = file.length();

--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
@@ -21,7 +21,7 @@ package fr.pilato.elasticsearch.crawler.fs.tika;
 
 import fr.pilato.elasticsearch.crawler.fs.meta.doc.Doc;
 import fr.pilato.elasticsearch.crawler.fs.meta.settings.FsSettings;
-import org.apache.commons.io.FilenameUtils;
+//moved to FsCrawlerUtil import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.input.TeeInputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -97,7 +97,7 @@ public class TikaDocParser {
 
         // File
         doc.getFile().setContentType(metadata.get(Metadata.CONTENT_TYPE));
-        doc.getFile().setExtension(FilenameUtils.getExtension(filename));
+        //moved to FsCrawlerUtil doc.getFile().setExtension(FilenameUtils.getExtension(filename));
 
         // We only add `indexed_chars` if we have other value than default or -1
         if (fsSettings.getFs().getIndexedChars() != null && fsSettings.getFs().getIndexedChars().value() != -1) {

--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
@@ -21,7 +21,6 @@ package fr.pilato.elasticsearch.crawler.fs.tika;
 
 import fr.pilato.elasticsearch.crawler.fs.meta.doc.Doc;
 import fr.pilato.elasticsearch.crawler.fs.meta.settings.FsSettings;
-//moved to FsCrawlerUtil import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.input.TeeInputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -97,7 +96,6 @@ public class TikaDocParser {
 
         // File
         doc.getFile().setContentType(metadata.get(Metadata.CONTENT_TYPE));
-        //moved to FsCrawlerUtil doc.getFile().setExtension(FilenameUtils.getExtension(filename));
 
         // We only add `indexed_chars` if we have other value than default or -1
         if (fsSettings.getFs().getIndexedChars() != null && fsSettings.getFs().getIndexedChars().value() != -1) {

--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/util/FsCrawlerUtil.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/util/FsCrawlerUtil.java
@@ -222,7 +222,7 @@ public class FsCrawlerUtil extends MetaParser {
         return time;
     }
 
-    public static String getFileExtension(File file) throws Exception {
+    public static String getFileExtension(File file) {
  	return FilenameUtils.getExtension(file.getAbsolutePath()).toLowerCase();
     }
 

--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/util/FsCrawlerUtil.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/util/FsCrawlerUtil.java
@@ -26,6 +26,7 @@ import fr.pilato.elasticsearch.crawler.fs.meta.settings.FsSettingsFileHandler;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.commons.io.FilenameUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -220,6 +221,17 @@ public class FsCrawlerUtil extends MetaParser {
         }
         return time;
     }
+
+    public static String getFileExtension(File file) {
+	String extension;
+        try  {
+ 	    extension = FilenameUtils.getExtension(file.getAbsolutePath());
+        } catch (Exception e) {
+            extension = null;
+        }
+        return extension.toLowerCase();
+    }
+
 
     /**
      * Determines the 'owner' of the file.

--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/util/FsCrawlerUtil.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/util/FsCrawlerUtil.java
@@ -223,7 +223,7 @@ public class FsCrawlerUtil extends MetaParser {
     }
 
     public static String getFileExtension(File file) {
- 	return FilenameUtils.getExtension(file.getAbsolutePath()).toLowerCase();
+        return FilenameUtils.getExtension(file.getAbsolutePath()).toLowerCase();
     }
 
     /**

--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/util/FsCrawlerUtil.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/util/FsCrawlerUtil.java
@@ -222,16 +222,9 @@ public class FsCrawlerUtil extends MetaParser {
         return time;
     }
 
-    public static String getFileExtension(File file) {
-	String extension;
-        try  {
- 	    extension = FilenameUtils.getExtension(file.getAbsolutePath());
-        } catch (Exception e) {
-            extension = null;
-        }
-        return extension.toLowerCase();
+    public static String getFileExtension(File file) throws Exception {
+ 	return FilenameUtils.getExtension(file.getAbsolutePath()).toLowerCase();
     }
-
 
     /**
      * Determines the 'owner' of the file.

--- a/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerImplAllParametersIT.java
+++ b/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerImplAllParametersIT.java
@@ -762,6 +762,7 @@ public class FsCrawlerImplAllParametersIT extends AbstractITCase {
 
         countTestHelper(getCrawlerName(), "content:file*", 0, null);
         countTestHelper(getCrawlerName(), "file.content_type:text*", 0, null);
+        countTestHelper(getCrawlerName(), "file.extension:txt", 1, null);
     }
 
     @Test

--- a/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/unit/FsCrawlerUtilTest.java
+++ b/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/unit/FsCrawlerUtilTest.java
@@ -26,6 +26,7 @@ import fr.pilato.elasticsearch.crawler.fs.test.AbstractFSCrawlerTestCase;
 import fr.pilato.elasticsearch.crawler.fs.util.FsCrawlerUtil;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -86,5 +87,12 @@ public class FsCrawlerUtilTest extends AbstractFSCrawlerTestCase {
         // We test that we can actually see the jobs
         List<String> jobs = FsCrawlerUtil.listExistingJobs(metadataDir);
         assertThat(jobs, hasSize(numJobs));
+    }
+
+    @Test
+    public void testGetFileExtension() {
+        assertThat(FsCrawlerUtil.getFileExtension(new File("foo.bar")), is("bar"));
+        assertThat(FsCrawlerUtil.getFileExtension(new File("foo")), is(""));
+        assertThat(FsCrawlerUtil.getFileExtension(new File("foo.bar.baz")), is("baz"));
     }
 }

--- a/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/unit/parser/TikaDocParserTest.java
+++ b/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/unit/parser/TikaDocParserTest.java
@@ -603,9 +603,7 @@ public class TikaDocParserTest extends DocParserTestCase {
 
     private Doc extractFromFileExtension(String extension) throws IOException {
         logger.info("Test extraction of [{}] file", extension);
-        Doc doc = extractFromFile("test." + extension);
-        assertThat(doc.getFile().getExtension(), is(extension));
-        return doc;
+        return extractFromFile("test." + extension);
     }
 
     private Doc extractFromFile(String filename) throws IOException {


### PR DESCRIPTION
`file.extension` is missing if `index_content` is set to `false`.

To fix this:

- implemented a function getFileExtension in FsCrawlerUtil
- extended class FileAbstractModel with a string "extension"
- extended class FileAbstractorFile with model.extension =
- FsCrawlerUtil.getFileExtension(file);
- extended class FsCrawlerImpl with with a string "extension"
- added doc.getFile().setExtension(extension) to FsCrawlerImpl
- commented extension stuff in TikaDocParser.java

Closes #317.