### PR TITLE
Check that pipeline actually exists when starting

### DIFF
--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -148,6 +148,28 @@ public class ElasticsearchClient extends RestHighLevelClient {
     }
 
     /**
+     * Check if a pipeline exists
+     * @param pipeline pipeline name
+     * @return true if the pipeline exists, false otherwise
+     * @throws IOException In case of error
+     */
+    public boolean isExistingPipeline(String pipeline) throws IOException {
+        logger.debug("is existing pipeline [{}]", pipeline);
+
+        try {
+            Response restResponse = getLowLevelClient().performRequest("GET", "/_ingest/pipeline/" + pipeline);
+            logger.trace("get pipeline metadata response: {}", LowLevelClientJsonUtil.asMap(restResponse));
+            return true;
+        } catch (ResponseException e) {
+            if (e.getResponse().getStatusLine().getStatusCode() == 404) {
+                logger.debug("pipeline [{}] does not exist", pipeline);
+                return false;
+            }
+            throw e;
+        }
+    }
+
+    /**
      * Refresh an index
      * @param index index name
      * @throws IOException In case of error

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClientManager.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClientManager.java
@@ -91,10 +91,18 @@ public class ElasticsearchClientManager {
             throw e;
         }
 
-        // Check that we don't try using an ingest pipeline with a non compatible version
-        if (settings.getElasticsearch().getPipeline() != null && !client.isIngestSupported()) {
-            throw new RuntimeException("You defined pipeline:" + settings.getElasticsearch().getPipeline() +
-                    ", but your elasticsearch cluster does not support this feature.");
+        if (settings.getElasticsearch().getPipeline() != null) {
+            // Check that we don't try using an ingest pipeline with a non compatible version
+            if (!client.isIngestSupported()) {
+                throw new RuntimeException("You defined pipeline:" + settings.getElasticsearch().getPipeline() +
+                        ", but your elasticsearch cluster does not support this feature.");
+            }
+
+            // Check that the pipeline exists
+            if (!client.isExistingPipeline(settings.getElasticsearch().getPipeline())) {
+                throw new RuntimeException("You defined pipeline:" + settings.getElasticsearch().getPipeline() +
+                        ", but it does not exist.");
+            }
         }
 
         bulkProcessorDoc = BulkProcessor.builder(client::bulkAsync, new DebugListener(logger))


### PR DESCRIPTION
When starting FSCrawler we don't check that the pipeline actually exists in elasticsearch.
This commit introduces a check before starting an elasticsearch client.

Closes #490.