### PR TITLE
Allow setting Tesseract path to executable and data

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,7 +536,9 @@ The job file must comply to the following `json` specifications:
     "continue_on_error" : false,
     "pdf_ocr" : true,
     "ocr" : {
-      "language" : "eng"
+      "language" : "eng",
+      "path": "/path/to/tesseract/if/not/available/in/PATH",
+      "data_path": "/path/to/tesseract/tessdata/if/needed"
     }
   },
   "server" : {
@@ -2071,7 +2073,8 @@ and run FS crawler on this mount point. You can also read details about
 
 ## OCR integration
 
-To deal with images containing text, just [install Tesseract](https://github.com/tesseract-ocr/tesseract/wiki). Tesseract will be auto-detected by Tika.
+To deal with images containing text, just [install Tesseract](https://github.com/tesseract-ocr/tesseract/wiki). Tesseract will be auto-detected by Tika
+or you can explicitly [set the path to tesseract binary](#ocr-path).
 Then add an image (png, jpg, ...) into your Fscrawler [root directory](#root-directory). After the next index update, the text will be indexed and placed in "_source.content".
 
 By default, FS crawler will try to extract also images from your PDF documents and run OCR on them.
@@ -2094,6 +2097,8 @@ Here is a list of OCR settings (under `fs.ocr` prefix)`:
 |               Name               | Default value |                                 Documentation                                     |
 |----------------------------------|---------------|-----------------------------------------------------------------------------------|
 | `fs.ocr.language`                | `"eng"`       | [OCR Language](#ocr-language)                                                     |
+| `fs.ocr.path`                    | `null`        | [OCR Path](#ocr-path)                                                             |
+| `fs.ocr.data_path`               | `null`        | [OCR Data Path](#ocr-data-path)                                                             |
 
 #### OCR Language
 
@@ -2107,6 +2112,44 @@ parsing your documents by setting `fs.ocr.language` property in your `~/.fscrawl
     "url" : "/path/to/data/dir",
     "ocr" : {
       "language": "eng"
+    }
+  }
+}
+```
+
+#### OCR Path
+
+If your Tesseract application is not available in default system PATH, you can define the path to use
+by setting `fs.ocr.path` property in your `~/.fscrawler/test/_settings.json` file:
+
+```json
+{
+  "name" : "test",
+  "fs" : {
+    "url" : "/path/to/data/dir",
+    "ocr" : {
+      "path": "/path/to/tesseract/executable"
+    }
+  }
+}
+```
+
+When you set it, it's highly recommended to [set the data path for Tesseract](#ocr-data-path).
+
+#### OCR Data Path
+
+Set the path to the 'tessdata' folder, which contains language files and config files if Tesseract
+can not be automatically detected. You can define the path to use
+by setting `fs.ocr.data_path` property in your `~/.fscrawler/test/_settings.json` file:
+
+```json
+{
+  "name" : "test",
+  "fs" : {
+    "url" : "/path/to/data/dir",
+    "ocr" : {
+      "path": "/path/to/tesseract/executable",
+      "data_path": "/path/to/tesseract/tessdata"
     }
   }
 }

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Ocr.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Ocr.java
@@ -22,6 +22,10 @@ package fr.pilato.elasticsearch.crawler.fs.settings;
 public class Ocr {
     // Language dictionary to be used.
     private String language = "eng";
+    // Path to tesseract program
+    private String path = null;
+    // Path to tesseract data
+    private String dataPath = null;
 
     public static Builder builder() {
         return new Builder();
@@ -30,23 +34,38 @@ public class Ocr {
     public static class Builder {
 
         private String language = "eng";
+        private String path = null;
+        private String dataPath = null;
 
         public Builder setLanguage(String language) {
             this.language = language;
             return this;
         }
 
-        public Ocr build() {
-            return new Ocr();
+        public Builder setPath(String path) {
+            this.path = path;
+            return this;
         }
+
+        public Builder setDataPath(String dataPath) {
+            this.dataPath = dataPath;
+            return this;
+        }
+
+        public Ocr build() {
+            return new Ocr(language, path, dataPath);
+        }
+
     }
 
     public Ocr( ) {
 
     }
 
-    private Ocr(String language) {
+    private Ocr(String language, String path, String dataPath) {
         this.language = language;
+        this.path = path;
+        this.dataPath = dataPath;
     }
 
     public String getLanguage() {
@@ -55,5 +74,21 @@ public class Ocr {
 
     public void setLanguage(String language) {
         this.language = language;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public String getDataPath() {
+        return dataPath;
+    }
+
+    public void setDataPath(String dataPath) {
+        this.dataPath = dataPath;
     }
 }

--- a/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaInstance.java
+++ b/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaInstance.java
@@ -110,6 +110,12 @@ public class TikaInstance {
             if (fs.isPdfOcr()) {
                 logger.debug("OCR is activated");
                 TesseractOCRConfig config = new TesseractOCRConfig();
+                if (fs.getOcr().getPath() != null) {
+                    config.setTesseractPath(fs.getOcr().getPath());
+                }
+                if (fs.getOcr().getDataPath() != null) {
+                    config.setTessdataPath(fs.getOcr().getDataPath());
+                }
                 config.setLanguage(fs.getOcr().getLanguage());
                 context.set(TesseractOCRConfig.class, config);
             }

--- a/tika/src/test/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParserTest.java
+++ b/tika/src/test/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParserTest.java
@@ -22,6 +22,7 @@ package fr.pilato.elasticsearch.crawler.fs.tika;
 import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
 import fr.pilato.elasticsearch.crawler.fs.settings.Fs;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
+import fr.pilato.elasticsearch.crawler.fs.settings.Ocr;
 import org.apache.tika.parser.external.ExternalParser;
 import org.junit.Test;
 
@@ -623,6 +624,18 @@ public class TikaDocParserTest extends DocParserTestCase {
         assertThat(doc.getContent(), isEmptyString());
         doc = extractFromFile("test-ocr.pdf", fsSettings);
         assertThat(doc.getContent(), is("\n\n"));
+
+        // Test with OCR On (default) but a wrong path to tesseract
+        fsSettings = FsSettings.builder(getCurrentTestName())
+                .setFs(Fs.builder().setOcr(Ocr.builder()
+                        .setPath("/path/to/doesnotexist")
+                        .setDataPath("/path/to/doesnotexist")
+                        .build()).build())
+                .build();
+        doc = extractFromFile("test-ocr.png", fsSettings);
+        assertThat(doc.getContent(), isEmptyString());
+        doc = extractFromFile("test-ocr.pdf", fsSettings);
+        assertThat(doc.getContent(), nullValue());
     }
 
     @Test


### PR DESCRIPTION
## OCR Path

If your Tesseract application is not available in default system PATH, you can define the path to use
by setting `fs.ocr.path` property in your `~/.fscrawler/test/_settings.json` file:

```json
{
  "name" : "test",
  "fs" : {
    "url" : "/path/to/data/dir",
    "ocr" : {
      "path": "/path/to/tesseract/executable"
    }
  }
}
```

When you set it, it's highly recommended to [set the data path for Tesseract](#ocr-data-path).

## OCR Data Path

Set the path to the 'tessdata' folder, which contains language files and config files if Tesseract
can not be automatically detected. You can define the path to use
by setting `fs.ocr.data_path` property in your `~/.fscrawler/test/_settings.json` file:

```json
{
  "name" : "test",
  "fs" : {
    "url" : "/path/to/data/dir",
    "ocr" : {
      "path": "/path/to/tesseract/executable",
      "data_path": "/path/to/tesseract/tessdata"
    }
  }
}
```

Closes #495.