### PR TITLE
Update to Elasticsearch 6.3.1

### DIFF
--- a/docs/source/fscrawler.ini
+++ b/docs/source/fscrawler.ini
@@ -3,7 +3,7 @@ Version=2.5-SNAPSHOT
 
 [3rdParty]
 TikaVersion=1.18
-ElasticsearchVersion=6.3.0
+ElasticsearchVersion=6.3.1
 LevigoVersion=2.0
 TiffVersion=1.3.1
 JpegVersion=1.3.0

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
@@ -233,7 +233,7 @@ public abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
                         new HttpHost(testClusterHost, testClusterPort), testClusterUser, testClusterPass));
                 elasticsearchClientTemporary.info();
                 staticLogger.debug("A node is already running locally. No need to start a Docker instance.");
-            } catch (ConnectException e) {
+            } catch (IOException e) {
                 staticLogger.debug("No local node running. We need to start a Docker instance.");
                 // We start an elasticsearch Docker instance
                 Properties props = readPropertiesFromClassLoader("elasticsearch.version.properties");

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <!--suppress CheckTagEmptyBody -->
     <properties>
-        <elasticsearch.version>6.3.0</elasticsearch.version>
+        <elasticsearch.version>6.3.1</elasticsearch.version>
 
         <tika.version>1.18</tika.version>
         <jackson.version>2.9.3</jackson.version>


### PR DESCRIPTION
Also fix an issue when running tests from IDE.
Elasticsearch which is not running (so we launch containers)
was not correctly detected.