### PR TITLE
Don't use `_source` but only stored fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,52 @@ files will be created again.
 * No specific step needed. Just note that mapping changed as we support more metadata. Might be useful to run
 similar steps as for 2.2 upgrade.
 
+### Upgrade to 2.5
+
+* A bug was causing a lot of data going over the wire each time FSCrawler was running. To fix this issue, we changed the
+default mapping and we set `store: true` on field `file.filename`. If this field is not stored and `remove_deleted` is
+`true` (default), FSCrawler will fail while crawling your documents. You need to create the new mapping accordingly
+and reindex your existing data either by deleting the old index and running again FSCrawler or by using the
+[reindex API](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-reindex.html) as follows:
+
+```
+# Backup old index data
+POST _reindex
+{
+  "source": {
+    "index": "job_name"
+  },
+  "dest": {
+    "index": "job_name_backup"
+  }
+}
+# Remove job_name index
+DELETE job_name
+```
+
+Restart FSCrawler with the following command. It will just create the right mapping again.
+
+```sh
+$ bin/fscrawler job_name --loop 0
+```
+
+Then restore old data:
+
+
+```
+POST _reindex
+{
+  "source": {
+    "index": "job_name_backup"
+  },
+  "dest": {
+    "index": "job_name"
+  }
+}
+# Remove backup index
+DELETE job_name_backup
+```
+
 # User Guide
 
 ## Getting Started

--- a/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsCrawlerImpl.java
+++ b/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsCrawlerImpl.java
@@ -68,7 +68,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static fr.pilato.elasticsearch.crawler.fs.FsCrawlerValidator.validateSettings;
-import static fr.pilato.elasticsearch.crawler.fs.client.JsonUtil.extractFromPath;
 import static fr.pilato.elasticsearch.crawler.fs.tika.TikaDocParser.generate;
 import static fr.pilato.elasticsearch.crawler.fs.util.FsCrawlerUtil.localDateTimeToDate;
 
@@ -546,7 +545,6 @@ public class FsCrawlerImpl {
                         new SearchRequest(fsSettings.getElasticsearch().getIndex()).source(
                                 new SearchSourceBuilder()
                                         .size(REQUEST_SIZE) // TODO: WHAT? DID I REALLY WROTE THAT? :p
-                                        .storedField("_source")
                                         .storedField(FILE_FILENAME)
                                         .query(QueryBuilders.termQuery(PATH_ROOT, SignTool.sign(path)))));
 
@@ -554,18 +552,15 @@ public class FsCrawlerImpl {
                 if (response.getHits() != null && response.getHits().getHits() != null) {
                     for (SearchHit hit : response.getHits().getHits()) {
                         String name;
-                        if (hit.getSourceAsMap() != null
-                                && extractFromPath(hit.getSourceAsMap(), Doc.FIELD_NAMES.FILE).get(fr.pilato.elasticsearch.crawler.fs.meta.doc.File.FIELD_NAMES.FILENAME) != null) {
-                            name = (String) extractFromPath(hit.getSourceAsMap(), Doc.FIELD_NAMES.FILE).get(fr.pilato.elasticsearch.crawler.fs.meta.doc.File.FIELD_NAMES.FILENAME);
-                        } else if (hit.getFields() != null
+                        if (hit.getFields() != null
                                 && hit.getFields().get(FILE_FILENAME) != null) {
                             // In case someone disabled _source which is not recommended
                             name = hit.getFields().get(FILE_FILENAME).getValue();
                         } else {
                             // Houston, we have a problem ! We can't get the old files from ES
-                            logger.warn("Can't find in _source nor fields the existing filenames in path [{}]. " +
-                                    "Please enable _source or store field [{}]", path, FILE_FILENAME);
-                            throw new RuntimeException("Mapping is incorrect: please enable _source or store field [" +
+                            logger.warn("Can't find stored field name to check existing filenames in path [{}]. " +
+                                    "Please set store: true on field [{}]", path, FILE_FILENAME);
+                            throw new RuntimeException("Mapping is incorrect: please set stored: true on field [" +
                                     FILE_FILENAME + "].");
                         }
                         files.add(name);
@@ -576,8 +571,6 @@ public class FsCrawlerImpl {
                         fsSettings.getElasticsearch().getIndex(),
                         REQUEST_SIZE,    // TODO: WHAT? DID I REALLY WROTE THAT? :p
                         FILE_FILENAME,
-                        Doc.FIELD_NAMES.FILE,
-                        fr.pilato.elasticsearch.crawler.fs.meta.doc.File.FIELD_NAMES.FILENAME,
                         path,
                         QueryBuilders.termQuery(PATH_ROOT, SignTool.sign(path)));
             }

--- a/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/2/_settings.json
+++ b/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/2/_settings.json
@@ -130,7 +130,8 @@
             },
             "filename": {
               "type": "string",
-              "index": "not_analyzed"
+              "index": "not_analyzed",
+              "store": true
             },
             "extension": {
               "type": "string",

--- a/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/5/_settings.json
+++ b/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/5/_settings.json
@@ -40,7 +40,8 @@
               "type" : "keyword"
             },
             "filename" : {
-              "type" : "keyword"
+              "type" : "keyword",
+              "store" : true
             },
             "extension" : {
               "type" : "keyword"

--- a/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/6/_settings.json
+++ b/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/6/_settings.json
@@ -40,7 +40,8 @@
               "type" : "keyword"
             },
             "filename" : {
-              "type" : "keyword"
+              "type" : "keyword",
+              "store" : true
             },
             "extension" : {
               "type" : "keyword"

--- a/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/ElasticsearchClientIT.java
+++ b/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/ElasticsearchClientIT.java
@@ -127,7 +127,7 @@ public class ElasticsearchClientIT extends AbstractITCase {
 
         // using fields
         Collection<String> fields = elasticsearchClient.getFromStoredFieldsV2(
-                getCrawlerName(), 10, "foo.bar", "foo", "bar", "/a/path", QueryBuilders.termQuery("foo.bar", "bar"));
+                getCrawlerName(), 10, "foo.bar", "/a/path", QueryBuilders.termQuery("foo.bar", "bar"));
         assertThat(fields, iterableWithSize(1));
         assertThat(fields.iterator().next(), is("bar"));
     }

--- a/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/unit/meta/settings/FsMappingTest.java
+++ b/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/unit/meta/settings/FsMappingTest.java
@@ -192,7 +192,8 @@ public class FsMappingTest extends AbstractFSCrawlerTestCase {
                 "            },\n" +
                 "            \"filename\": {\n" +
                 "              \"type\": \"string\",\n" +
-                "              \"index\": \"not_analyzed\"\n" +
+                "              \"index\": \"not_analyzed\",\n" +
+                "              \"store\": true\n" +
                 "            },\n" +
                 "            \"extension\": {\n" +
                 "              \"type\": \"string\",\n" +
@@ -359,7 +360,8 @@ public class FsMappingTest extends AbstractFSCrawlerTestCase {
                 "              \"type\" : \"keyword\"\n" +
                 "            },\n" +
                 "            \"filename\" : {\n" +
-                "              \"type\" : \"keyword\"\n" +
+                "              \"type\" : \"keyword\",\n" +
+                "              \"store\" : true\n" +
                 "            },\n" +
                 "            \"extension\" : {\n" +
                 "              \"type\" : \"keyword\"\n" +
@@ -605,7 +607,8 @@ public class FsMappingTest extends AbstractFSCrawlerTestCase {
                 "              \"type\" : \"keyword\"\n" +
                 "            },\n" +
                 "            \"filename\" : {\n" +
-                "              \"type\" : \"keyword\"\n" +
+                "              \"type\" : \"keyword\",\n" +
+                "              \"store\" : true\n" +
                 "            },\n" +
                 "            \"extension\" : {\n" +
                 "              \"type\" : \"keyword\"\n" +


### PR DESCRIPTION
A bug was causing a lot of data going over the wire each time FSCrawler was running.
It was likely throwing an "entity content is too long" Exception.

That is caused by the fact we are trying to find deleted documents by reading existing data in elasticsearch.
The problem is that we have been doing so by searching data with `fields=_source,file.filename` in case `file.filename` was not a stored field.
As people can index very very big documents, getting the full `_source` back could cause a response bigger than `100mb`.

To fix this issue, we changed the default mapping and we set `store: true` on field `file.filename`. If this field is not stored and `remove_deleted` is `true` (default), FSCrawler will fail while crawling your documents. You need to create the new mapping accordingly and reindex your existing data either by deleting the old index and running again FSCrawler or by using the [reindex API](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-reindex.html) as follows:

```
# Backup old index data
POST _reindex
{
  "source": {
    "index": "job_name"
  },
  "dest": {
    "index": "job_name_backup"
  }
}
# Remove job_name index
DELETE job_name
```

Restart FSCrawler with the following command. It will just create the right mapping again.

```sh
$ bin/fscrawler job_name --loop 0
```

Then restore old data:

```
POST _reindex
{
  "source": {
    "index": "job_name_backup"
  },
  "dest": {
    "index": "job_name"
  }
}
# Remove backup index
DELETE job_name_backup
```

Closes #432.