### PR TITLE
Fix REST Server (missing library)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -558,6 +558,11 @@
             <artifactId>jersey-media-multipart</artifactId>
             <version>${jersey.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
 
         <!-- Logging dependencies -->
         <dependency>


### PR DESCRIPTION
Missing library when we moved to the latest version of Jersey.

Related to #433.