### PR TITLE
Update to Tika 1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -1928,3 +1928,15 @@ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations under
 the License.
 ```
+
+# Incompatible 3rd party library licenses
+
+Some libraries are not Apache2 compatible. Therefore they are not packaged with FSCrawler so you need
+to download and add manually them to the `lib` directory:
+
+* `jbig2`: [com.levigo.jbig2:levigo-jbig2-imageio:2.0](http://repo1.maven.org/maven2/com/levigo/jbig2/levigo-jbig2-imageio/)
+* `tiff`: [com.github.jai-imageio:jai-imageio-core:1.3.1](http://repo1.maven.org/maven2/com/github/jai-imageio/jai-imageio-core/)
+* `JPEG2000`: [com.github.jai-imageio:jai-imageio-jpeg2000:1.3.0](http://repo1.maven.org/maven2/com/github/jai-imageio/jai-imageio-jpeg2000/)
+
+See [pdfbox](https://pdfbox.apache.org/2.0/dependencies.html#jai-image-io) for more details.
+

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <!-- Don't depend on elasticsearch.version here as it will fail with 1.x and 2.x series -->
         <elasticsearch.client.version>5.5.0</elasticsearch.client.version>
 
-        <tika.version>1.15</tika.version>
+        <tika.version>1.16</tika.version>
         <jackson.version>2.8.6</jackson.version>
         <log4j.version>2.8.1</log4j.version>
         <jansi.version>1.13</jansi.version>
@@ -479,6 +479,36 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Add some optional dependencies -->
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.19.3</version>
+        </dependency>
+
+        <!--
+        For legal reasons (incompatible license), these dependencies are to marked as optional so users who might want
+        to use them have to provided them manually in the lib dir.
+        -->
+        <dependency>
+            <groupId>com.levigo.jbig2</groupId>
+            <artifactId>levigo-jbig2-imageio</artifactId>
+            <version>2.0</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.github.jai-imageio</groupId>
+            <artifactId>jai-imageio-core</artifactId>
+            <version>1.3.1</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.github.jai-imageio</groupId>
+            <artifactId>jai-imageio-jpeg2000</artifactId>
+            <version>1.3.0</version>
+            <optional>true</optional>
+        </dependency>
+
         <!-- For Language detection -->
         <dependency>
             <groupId>org.apache.tika</groupId>

--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaInstance.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaInstance.java
@@ -23,13 +23,18 @@ package fr.pilato.elasticsearch.crawler.fs.tika;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tika.Tika;
+import org.apache.tika.config.ServiceLoader;
 import org.apache.tika.language.detect.LanguageDetector;
+import org.apache.tika.mime.MediaTypeRegistry;
 import org.apache.tika.parser.AutoDetectParser;
+import org.apache.tika.parser.DefaultParser;
 import org.apache.tika.parser.Parser;
 import org.apache.tika.parser.external.ExternalParser;
+import org.apache.tika.parser.ocr.TesseractOCRParser;
 import org.apache.tika.parser.pdf.PDFParser;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import static org.apache.tika.langdetect.OptimaizeLangDetector.getDefaultLanguageDetector;
 
@@ -51,6 +56,7 @@ public class TikaInstance {
     public static Tika tika(boolean ocr) {
         if (tika == null) {
             PDFParser pdfParser = new PDFParser();
+            DefaultParser defaultParser;
 
             if (ocr) {
                 logger.debug("OCR is activated for PDF documents");
@@ -59,10 +65,17 @@ public class TikaInstance {
                 } else {
                     logger.debug("But Tesseract is not installed so we won't run OCR.");
                 }
+                defaultParser = new DefaultParser();
+            } else {
+                logger.debug("OCR is disabled. Even though it's detected, it must be disabled explicitly");
+                defaultParser = new DefaultParser(
+                        MediaTypeRegistry.getDefaultRegistry(),
+                        new ServiceLoader(),
+                        Collections.singletonList(TesseractOCRParser.class));
             }
 
             Parser PARSERS[] = new Parser[2];
-            PARSERS[0] = new org.apache.tika.parser.DefaultParser();
+            PARSERS[0] = defaultParser;
             PARSERS[1] = pdfParser;
 
             AutoDetectParser parser;

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -15,6 +15,9 @@
       <Logger name="org.glassfish" level="warn" additivity="false">
          <AppenderRef ref="CONSOLE"/>
       </Logger>
+      <Logger name="org.apache.tika.parser.ocr.TesseractOCRParser" level="error" additivity="false">
+         <AppenderRef ref="CONSOLE"/>
+      </Logger>
       <Root level="info">
          <AppenderRef ref="CONSOLE"/>
       </Root>

--- a/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/unit/parser/TikaDocParserTest.java
+++ b/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/unit/parser/TikaDocParserTest.java
@@ -41,6 +41,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -536,7 +537,7 @@ public class TikaDocParserTest extends DocParserTestCase {
         assertThat(doc.getContent(), is(""));
 
         // Content Type
-        assertThat(doc.getFile().getContentType(), is("audio/x-wav"));
+        assertThat(doc.getFile().getContentType(), is("audio/vnd.wave"));
 
         // Meta data
         assertThat(doc.getMeta().getAuthor(), is(nullValue()));
@@ -551,7 +552,7 @@ public class TikaDocParserTest extends DocParserTestCase {
         assertThat(raw, hasEntry("bits", "16"));
         assertThat(raw, hasEntry("encoding", "PCM_SIGNED"));
         assertThat(raw, hasEntry("xmpDM:audioSampleType", "16Int"));
-        assertThat(raw, hasEntry("Content-Type", "audio/x-wav"));
+        assertThat(raw, hasEntry("Content-Type", "audio/vnd.wave"));
         assertThat(raw, hasEntry("samplerate", "44100.0"));
     }
 
@@ -620,7 +621,7 @@ public class TikaDocParserTest extends DocParserTestCase {
                 .setFs(Fs.builder().setPdfOcr(false).build())
                 .build();
         doc = extractFromFile("test-ocr.png", fsSettings);
-        assertThat(doc.getContent(), containsString("This file contains some words."));
+        assertThat(doc.getContent(), isEmptyString());
         doc = extractFromFile("test-ocr.pdf", fsSettings);
         assertThat(doc.getContent(), is("\n\n"));
     }

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -45,6 +45,9 @@
       <Logger name="org.glassfish" level="error" additivity="false">
          <AppenderRef ref="CONSOLE"/>
       </Logger>
+      <Logger name="org.apache.tika.parser.ocr.TesseractOCRParser" level="error" additivity="false">
+         <AppenderRef ref="CONSOLE"/>
+      </Logger>
       <Root level="info">
          <AppenderRef ref="CONSOLE"/>
       </Root>


### PR DESCRIPTION
Note that `audio/x-wav` is now detected as `audio/vnd.wave`.

```
11:11:23,309 WARN  [o.a.t.p.o.TesseractOCRParser] Tesseract OCR is installed and will be automatically applied to image files unless
you've excluded the TesseractOCRParser from the default parser.
Tesseract may dramatically slow down content extraction (TIKA-2359).
As of Tika 1.15 (and prior versions), Tesseract is automatically called.
In future versions of Tika, users may need to turn the TesseractOCRParser on via TikaConfig.
```

We also need to provide `sqlite-jdbc`:

```
11:11:23,332 WARN  [o.a.t.p.SQLite3Parser] org.xerial's sqlite-jdbc is not loaded.
Please provide the jar on your classpath to parse sqlite files.
See tika-parsers/pom.xml for the correct version.
```

We also need to provide `JBIG2ImageReader`:

```
11:11:23,255 WARN  [o.a.t.p.PDFParser] JBIG2ImageReader not loaded. jbig2 files will be ignored
See https://pdfbox.apache.org/2.0/dependencies.html#jai-image-io
for optional dependencies.
```

We also need to provide `TIFFImageWriter`:

```
TIFFImageWriter not loaded. tiff files will not be processed
See https://pdfbox.apache.org/2.0/dependencies.html#jai-image-io
for optional dependencies.
```

We also need to provide `J2KImageReader`:

```
J2KImageReader not loaded. JPEG2000 files will not be processed.
See https://pdfbox.apache.org/2.0/dependencies.html#jai-image-io
for optional dependencies.
```

Closes #406.

Also fix that `pdf_ocr:false` should disable OCR entirely which is not the case yet. We explicit exclude TesseractOCRParser.

Closes #410.