### PR TITLE
Start elasticsearch with docker-maven-plugin when running from the CLI

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -107,7 +107,7 @@
                 <configuration>
                     <images>
                         <image>
-                            <alias>elasticsearch</alias>
+                            <alias>elasticsearch-it</alias>
                             <name>dadoonet/docker-elasticsearch:${project.version}</name>
                             <build>
                                 <from>docker.elastic.co/elasticsearch/elasticsearch:${elasticsearch.version}</from>
@@ -128,15 +128,16 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <id>start</id>
+                        <id>start-elasticsearch</id>
                         <phase>pre-integration-test</phase>
                         <goals>
                             <goal>build</goal>
+                            <goal>stop</goal>
                             <goal>start</goal>
                         </goals>
                     </execution>
                     <execution>
-                        <id>stop</id>
+                        <id>stop-elasticsearch</id>
                         <phase>post-integration-test</phase>
                         <goals>
                             <goal>stop</goal>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -61,10 +61,6 @@
 
     </dependencies>
 
-    <properties>
-        <tests.parallelism>1</tests.parallelism>
-    </properties>
-
     <build>
         <testResources>
             <testResource>
@@ -102,6 +98,51 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.24.0</version>
+                <configuration>
+                    <images>
+                        <image>
+                            <alias>elasticsearch</alias>
+                            <name>dadoonet/docker-elasticsearch:${project.version}</name>
+                            <build>
+                                <from>docker.elastic.co/elasticsearch/elasticsearch:${elasticsearch.version}</from>
+                            </build>
+                            <run>
+                                <ports>
+                                    <port>integ.elasticsearch.port:9200</port>
+                                </ports>
+                                <wait>
+                                    <http>
+                                        <url>http://localhost:${integ.elasticsearch.port}/</url>
+                                    </http>
+                                    <time>60000</time>
+                                </wait>
+                            </run>
+                        </image>
+                    </images>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>start</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <integ.elasticsearch.version>${elasticsearch.version}</integ.elasticsearch.version>
         <integ.security.username>elastic</integ.security.username>
         <integ.security.password>changeme</integ.security.password>
+        <integ.elasticsearch.port>9200</integ.elasticsearch.port>
 
         <!-- Randomized testing framework -->
         <tests.locale>random</tests.locale>


### PR DESCRIPTION
This commit starts elasticsearch from a maven pre-integration-tests phase using Docker.
It avoids having to run "manually" for each IT so we can start to run tests in parallel.

Closes #510.