### PR TITLE
Add ossindex Maven plugin

### DIFF
--- a/docs/source/dev/build.rst
+++ b/docs/source/dev/build.rst
@@ -1,0 +1,75 @@
+Building the project
+--------------------
+
+This project is built with `Maven <https://maven.apache.org/>`_.
+
+Build the artifact
+^^^^^^^^^^^^^^^^^^
+
+To build the project, run::
+
+    mvn clean package
+
+The final artifact is available in ``distribution/target`` directory.
+
+.. tip::
+
+    To build it faster (without tests), run::
+
+        mvn clean package -DskipTests
+
+Run tests with an external cluster
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To run the test suite against an elasticsearch instance running locally, just run::
+
+    mvn check
+
+.. tip::
+
+    If you don't want to rebuild everything (ie. you just touch test classes), run::
+
+        mvn -pl fr.pilato.elasticsearch.crawler:fscrawler-it check
+
+If elasticsearch is not running yet on ``http://localhost:9200``, FSCrawler project will run a Docker instance before
+the tests start.
+
+.. hint::
+
+    If you are using a secured instance, use ``tests.cluster.user``, ``tests.cluster.pass`` and ``tests.cluster.scheme``::
+
+        mvn check \
+            -Dtests.cluster.user=elastic \
+            -Dtests.cluster.pass=changeme \
+            -Dtests.cluster.scheme=HTTPS \
+
+.. hint::
+
+    To run tests against another instance (ie. running on
+    `Elasticsearch service by Elastic <https://www.elastic.co/cloud/elasticsearch-service>`_,
+    you can also use ``tests.cluster.host`` and ``tests.cluster.port`` to set where elasticsearch
+    is running::
+
+        mvn check \
+            -Dtests.cluster.user=elastic \
+            -Dtests.cluster.pass=changeme \
+            -Dtests.cluster.scheme=HTTPS \
+            -Dtests.cluster.host=XYZ.es.io:9243 \
+            -Dtests.cluster.port=9243
+
+Check for vulnerabilities (CVE)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The project is using `OSS Sonatype service <https://ossindex.sonatype.org/>`_ to check for known
+vulnerabilities. This is ran during the `check` phase.
+
+Sonatype provides this service but with a anonymous account, you might be limited
+by the number of tests you can run during a given period.
+
+If you have an existing account, you can use it to bypass this limit for anonymous users by
+setting ``sonatype.username`` and ``sonatype.password``::
+
+        mvn check -DskipTests \
+            -Dsonatype.username=youremail@domain.com \
+            -Dsonatype.password=yourverysecuredpassword
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -61,6 +61,7 @@ This crawler helps to index binary documents such as PDF, Open Office, MS Office
       :caption: Developer Guide
       :maxdepth: 3
 
+      dev/build
       dev/doc
       dev/release
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <elasticsearch.version>6.3.2</elasticsearch.version>
 
         <tika.version>1.18</tika.version>
-        <jackson.version>2.9.3</jackson.version>
+        <jackson.version>2.9.6</jackson.version>
         <log4j.version>2.10.0</log4j.version>
         <jansi.version>1.16</jansi.version>
         <jersey.version>2.26</jersey.version>

--- a/pom.xml
+++ b/pom.xml
@@ -680,6 +680,12 @@
                 <version>0.1</version>
             </dependency>
 
+            <!-- CVE Temporary Fix -->
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk15on</artifactId>
+                <version>1.60</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,12 @@
         <tests.timeoutSuite>600000</tests.timeoutSuite>
         <tests.timeout>600000</tests.timeout>
 
+        <!-- For CVE Audit with Sonatype -->
+        <env.SONATYPE_USER></env.SONATYPE_USER>
+        <env.SONATYPE_PASS></env.SONATYPE_PASS>
+        <sonatype.username>${env.SONATYPE_USER}</sonatype.username>
+        <sonatype.password>${env.SONATYPE_PASS}</sonatype.password>
+
         <java.compiler.version>1.8</java.compiler.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -296,6 +302,28 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                    <groupId>org.sonatype.ossindex.maven</groupId>
+                    <artifactId>ossindex-maven-plugin</artifactId>
+                    <version>1.0.0</version>
+                    <executions>
+                        <execution>
+                            <id>audit-dependencies</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>audit</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <clientConfiguration>
+                            <authConfiguration>
+                                <username>${env.SONATYPE_USER}</username>
+                                <password>${env.SONATYPE_PASS}</password>
+                            </authConfiguration>
+                        </clientConfiguration>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <groupId>org.sonatype.plugins</groupId>
                     <artifactId>nexus-staging-maven-plugin</artifactId>
                     <version>1.6.8</version>
@@ -334,6 +362,13 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <!-- For each module, we automatically check for vulnerabilities -->
+            <plugin>
+                <groupId>org.sonatype.ossindex.maven</groupId>
+                <artifactId>ossindex-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
     </build>
 
     <dependencyManagement>


### PR DESCRIPTION
This [plugin](https://sonatype.github.io/ossindex-maven/maven-plugin/) checks against [OSS Sonatype service](https://ossindex.sonatype.org/) to check for known vulnerabilities.

This is ran during the `check` phase.

Sonatype provides this service but with a anonymous account, you might be limited by the number of tests you can run during a given period.

If you have an existing account, you can use it to bypass this limit for anonymous users by setting ``sonatype.username`` and ``sonatype.password``::

```sh
mvn check -DskipTests \
     -Dsonatype.username=youremail@domain.com \
     -Dsonatype.password=yourverysecuredpassword
```