### PR TITLE
Increase the limit of fields to 2000 instead of 1000

### DIFF
--- a/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/5/_settings.json
+++ b/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/5/_settings.json
@@ -1,5 +1,6 @@
 {
   "settings": {
+    "index.mapping.total_fields.limit": 2000,
     "analysis": {
       "analyzer": {
         "fscrawler_path": {

--- a/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/6/_settings.json
+++ b/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/6/_settings.json
@@ -1,5 +1,6 @@
 {
   "settings": {
+    "index.mapping.total_fields.limit": 2000,
     "analysis": {
       "analyzer": {
         "fscrawler_path": {

--- a/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/unit/meta/settings/FsMappingTest.java
+++ b/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/unit/meta/settings/FsMappingTest.java
@@ -255,6 +255,7 @@ public class FsMappingTest extends AbstractFSCrawlerTestCase {
         logger.info("Settings used for doc index v5 : " + settings);
         assertThat(settings, is("{\n" +
                 "  \"settings\": {\n" +
+                "    \"index.mapping.total_fields.limit\": 2000,\n" +
                 "    \"analysis\": {\n" +
                 "      \"analyzer\": {\n" +
                 "        \"fscrawler_path\": {\n" +
@@ -440,6 +441,7 @@ public class FsMappingTest extends AbstractFSCrawlerTestCase {
         logger.info("Settings used for doc index v6 : " + settings);
         assertThat(settings, is("{\n" +
                 "  \"settings\": {\n" +
+                "    \"index.mapping.total_fields.limit\": 2000,\n" +
                 "    \"analysis\": {\n" +
                 "      \"analyzer\": {\n" +
                 "        \"fscrawler_path\": {\n" +


### PR DESCRIPTION
By default from elasticsearch 5.x, there is [a limit of 1000 fields](https://www.elastic.co/guide/en/elasticsearch/reference/5.5/mapping.html#mapping-limit-settings) within an index.

Because of the `meta.raw.*` subfields, if you index a lot of different kind of documents, you might hit this limit as described in https://discuss.elastic.co/t/filesearch-solution-using-es-5-5-0/94377/11.

This fix increases that limit to `2000`.

Closes #415.