### PR TITLE
Add support for language setting for tesseract

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,35 +456,36 @@ The job file must comply to the following `json` specifications:
 {
   "name" : "job_name",
   "fs" : {
-    "url" : "/path/to/data/dir",
-    "update_rate" : "15m",
-    "includes": [
-      "*.*"
-    ],
-    "excludes": [
-      "*.json"
-    ],
+    "url" : "/path/to/docs",
+    "update_rate" : "5m",
+    "includes" : [ "*.doc", "*.xls" ],
+    "excludes" : [ "resume.doc" ],
     "json_support" : false,
-    "xml_support" : false,
-    "ignore_folders" : false,
-    "attributes_support" : false,
-    "raw_metadata" : false,
-    "filename_as_id" : false,
+    "filename_as_id" : true,
     "add_filesize" : true,
     "remove_deleted" : true,
-    "store_source" : false,
+    "add_as_inner_object" : false,
+    "store_source" : true,
+    "index_content" : true,
+    "indexed_chars" : "10000.0",
+    "attributes_support" : false,
+    "raw_metadata" : true,
+    "xml_support" : false,
+    "index_folders" : true,
     "lang_detect" : false,
     "continue_on_error" : false,
     "pdf_ocr" : true,
-    "indexed_chars" : "10000"
+    "ocr" : {
+      "language" : "eng"
+    }
   },
   "server" : {
-    "hostname" : null,
+    "hostname" : "localhost",
     "port" : 22,
-    "username" : null,
-    "password" : null,
-    "protocol" : "local",
-    "pem_path" : null
+    "username" : "dadoonet",
+    "password" : "password",
+    "protocol" : "SSH",
+    "pem_path" : "/path/to/pemfile"
   },
   "elasticsearch" : {
     "nodes" : [ {
@@ -493,19 +494,16 @@ The job file must comply to the following `json` specifications:
       "scheme" : "HTTP"
     } ],
     "index" : "docs",
-    "index_folder" : "folders",
-    "bulk_size" : 100,
+    "bulk_size" : 1000,
     "flush_interval" : "5s",
-    "username" : "username",
-    "password" : "password",
-    "pipeline" : "pipeline-id-if-any"
+    "username" : "elastic",
+    "password" : "password"
   },
   "rest" : {
-    "enabled" : false,
     "scheme" : "HTTP",
     "host" : "127.0.0.1",
     "port" : 8080,
-    "port" : "fscrawler"
+    "endpoint" : "fscrawler"
   }
 }
 ```
@@ -560,7 +558,7 @@ Here is a list of Local FS settings (under `fs.` prefix)`:
 | `fs.continue_on_error`           | `false`       | [Continue on File Permission Error](#continue-on-error) (from 2.3)                |
 | `fs.pdf_ocr`                     | `true`        | [Run OCR on PDF documents](#ocr-integration) (from 2.3)                           |
 | `fs.indexed_chars`               | `100000.0`    | [Extracted characters](#extracted-characters)                                     |
-| `fs.checksum`                    | `null`        | [File Checksum](#file-checksum)                                                 |
+| `fs.checksum`                    | `null`        | [File Checksum](#file-checksum)                                                   |
 
 #### Root directory
 
@@ -1913,6 +1911,31 @@ to `false`:
   "name" : "test",
   "fs" : {
     "pdf_ocr" : false
+  }
+}
+```
+
+### OCR settings
+
+Here is a list of OCR settings (under `fs.ocr` prefix)`:
+
+|               Name               | Default value |                                 Documentation                                     |
+|----------------------------------|---------------|-----------------------------------------------------------------------------------|
+| `fs.ocr.language`                | `"eng"`       | [OCR Language](#ocr-language)                                                     |
+
+#### OCR Language
+
+If you have installed a [Tesseract Language pack](https://wiki.apache.org/tika/TikaOCR), you can use it when
+parsing your documents by setting `fs.ocr.language` property in your `~/.fscrawler/test/_settings.json` file:
+
+```json
+{
+  "name" : "test",
+  "fs" : {
+    "url" : "/path/to/data/dir",
+    "ocr" : {
+      "language": "eng"
+    }
   }
 }
 ```

--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/meta/settings/Fs.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/meta/settings/Fs.java
@@ -45,6 +45,7 @@ public class Fs {
     private boolean langDetect = false;
     private boolean continueOnError = false;
     private boolean pdfOcr = true;
+    private Ocr ocr = new Ocr();
 
     public static Builder builder() {
         return new Builder();
@@ -75,6 +76,7 @@ public class Fs {
         private boolean langDetect = false;
         private boolean continueOnError = false;
         private boolean pdfOcr = true;
+        private Ocr ocr = new Ocr();
 
         public Builder setUrl(String url) {
             this.url = url;
@@ -202,10 +204,15 @@ public class Fs {
             return this;
         }
 
+        public Builder setOcr(Ocr ocr) {
+            this.ocr = ocr;
+            return this;
+        }
+
         public Fs build() {
             return new Fs(url, updateRate, includes, excludes, jsonSupport, filenameAsId, addFilesize,
                     removeDeleted, addAsInnerObject, storeSource, indexedChars, indexContent, attributesSupport, rawMetadata,
-                    checksum, xmlSupport, indexFolders, langDetect, continueOnError, pdfOcr);
+                    checksum, xmlSupport, indexFolders, langDetect, continueOnError, pdfOcr, ocr);
         }
     }
 
@@ -216,7 +223,7 @@ public class Fs {
     private Fs(String url, TimeValue updateRate, List<String> includes, List<String> excludes, boolean jsonSupport,
                boolean filenameAsId, boolean addFilesize, boolean removeDeleted, boolean addAsInnerObject, boolean storeSource,
                Percentage indexedChars, boolean indexContent, boolean attributesSupport, boolean rawMetadata, String checksum, boolean xmlSupport,
-               boolean indexFolders, boolean langDetect, boolean continueOnError, boolean pdfOcr) {
+               boolean indexFolders, boolean langDetect, boolean continueOnError, boolean pdfOcr, Ocr ocr) {
         this.url = url;
         this.updateRate = updateRate;
         this.includes = includes;
@@ -237,6 +244,7 @@ public class Fs {
         this.langDetect = langDetect;
         this.continueOnError = continueOnError;
         this.pdfOcr = pdfOcr;
+        this.ocr = ocr;
     }
 
     public String getUrl() {
@@ -397,6 +405,14 @@ public class Fs {
 
     public void setPdfOcr(boolean pdfOcr) {
         this.pdfOcr = pdfOcr;
+    }
+
+    public Ocr getOcr() {
+        return ocr;
+    }
+
+    public void setOcr(Ocr ocr) {
+        this.ocr = ocr;
     }
 
     @Override

--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/meta/settings/Ocr.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/meta/settings/Ocr.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package fr.pilato.elasticsearch.crawler.fs.meta.settings;
+
+public class Ocr {
+    // Language dictionary to be used.
+    private String language = "eng";
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String language = "eng";
+
+        public Builder setLanguage(String language) {
+            this.language = language;
+            return this;
+        }
+
+        public Ocr build() {
+            return new Ocr();
+        }
+    }
+
+    public Ocr( ) {
+
+    }
+
+    private Ocr(String language) {
+        this.language = language;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+}

--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
@@ -40,8 +40,8 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 
+import static fr.pilato.elasticsearch.crawler.fs.tika.TikaInstance.extractText;
 import static fr.pilato.elasticsearch.crawler.fs.tika.TikaInstance.langDetector;
-import static fr.pilato.elasticsearch.crawler.fs.tika.TikaInstance.tika;
 import static fr.pilato.elasticsearch.crawler.fs.util.FsCrawlerUtil.localDateTimeToDate;
 
 /**
@@ -88,7 +88,7 @@ public class TikaDocParser {
         try {
             // Set the maximum length of strings returned by the parseToString method, -1 sets no limit
             logger.trace("Beginning Tika extraction");
-            parsedContent = tika(fsSettings.getFs().isPdfOcr()).parseToString(inputStream, metadata, indexedChars);
+            parsedContent = extractText(fsSettings, indexedChars, inputStream, metadata);
             logger.trace("End of Tika extraction");
         } catch (Throwable e) {
             logger.debug("Failed to extract [" + indexedChars + "] characters of text for [" + filename + "]", e);

--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaInstance.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaInstance.java
@@ -20,20 +20,29 @@
 package fr.pilato.elasticsearch.crawler.fs.tika;
 
 
+import fr.pilato.elasticsearch.crawler.fs.meta.settings.Fs;
+import fr.pilato.elasticsearch.crawler.fs.meta.settings.FsSettings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.tika.Tika;
 import org.apache.tika.config.ServiceLoader;
+import org.apache.tika.exception.TikaException;
 import org.apache.tika.language.detect.LanguageDetector;
+import org.apache.tika.metadata.Metadata;
 import org.apache.tika.mime.MediaTypeRegistry;
 import org.apache.tika.parser.AutoDetectParser;
 import org.apache.tika.parser.DefaultParser;
+import org.apache.tika.parser.ParseContext;
 import org.apache.tika.parser.Parser;
 import org.apache.tika.parser.external.ExternalParser;
+import org.apache.tika.parser.ocr.TesseractOCRConfig;
 import org.apache.tika.parser.ocr.TesseractOCRParser;
 import org.apache.tika.parser.pdf.PDFParser;
+import org.apache.tika.sax.BodyContentHandler;
+import org.apache.tika.sax.WriteOutContentHandler;
+import org.xml.sax.SAXException;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Collections;
 
 import static org.apache.tika.langdetect.OptimaizeLangDetector.getDefaultLanguageDetector;
@@ -45,20 +54,31 @@ public class TikaInstance {
 
     private static final Logger logger = LogManager.getLogger(TikaInstance.class);
 
-    private static Tika tika;
+    private static Parser parser;
+    private static ParseContext context;
     private static LanguageDetector detector;
 
     /* For tests only */
     public static void reloadTika() {
-        tika = null;
+        parser = null;
+        context = null;
     }
 
-    public static Tika tika(boolean ocr) {
-        if (tika == null) {
+    /**
+     * This initialize if needed a parser and a parse context for tika
+     * @param fs fs settings
+     */
+    private static void initTika(Fs fs) {
+        initParser(fs);
+        initContext(fs);
+    }
+
+    private static void initParser(Fs fs) {
+        if (parser == null) {
             PDFParser pdfParser = new PDFParser();
             DefaultParser defaultParser;
 
-            if (ocr) {
+            if (fs.isPdfOcr()) {
                 logger.debug("OCR is activated for PDF documents");
                 if (ExternalParser.check("tesseract")) {
                     pdfParser.setOcrStrategy("ocr_and_text");
@@ -78,16 +98,42 @@ public class TikaInstance {
             PARSERS[0] = defaultParser;
             PARSERS[1] = pdfParser;
 
-            AutoDetectParser parser;
             parser = new AutoDetectParser(PARSERS);
-
-            tika = new Tika(parser.getDetector(), parser);
         }
 
-        return tika;
     }
 
-    public static LanguageDetector langDetector() throws IOException {
+    private static void initContext(Fs fs) {
+        if (context == null) {
+            context = new ParseContext();
+            context.set(Parser.class, parser);
+            if (fs.isPdfOcr()) {
+                logger.debug("OCR is activated");
+                TesseractOCRConfig config = new TesseractOCRConfig();
+                config.setLanguage(fs.getOcr().getLanguage());
+                context.set(TesseractOCRConfig.class, config);
+            }
+        }
+    }
+
+    static String extractText(FsSettings fsSettings, int indexedChars, InputStream stream, Metadata metadata) throws IOException,
+            TikaException {
+        initTika(fsSettings.getFs());
+        WriteOutContentHandler handler = new WriteOutContentHandler(indexedChars);
+        try {
+            parser.parse(stream, new BodyContentHandler(handler), metadata, context);
+        } catch (SAXException e) {
+            if (!handler.isWriteLimitReached(e)) {
+                // This should never happen with BodyContentHandler...
+                throw new TikaException("Unexpected SAX processing failure", e);
+            }
+        } finally {
+            stream.close();
+        }
+        return handler.toString();
+    }
+
+    static LanguageDetector langDetector() throws IOException {
         if (detector == null) {
              detector = getDefaultLanguageDetector().loadModels();
         }

--- a/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/unit/meta/settings/FsSettingsParserTest.java
+++ b/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/unit/meta/settings/FsSettingsParserTest.java
@@ -24,6 +24,7 @@ import fr.pilato.elasticsearch.crawler.fs.meta.settings.Elasticsearch;
 import fr.pilato.elasticsearch.crawler.fs.meta.settings.Fs;
 import fr.pilato.elasticsearch.crawler.fs.meta.settings.FsSettings;
 import fr.pilato.elasticsearch.crawler.fs.meta.settings.FsSettingsParser;
+import fr.pilato.elasticsearch.crawler.fs.meta.settings.Ocr;
 import fr.pilato.elasticsearch.crawler.fs.meta.settings.Percentage;
 import fr.pilato.elasticsearch.crawler.fs.meta.settings.Rest;
 import fr.pilato.elasticsearch.crawler.fs.meta.settings.Server;
@@ -44,6 +45,8 @@ import static org.hamcrest.Matchers.nullValue;
 
 public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
 
+    private static final Ocr OCR_FULL = Ocr.builder().setLanguage("eng").build();
+
     private static final Fs FS_EMPTY = Fs.builder().build();
     private static final Fs FS_FULL = Fs.builder()
             .setUrl("/path/to/docs")
@@ -57,6 +60,7 @@ public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
             .setRemoveDeleted(true)
             .setUpdateRate(TimeValue.timeValueMinutes(5))
             .setIndexContent(true)
+            .setOcr(OCR_FULL)
             .build();
     private static final Elasticsearch ELASTICSEARCH_EMPTY = Elasticsearch.builder().build();
     private static final Elasticsearch ELASTICSEARCH_FULL = Elasticsearch.builder()
@@ -69,10 +73,11 @@ public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
             .setBulkSize(1000)
             .setFlushInterval(TimeValue.timeValueSeconds(5))
             .setIndex("docs")
+            .setPipeline("pipeline-id-if-any")
             .build();
     private static final Server SERVER_EMPTY = Server.builder().build();
     private static final Server SERVER_FULL = Server.builder()
-            .setHostname("localhost")
+            .setHostname("127.0.0.1")
             .setUsername("dadoonet")
             .setPassword("WhATDidYOUexPECt?")
             .setPort(22)
@@ -80,7 +85,7 @@ public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
             .setPemPath("/path/to/pemfile")
             .build();
     private static final Rest REST_FULL = Rest.builder()
-            .setHost("localhost")
+            .setHost("127.0.0.1")
             .setPort(8080)
             .setScheme(Rest.Scheme.HTTP)
             .setEndpoint("fscrawler")
@@ -264,6 +269,7 @@ public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
                         .setElasticsearch(ELASTICSEARCH_FULL)
                         .setServer(SERVER_FULL)
                         .setFs(FS_FULL)
+                        .setRest(REST_FULL)
                         .build()
         );
     }


### PR DESCRIPTION
This introduces a new type of settings `fs.ocr` which for now
only exposes `language` but in the future we can easily implement
other settings like tesseract path, min/max file size settings,
timeout and so on.

Actually all properties that we can set from [TesseractOCRConfig](https://github.com/apache/tika/blob/master/tika-parsers/src/main/java/org/apache/tika/parser/ocr/TesseractOCRConfig.java).

So if you have installed a [Tesseract Language pack](https://wiki.apache.org/tika/TikaOCR), you can use it when
parsing your documents by setting `fs.ocr.language` property in your `~/.fscrawler/test/_settings.json` file:

```json
{
  "name" : "test",
  "fs" : {
    "url" : "/path/to/data/dir",
    "ocr" : {
      "language": "eng"
    }
  }
}
```

Closes #398