### PR TITLE
Allow using `store_source` without indexing content

### DIFF
--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerTestStoreSourceIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerTestStoreSourceIT.java
@@ -61,4 +61,19 @@ public class FsCrawlerTestStoreSourceIT extends AbstractFsCrawlerITCase {
             assertThat(hit.getSourceAsMap().get(Doc.FIELD_NAMES.ATTACHMENT), nullValue());
         }
     }
+
+    @Test
+    public void test_store_source_no_index_content() throws Exception {
+        Fs fs = startCrawlerDefinition()
+                .setStoreSource(true)
+                .setIndexContent(false)
+                .build();
+        startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+
+        SearchResponse searchResponse = countTestHelper(new SearchRequest(getCrawlerName()), 1L, null);
+        for (SearchHit hit : searchResponse.getHits().getHits()) {
+            // We check that the field is in _source
+            assertThat(hit.getSourceAsMap().get(Doc.FIELD_NAMES.ATTACHMENT), notNullValue());
+        }
+    }
 }

--- a/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
+++ b/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
@@ -19,6 +19,7 @@
 
 package fr.pilato.elasticsearch.crawler.fs.tika;
 
+import com.google.common.io.ByteStreams;
 import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
 import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
@@ -78,107 +79,113 @@ public class TikaDocParser {
             inputStream = new DigestInputStream(inputStream, messageDigest);
         }
 
-        ByteArrayOutputStream bos = null;
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
         if (fsSettings.getFs().isStoreSource()) {
             logger.debug("Using a TeeInputStream as we need to store the source");
             bos = new ByteArrayOutputStream();
             inputStream = new TeeInputStream(inputStream, bos);
         }
 
-        try {
-            // Set the maximum length of strings returned by the parseToString method, -1 sets no limit
-            logger.trace("Beginning Tika extraction");
-            parsedContent = extractText(fsSettings, indexedChars, inputStream, metadata);
-            logger.trace("End of Tika extraction");
-        } catch (Throwable e) {
-            logger.debug("Failed to extract [" + indexedChars + "] characters of text for [" + filename + "]", e);
-        }
-
-        // Adding what we found to the document we want to index
-
-        // File
-        doc.getFile().setContentType(metadata.get(Metadata.CONTENT_TYPE));
-
-        // We only add `indexed_chars` if we have other value than default or -1
-        if (fsSettings.getFs().getIndexedChars() != null && fsSettings.getFs().getIndexedChars().value() != -1) {
-            doc.getFile().setIndexedChars(indexedChars);
-        }
-
-        if (fsSettings.getFs().isAddFilesize()) {
-            if (metadata.get(Metadata.CONTENT_LENGTH) != null) {
-                // We try to get CONTENT_LENGTH from Tika first
-                doc.getFile().setFilesize(Long.parseLong(metadata.get(Metadata.CONTENT_LENGTH)));
+        if (fsSettings.getFs().isIndexContent()) {
+            try {
+                // Set the maximum length of strings returned by the parseToString method, -1 sets no limit
+                logger.trace("Beginning Tika extraction");
+                parsedContent = extractText(fsSettings, indexedChars, inputStream, metadata);
+                logger.trace("End of Tika extraction");
+            } catch (Throwable e) {
+                logger.debug("Failed to extract [" + indexedChars + "] characters of text for [" + filename + "]", e);
             }
-        }
-        if (messageDigest != null) {
-            byte[] digest = messageDigest.digest();
-            StringBuilder result = new StringBuilder();
-            // Convert to Hexa
-            for (byte aDigest : digest) {
-                result.append(Integer.toString((aDigest & 0xff) + 0x100, 16).substring(1));
-            }
-            doc.getFile().setChecksum(result.toString());
-        }
-        // File
 
-        // Standard Meta
-        setMeta(filename, metadata, TikaCoreProperties.CREATOR, doc.getMeta()::setAuthor, Function.identity());
-        setMeta(filename, metadata, TikaCoreProperties.TITLE, doc.getMeta()::setTitle, Function.identity());
-        setMeta(filename, metadata, TikaCoreProperties.MODIFIED, doc.getMeta()::setDate, FsCrawlerUtil::localDateTimeToDate);
-        setMeta(filename, metadata, TikaCoreProperties.KEYWORDS, doc.getMeta()::setKeywords, TikaDocParser::commaDelimitedListToStringArray);
-        setMeta(filename, metadata, TikaCoreProperties.FORMAT, doc.getMeta()::setFormat, Function.identity());
-        setMeta(filename, metadata, TikaCoreProperties.IDENTIFIER, doc.getMeta()::setIdentifier, Function.identity());
-        setMeta(filename, metadata, TikaCoreProperties.CONTRIBUTOR, doc.getMeta()::setContributor, Function.identity());
-        setMeta(filename, metadata, TikaCoreProperties.COVERAGE, doc.getMeta()::setCoverage, Function.identity());
-        setMeta(filename, metadata, TikaCoreProperties.MODIFIER, doc.getMeta()::setModifier, Function.identity());
-        setMeta(filename, metadata, TikaCoreProperties.CREATOR_TOOL, doc.getMeta()::setCreatorTool, Function.identity());
-        String finalParsedContent = parsedContent;
-        setMeta(filename, metadata, TikaCoreProperties.LANGUAGE, doc.getMeta()::setLanguage, (lang) -> {
-            if (lang != null) {
-                return lang;
-            } else if (fsSettings.getFs().isLangDetect() && finalParsedContent != null) {
-                List<LanguageResult> languages = langDetector().detectAll(finalParsedContent);
-                if (!languages.isEmpty()) {
-                    LanguageResult language = languages.get(0);
-                    logger.trace("Main detected language: [{}]", language);
-                    return language.getLanguage();
+            // Adding what we found to the document we want to index
+
+            // File
+            doc.getFile().setContentType(metadata.get(Metadata.CONTENT_TYPE));
+
+            // We only add `indexed_chars` if we have other value than default or -1
+            if (fsSettings.getFs().getIndexedChars() != null && fsSettings.getFs().getIndexedChars().value() != -1) {
+                doc.getFile().setIndexedChars(indexedChars);
+            }
+
+            if (fsSettings.getFs().isAddFilesize()) {
+                if (metadata.get(Metadata.CONTENT_LENGTH) != null) {
+                    // We try to get CONTENT_LENGTH from Tika first
+                    doc.getFile().setFilesize(Long.parseLong(metadata.get(Metadata.CONTENT_LENGTH)));
                 }
             }
-            return null;
-        });
-        setMeta(filename, metadata, TikaCoreProperties.PUBLISHER, doc.getMeta()::setPublisher, Function.identity());
-        setMeta(filename, metadata, TikaCoreProperties.RELATION, doc.getMeta()::setRelation, Function.identity());
-        setMeta(filename, metadata, TikaCoreProperties.RIGHTS, doc.getMeta()::setRights, Function.identity());
-        setMeta(filename, metadata, TikaCoreProperties.SOURCE, doc.getMeta()::setSource, Function.identity());
-        setMeta(filename, metadata, TikaCoreProperties.TYPE, doc.getMeta()::setType, Function.identity());
-        setMeta(filename, metadata, TikaCoreProperties.DESCRIPTION, doc.getMeta()::setDescription, Function.identity());
-        setMeta(filename, metadata, TikaCoreProperties.CREATED, doc.getMeta()::setCreated, FsCrawlerUtil::localDateTimeToDate);
-        setMeta(filename, metadata, TikaCoreProperties.PRINT_DATE, doc.getMeta()::setPrintDate, FsCrawlerUtil::localDateTimeToDate);
-        setMeta(filename, metadata, TikaCoreProperties.METADATA_DATE, doc.getMeta()::setMetadataDate, FsCrawlerUtil::localDateTimeToDate);
-        setMeta(filename, metadata, TikaCoreProperties.LATITUDE, doc.getMeta()::setLatitude, Function.identity());
-        setMeta(filename, metadata, TikaCoreProperties.LONGITUDE, doc.getMeta()::setLongitude, Function.identity());
-        setMeta(filename, metadata, TikaCoreProperties.ALTITUDE, doc.getMeta()::setAltitude, Function.identity());
-        setMeta(filename, metadata, TikaCoreProperties.RATING, doc.getMeta()::setRating, (value) -> value == null ? null : Integer.parseInt(value));
-        setMeta(filename, metadata, TikaCoreProperties.COMMENTS, doc.getMeta()::setComments, Function.identity());
-
-        // Add support for more OOTB standard metadata
-
-        if (fsSettings.getFs().isRawMetadata()) {
-            logger.trace("Listing all available metadata:");
-            for (String metadataName : metadata.names()) {
-                String value = metadata.get(metadataName);
-                // This is a logger trick which helps to generate our unit tests
-                // You need to change test/resources/log4j2.xml fr.pilato.elasticsearch.crawler.fs.tika level to trace
-                logger.trace("  assertThat(raw, hasEntry(\"{}\", \"{}\"));", metadataName, value);
-
-                // We need to remove dots in field names if any. See https://github.com/dadoonet/fscrawler/issues/256
-                doc.getMeta().addRaw(metadataName.replaceAll("\\.", ":"), value);
+            if (messageDigest != null) {
+                byte[] digest = messageDigest.digest();
+                StringBuilder result = new StringBuilder();
+                // Convert to Hexa
+                for (byte aDigest : digest) {
+                    result.append(Integer.toString((aDigest & 0xff) + 0x100, 16).substring(1));
+                }
+                doc.getFile().setChecksum(result.toString());
             }
-        }
-        // Meta
+            // File
 
-        // Doc content
-        doc.setContent(parsedContent);
+            // Standard Meta
+            setMeta(filename, metadata, TikaCoreProperties.CREATOR, doc.getMeta()::setAuthor, Function.identity());
+            setMeta(filename, metadata, TikaCoreProperties.TITLE, doc.getMeta()::setTitle, Function.identity());
+            setMeta(filename, metadata, TikaCoreProperties.MODIFIED, doc.getMeta()::setDate, FsCrawlerUtil::localDateTimeToDate);
+            setMeta(filename, metadata, TikaCoreProperties.KEYWORDS, doc.getMeta()::setKeywords, TikaDocParser::commaDelimitedListToStringArray);
+            setMeta(filename, metadata, TikaCoreProperties.FORMAT, doc.getMeta()::setFormat, Function.identity());
+            setMeta(filename, metadata, TikaCoreProperties.IDENTIFIER, doc.getMeta()::setIdentifier, Function.identity());
+            setMeta(filename, metadata, TikaCoreProperties.CONTRIBUTOR, doc.getMeta()::setContributor, Function.identity());
+            setMeta(filename, metadata, TikaCoreProperties.COVERAGE, doc.getMeta()::setCoverage, Function.identity());
+            setMeta(filename, metadata, TikaCoreProperties.MODIFIER, doc.getMeta()::setModifier, Function.identity());
+            setMeta(filename, metadata, TikaCoreProperties.CREATOR_TOOL, doc.getMeta()::setCreatorTool, Function.identity());
+            String finalParsedContent = parsedContent;
+            setMeta(filename, metadata, TikaCoreProperties.LANGUAGE, doc.getMeta()::setLanguage, (lang) -> {
+                if (lang != null) {
+                    return lang;
+                } else if (fsSettings.getFs().isLangDetect() && finalParsedContent != null) {
+                    List<LanguageResult> languages = langDetector().detectAll(finalParsedContent);
+                    if (!languages.isEmpty()) {
+                        LanguageResult language = languages.get(0);
+                        logger.trace("Main detected language: [{}]", language);
+                        return language.getLanguage();
+                    }
+                }
+                return null;
+            });
+            setMeta(filename, metadata, TikaCoreProperties.PUBLISHER, doc.getMeta()::setPublisher, Function.identity());
+            setMeta(filename, metadata, TikaCoreProperties.RELATION, doc.getMeta()::setRelation, Function.identity());
+            setMeta(filename, metadata, TikaCoreProperties.RIGHTS, doc.getMeta()::setRights, Function.identity());
+            setMeta(filename, metadata, TikaCoreProperties.SOURCE, doc.getMeta()::setSource, Function.identity());
+            setMeta(filename, metadata, TikaCoreProperties.TYPE, doc.getMeta()::setType, Function.identity());
+            setMeta(filename, metadata, TikaCoreProperties.DESCRIPTION, doc.getMeta()::setDescription, Function.identity());
+            setMeta(filename, metadata, TikaCoreProperties.CREATED, doc.getMeta()::setCreated, FsCrawlerUtil::localDateTimeToDate);
+            setMeta(filename, metadata, TikaCoreProperties.PRINT_DATE, doc.getMeta()::setPrintDate, FsCrawlerUtil::localDateTimeToDate);
+            setMeta(filename, metadata, TikaCoreProperties.METADATA_DATE, doc.getMeta()::setMetadataDate, FsCrawlerUtil::localDateTimeToDate);
+            setMeta(filename, metadata, TikaCoreProperties.LATITUDE, doc.getMeta()::setLatitude, Function.identity());
+            setMeta(filename, metadata, TikaCoreProperties.LONGITUDE, doc.getMeta()::setLongitude, Function.identity());
+            setMeta(filename, metadata, TikaCoreProperties.ALTITUDE, doc.getMeta()::setAltitude, Function.identity());
+            setMeta(filename, metadata, TikaCoreProperties.RATING, doc.getMeta()::setRating, (value) -> value == null ? null : Integer.parseInt(value));
+            setMeta(filename, metadata, TikaCoreProperties.COMMENTS, doc.getMeta()::setComments, Function.identity());
+
+            // Add support for more OOTB standard metadata
+
+            if (fsSettings.getFs().isRawMetadata()) {
+                logger.trace("Listing all available metadata:");
+                for (String metadataName : metadata.names()) {
+                    String value = metadata.get(metadataName);
+                    // This is a logger trick which helps to generate our unit tests
+                    // You need to change test/resources/log4j2.xml fr.pilato.elasticsearch.crawler.fs.tika level to trace
+                    logger.trace("  assertThat(raw, hasEntry(\"{}\", \"{}\"));", metadataName, value);
+
+                    // We need to remove dots in field names if any. See https://github.com/dadoonet/fscrawler/issues/256
+                    doc.getMeta().addRaw(metadataName.replaceAll("\\.", ":"), value);
+                }
+            }
+            // Meta
+
+            // Doc content
+            doc.setContent(parsedContent);
+        } else if (fsSettings.getFs().isStoreSource()) {
+            // We don't extract content but just store the binary file
+            // We need to create the ByteArrayOutputStream which has not been created then
+            ByteStreams.copy(inputStream, bos);
+        }
 
         // Doc as binary attachment
         if (fsSettings.getFs().isStoreSource()) {

--- a/tika/src/test/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParserTest.java
+++ b/tika/src/test/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParserTest.java
@@ -569,6 +569,18 @@ public class TikaDocParserTest extends DocParserTestCase {
     }
 
     @Test
+    public void testExtractFromTxtStoreSourceAndNoIndexContent() throws IOException {
+        Doc doc = extractFromFile("test.txt",
+                FsSettings.builder(getCurrentTestName())
+                        .setFs(Fs.builder().setStoreSource(true).setIndexContent(false).build())
+                        .build());
+
+        // Extracted content
+        assertThat(doc.getContent(), nullValue());
+        assertThat(doc.getAttachment(), notNullValue());
+    }
+
+    @Test
     public void testExtractFromTxtAndStoreSourceWithDigest() throws IOException {
         try {
             MessageDigest.getInstance("MD5");


### PR DESCRIPTION
When using `store_source` and `index_content`, we are able to store the
binary document as is and the extracted text:

```json
{
  "store_source" : true,
  "index_content" : true
}
```

But when we just want to store the binary content it fails:

```json
{
  "store_source" : true,
  "index_content" : false
}
```

This patch fixes the problem.

Closes #532.