### PR TITLE
Skip sonar build for external PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_script:
 script:
   - mvn --batch-mode clean verify -Pes-5x
   - mvn --batch-mode clean verify -Poss
-  - mvn --batch-mode clean org.jacoco:jacoco-maven-plugin:prepare-agent verify sonar:sonar
+  - "[[ ${TRAVIS_SECURE_ENV_VARS} == 'true' ]] && mvn --batch-mode clean org.jacoco:jacoco-maven-plugin:prepare-agent verify sonar:sonar"
 after_success:
   - "[[ ${TRAVIS_PULL_REQUEST} == 'false' ]] && [[ ${TRAVIS_TAG} == '' ]] && mvn deploy -DskipTests --settings deploy-settings.xml"
 cache:


### PR DESCRIPTION
This is coming from: https://community.sonarsource.com/t/travis-plugin-is-failing-on-external-pull-request/807/

It's a workaround for now until https://jira.sonarsource.com/browse/TRAVIS-19 is solved.