### PR TITLE
Set Tika RESOURCE_NAME_KEY before extraction

### DIFF
--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
@@ -69,6 +69,7 @@ public class TikaDocParser {
             }
         }
         Metadata metadata = new Metadata();
+        metadata.set(Metadata.RESOURCE_NAME_KEY, filename);
 
         String parsedContent = null;
 

--- a/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerImplAllDocumentsIT.java
+++ b/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerImplAllDocumentsIT.java
@@ -221,6 +221,11 @@ public class FsCrawlerImplAllDocumentsIT extends AbstractITCase {
         runSearch("test-ocr.pdf", "words");
     }
 
+    @Test
+    public void testShiftJisEncoding() throws IOException {
+        runSearch("issue-400-shiftjis.txt", "elasticsearch");
+    }
+
     private SearchResponse runSearch(String filename) throws IOException {
         return runSearch(filename, null);
     }

--- a/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/unit/parser/TikaDocParserTest.java
+++ b/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/unit/parser/TikaDocParserTest.java
@@ -41,6 +41,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -626,6 +627,11 @@ public class TikaDocParserTest extends DocParserTestCase {
         assertThat(doc.getContent(), is("\n\n"));
     }
 
+    @Test
+    public void testShiftJisEncoding() throws IOException {
+        Doc doc = extractFromFile("issue-400-shiftjis.txt");
+        assertThat(doc.getContent(), not(isEmptyOrNullString()));
+    }
 
     private Doc extractFromFileExtension(String extension) throws IOException {
         logger.info("Test extraction of [{}] file", extension);

--- a/src/test/resources/documents/issue-400-shiftjis.txt
+++ b/src/test/resources/documents/issue-400-shiftjis.txt
@@ -1,0 +1,15 @@
+全文検索の技術調査について2
+
+
+　■Apache Solr
+  　ライセンス：Apache Lisence 2.0
+　　開発環境：Java　(サードパーティー提供の環境は Javascript、Ruby　等多数)
+
+    http://lucene.apache.org/solr/
+
+　■Elasticsearch
+  　ライセンス：Apache Lisence 2.0
+　　開発環境：Java、Javascript、.Net Framework、Ruby　等多数
+
+    https://www.elastic.co/jp/products/elasticsearch
+


### PR DESCRIPTION
It helps Tika to make a better detection of content encoding and
parser to use.

Closes #400.