### PR TITLE
fixed JSON, missing comma added

### DIFF
--- a/README.md
+++ b/README.md
@@ -934,7 +934,7 @@ PUT _ingest/pipeline/langdetect
   "processors" : [
     {
       "set": {
-        "field": "_index"
+        "field": "_index",
         "value": "myindex-{{meta.language}}"
       }
     }


### PR DESCRIPTION
This fixes the example shown for language pipeline.