### PR TITLE
Reduce Time to run tests from the IDE

### DIFF
--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
@@ -48,7 +48,6 @@ import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.hamcrest.Matcher;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.testcontainers.containers.wait.HttpWaitStrategy;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -66,7 +65,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.time.Duration;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -239,14 +237,8 @@ public abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
                 // We start an elasticsearch Docker instance
                 Properties props = new Properties();
                 props.load(AbstractITCase.class.getResourceAsStream("/elasticsearch.version.properties"));
-                container = new ElasticsearchContainer().withVersion(props.getProperty("version"));
-                container.withEnv("ELASTIC_PASSWORD", testClusterPass);
-                container.setWaitStrategy(
-                        new HttpWaitStrategy()
-                                .forStatusCode(200)
-                                .withBasicCredentials(testClusterUser, testClusterPass)
-                                .withStartupTimeout(Duration.ofSeconds(90)));
-                container.start();
+                container = ElasticsearchContainerSingleton.getInstance(props.getProperty("version"),
+                        testClusterUser, testClusterPass);
 
                 testClusterHost = container.getHost().getHostName();
                 testClusterPort = container.getFirstMappedPort();
@@ -301,10 +293,12 @@ public abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
             esRestClient = null;
         }
 
+        /*
         if (container != null) {
             container.close();
             container = null;
         }
+        */
     }
 
     private static RestClientBuilder getClientBuilder(HttpHost host, String username, String password) {

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/ElasticsearchContainerSingleton.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/ElasticsearchContainerSingleton.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package fr.pilato.elasticsearch.crawler.fs.test.integration;
+
+import fr.pilato.elasticsearch.containers.ElasticsearchContainer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.testcontainers.containers.wait.HttpWaitStrategy;
+
+import java.time.Duration;
+
+public class ElasticsearchContainerSingleton {
+
+    protected static final Logger logger = LogManager.getLogger(ElasticsearchContainerSingleton.class);
+    private static ElasticsearchContainer container = null;
+
+    static ElasticsearchContainer getInstance(String version, String user, String password) {
+        if (container == null) {
+            logger.debug("No local node running. We need to start a Docker instance.");
+            container = new ElasticsearchContainer().withVersion(version);
+            container.withEnv("ELASTIC_PASSWORD", password);
+            container.setWaitStrategy(
+                    new HttpWaitStrategy()
+                            .forStatusCode(200)
+                            .withBasicCredentials(user, password)
+                            .withStartupTimeout(Duration.ofSeconds(90)));
+            container.start();
+        }
+
+        return container;
+    }
+
+}


### PR DESCRIPTION
With recent changes like #500 and #514 it takes much more time to run all tests from the IDE when elasticsearch is not running yet locally.
The reason is that we start a new elasticsearch test container for every class. Starting a container can take some time.

We should try to reduce that and share the same docker instance for all tests.

Closes #516