### PR TITLE
Close bulk processors with awaitClose instead of close

### DIFF
--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClientManager.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClientManager.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.unit.TimeValue;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
 
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.INDEX_SETTINGS_FILE;
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.INDEX_SETTINGS_FOLDER_FILE;
@@ -191,10 +192,18 @@ public class ElasticsearchClientManager {
     public void close() {
         logger.debug("Closing Elasticsearch client manager");
         if (bulkProcessorDoc != null) {
-            bulkProcessorDoc.close();
+            try {
+                bulkProcessorDoc.awaitClose(30, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                logger.warn("Did not succeed in closing the bulk processor for documents", e);
+            }
         }
         if (bulkProcessorFolder != null) {
-            bulkProcessorFolder.close();
+            try {
+                bulkProcessorFolder.awaitClose(30, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                logger.warn("Did not succeed in closing the bulk processor for folders", e);
+            }
         }
         if (client != null) {
             try {


### PR DESCRIPTION
We were closing the bulk processors with `close()` which was
trying to immediately exit the bulk processor.

Calling `awaitClose(30, TimeUnit.SECONDS)` is giving 30 more seconds
to the bulk processor to flush first all existing request before
actually closing.

I thought that `close()` was doing the same behind the scene but
apparently not.

Closes #547.