### PR TITLE
Add tests on OSS image as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,9 @@ addons:
 before_script:
   - sudo sysctl -w vm.max_map_count=262144
 script:
-  - mvn --batch-mode clean verify -Pes-5x && mvn --batch-mode clean verify
+  - mvn --batch-mode clean verify -Pes-5x
+  - mvn --batch-mode clean verify -Poss
+  - mvn --batch-mode clean verify
   - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar
 after_success:
   - "[[ ${TRAVIS_PULL_REQUEST} == 'false' ]] && [[ ${TRAVIS_TAG} == '' ]] && mvn deploy -DskipTests --settings deploy-settings.xml"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,13 @@ You can also tell maven to run integration tests by deploying another version of
 mvn install -Pes-5x
 ```
 
-By default, it will run integration tests against elasticsearch 6.x series cluster.
+By default, it will run integration tests against elasticsearch 6.x series cluster protected with X-Pack.
+
+You can also run test without X-Pack by using the `oss` maven profile:
+
+```sh
+mvn install -Poss
+```
 
 ### Running tests against an external cluster
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -100,51 +100,10 @@
                 <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
 
+            <!-- To start Docker when running IT -->
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>0.24.0</version>
-                <configuration>
-                    <images>
-                        <image>
-                            <alias>elasticsearch-it</alias>
-                            <name>dadoonet/docker-elasticsearch:${project.version}</name>
-                            <build>
-                                <from>docker.elastic.co/elasticsearch/elasticsearch:${integ.elasticsearch.version}</from>
-                            </build>
-                            <run>
-                                <ports>
-                                    <port>integ.elasticsearch.port:9200</port>
-                                </ports>
-                                <wait>
-                                    <http>
-                                        <url>http://localhost:${integ.elasticsearch.port}/</url>
-                                        <status>200..499</status>
-                                    </http>
-                                    <time>60000</time>
-                                </wait>
-                            </run>
-                        </image>
-                    </images>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>start-elasticsearch</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>build</goal>
-                            <goal>stop</goal>
-                            <goal>start</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>stop-elasticsearch</id>
-                        <phase>post-integration-test</phase>
-                        <goals>
-                            <goal>stop</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -48,9 +48,9 @@
         <skipTests>false</skipTests>
         <skipUnitTests>${skipTests}</skipUnitTests>
         <skipIntegTests>${skipTests}</skipIntegTests>
-        <skipXPack>true</skipXPack>
 
         <!-- For integration tests using Docker or external cluster -->
+        <integ.elasticsearch.image>docker.elastic.co/elasticsearch/elasticsearch</integ.elasticsearch.image>
         <integ.elasticsearch.version>${elasticsearch.version}</integ.elasticsearch.version>
         <integ.security.username>elastic</integ.security.username>
         <integ.security.password>changeme</integ.security.password>
@@ -219,6 +219,55 @@
                         <execution>
                             <id>default-test</id>
                             <phase>none</phase>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <!-- For IT using Docker -->
+                <plugin>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <version>0.24.0</version>
+                    <configuration>
+                        <images>
+                            <image>
+                                <alias>elasticsearch-it</alias>
+                                <name>dadoonet/docker-elasticsearch:${project.version}</name>
+                                <build>
+                                    <from>${integ.elasticsearch.image}:${integ.elasticsearch.version}</from>
+                                </build>
+                                <run>
+                                    <ports>
+                                        <port>integ.elasticsearch.port:9200</port>
+                                    </ports>
+                                    <wait>
+                                        <http>
+                                            <url>http://localhost:${integ.elasticsearch.port}/</url>
+                                            <status>200..499</status>
+                                        </http>
+                                        <time>60000</time>
+                                    </wait>
+                                </run>
+                            </image>
+                        </images>
+                        <skip>${skipIntegTests}</skip>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>start-elasticsearch</id>
+                            <phase>pre-integration-test</phase>
+                            <goals>
+                                <goal>build</goal>
+                                <goal>stop</goal>
+                                <goal>start</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>stop-elasticsearch</id>
+                            <phase>post-integration-test</phase>
+                            <goals>
+                                <goal>stop</goal>
+                            </goals>
                         </execution>
                     </executions>
                 </plugin>
@@ -626,6 +675,12 @@
     </repositories>
 
     <profiles>
+        <profile>
+            <id>oss</id>
+            <properties>
+                <integ.elasticsearch.image>docker.elastic.co/elasticsearch/elasticsearch-oss</integ.elasticsearch.image>
+            </properties>
+        </profile>
         <profile>
             <id>es-5x</id>
             <properties>


### PR DESCRIPTION
Previously we were testing the code with x-pack and without.
We can still do that by pulling the right Docker image anytime we want to start integration tests.

This is available with a new Maven profile `oss`.

We also move the `docker-maven-plugin` to the parent pom so we can reuse this configuration in other modules.
There is not other one yet but I'm thinking of building at the end a FSCrawler Docker image which I can start for real and run more advanced integration tests.