### PR TITLE
add custom properties to doc via upload api

### DIFF
--- a/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/Doc.java
+++ b/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/Doc.java
@@ -19,6 +19,7 @@
 
 package fr.pilato.elasticsearch.crawler.fs.beans;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -45,11 +46,13 @@ public class Doc {
     private Path path;
     private Attributes attributes;
     private Map object;
+    private Map<String, String> properties;
 
     public Doc() {
         meta = new Meta();
         file = new File();
         path = new Path();
+        properties = new HashMap<>();
     }
 
     public Map getObject() {
@@ -106,5 +109,13 @@ public class Doc {
 
     public void setAttributes(Attributes attributes) {
         this.attributes = attributes;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
     }
 }

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/CustomPropertiesUtil.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/CustomPropertiesUtil.java
@@ -1,0 +1,38 @@
+package fr.pilato.elasticsearch.crawler.fs.framework;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CustomPropertiesUtil {
+
+  private static final Logger logger = LogManager.getLogger(CustomPropertiesUtil.class);
+
+  /**
+   * Parses a comma separated properties string and returns a map
+   * @param propertiesString e.g. prop1=value1;prop2=value2
+   * @return Map containing the key/values
+   */
+  public static Map<String, String> parseCustomProperties(String propertiesString) {
+    Map<String, String> properties = new HashMap<>();
+
+    if (propertiesString == null) {
+      return properties;
+    }
+
+    try {
+      String[] splittedProps = propertiesString.split(";");
+
+      for (String splittedProp: splittedProps) {
+        String[] keyValue = splittedProp.split("=");
+        properties.put(keyValue[0], keyValue[1]);
+      }
+    } catch(Exception e) {
+      logger.error("Not able to parse custom properties from " + propertiesString, e);
+    }
+
+    return properties;
+  }
+}

--- a/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/UploadApi.java
+++ b/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/UploadApi.java
@@ -22,6 +22,7 @@ package fr.pilato.elasticsearch.crawler.fs.rest;
 
 import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
 import fr.pilato.elasticsearch.crawler.fs.beans.DocParser;
+import fr.pilato.elasticsearch.crawler.fs.framework.CustomPropertiesUtil;
 import fr.pilato.elasticsearch.crawler.fs.framework.SignTool;
 import fr.pilato.elasticsearch.crawler.fs.settings.Elasticsearch;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
@@ -43,6 +44,7 @@ import java.io.InputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
+import java.util.Map;
 
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.buildUrl;
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.localDateTimeToDate;
@@ -74,6 +76,7 @@ public class UploadApi extends RestApi {
             @QueryParam("debug") String debug,
             @QueryParam("simulate") String simulate,
             @FormDataParam("id") String id,
+            @FormDataParam("props") String props,
             @FormDataParam("file") InputStream filecontent,
             @FormDataParam("file") FormDataContentDisposition d) throws IOException, NoSuchAlgorithmException {
 
@@ -88,6 +91,11 @@ public class UploadApi extends RestApi {
         doc.getFile().setExtension(FilenameUtils.getExtension(filename).toLowerCase());
         doc.getFile().setIndexingDate(localDateTimeToDate(LocalDateTime.now()));
         // File
+
+        // custom properties
+        Map<String, String> properties = CustomPropertiesUtil.parseCustomProperties(props);
+        doc.setProperties(properties);
+        // custom properties
 
         // Path
         if (id == null) {


### PR DESCRIPTION
Add custom properties to the document.
Gives additional filtering opportunities:
- filter documents on project/tenant etc.
- in case of extremely large documents, split documents by page (and index) and filter on page number

Usage via curl, e.g.:

```sh
curl -F "file=@document.pdf" -F "props=projectId=1;tenantId=1" "http://127.0.0.1:8080/fscrawler/_upload"
```

filter query e.g.

```
GET /job_name/_search
{
   "query" : {
      "constant_score" : { 
         "filter" : {
            "bool" : {
              "must" : [
                 { "term" : {"props.projectId.keyword" : "1"}}, 
                 { "term" : {"props.tenantId.keyword" : "1"}} 
              ]
           }
         }
      }
   }
}
```