### PR TITLE
Add support for cloud id

### DIFF
--- a/docs/source/admin/fs/elasticsearch.rst
+++ b/docs/source/admin/fs/elasticsearch.rst
@@ -452,6 +452,27 @@ a production cluster:
      }
    }
 
+If you are using `Elasticsearch service by Elastic <https://www.elastic.co/cloud/elasticsearch-service>`_,
+you can just use the ``Cloud ID`` which is available in the Cloud Console and paste it:
+
+.. code:: json
+
+   {
+     "name" : "test",
+     "elasticsearch" : {
+       "nodes" : [
+         { "cloud_id" : "fscrawler:ZXVyb3BlLXdlc3QxLmdjcC5jbG91ZC5lcy5pbyQxZDFlYTk5Njg4Nzc0NWE2YTJiN2NiNzkzMTUzNDhhMyQyOTk1MDI3MzZmZGQ0OTI5OTE5M2UzNjdlOTk3ZmU3Nw==" }
+       ]
+     }
+   }
+
+This ID will be used to automatically generate the right host, port and scheme.
+
+.. hint::
+
+    In the context of `Elasticsearch service by Elastic <https://www.elastic.co/cloud/elasticsearch-service>`_,
+    you will most likely need to provide as well the username and the password. See :ref:`credentials`.
+
 You can define multiple nodes:
 
 .. code:: json

--- a/docs/source/admin/fs/index.rst
+++ b/docs/source/admin/fs/index.rst
@@ -43,6 +43,10 @@ The job file must comply to the following ``json`` specifications:
      },
      "elasticsearch" : {
        "nodes" : [ {
+         // With Cloud ID
+         "cloud_id" : "CLOUD_ID"
+       }, {
+         // With scheme, host and port
          "host" : "127.0.0.1",
          "port" : 9200,
          "scheme" : "HTTP"

--- a/docs/source/dev/build.rst
+++ b/docs/source/dev/build.rst
@@ -57,6 +57,14 @@ the tests start.
             -Dtests.cluster.host=XYZ.es.io:9243 \
             -Dtests.cluster.port=9243
 
+    Or even easier, you can use the ``Cloud ID`` available on you Cloud Console::
+
+        mvn verify \
+            -Dtests.cluster.user=elastic \
+            -Dtests.cluster.pass=changeme \
+            -Dtests.cluster.cloud_id=fscrawler:ZXVyb3BlLXdlc3QxLmdjcC5jbG91ZC5lcy5pbyQxZDFlYTk5Njg4Nzc0NWE2YTJiN2NiNzkzMTUzNDhhMyQyOTk1MDI3MzZmZGQ0OTI5OTE5M2UzNjdlOTk3ZmU3Nw==
+
+
 Check for vulnerabilities (CVE)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -40,6 +40,7 @@ import org.elasticsearch.index.query.TermQueryBuilder;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -290,9 +291,28 @@ public class ElasticsearchClient extends RestHighLevelClient {
         return VERSION;
     }
 
+    public static Node decodeCloudId(String cloudId) {
+     	// 1. Ignore anything before `:`.
+        String id = cloudId.substring(cloudId.indexOf(":")+1);
+
+     	// 2. base64 decode
+        String decoded = new String(Base64.getDecoder().decode(id));
+
+        // 3. separate based on `$`
+        String[] words = decoded.split("\\$");
+
+ 	    // 4. form the URLs
+        return Node.builder().setHost(words[1] + "." + words[0]).setPort(443).setScheme(Node.Scheme.HTTPS).build();
+    }
+
     public static RestClientBuilder buildRestClient(Elasticsearch settings) {
         List<HttpHost> hosts = new ArrayList<>(settings.getNodes().size());
         settings.getNodes().forEach(node -> {
+            if (node.getCloudId() != null) {
+                // We have a cloud id which simplifies all
+                node = decodeCloudId(node.getCloudId());
+            }
+
             Node.Scheme scheme = node.getScheme();
             if (scheme == null) {
                 // Default to HTTP. In case we are reading an old configuration

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -293,7 +293,7 @@ public class ElasticsearchClient extends RestHighLevelClient {
 
     public static Node decodeCloudId(String cloudId) {
      	// 1. Ignore anything before `:`.
-        String id = cloudId.substring(cloudId.indexOf(":")+1);
+        String id = cloudId.substring(cloudId.indexOf(':')+1);
 
      	// 2. base64 decode
         String decoded = new String(Base64.getDecoder().decode(id));

--- a/elasticsearch-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClientTest.java
+++ b/elasticsearch-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClientTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package fr.pilato.elasticsearch.crawler.fs.client;
+
+import fr.pilato.elasticsearch.crawler.fs.settings.Elasticsearch;
+import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
+import org.junit.Test;
+
+import static fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchClient.decodeCloudId;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class ElasticsearchClientTest extends AbstractFSCrawlerTestCase {
+
+    @Test
+    public void testCloudId() {
+
+        String cloudId = "fscrawler:ZXVyb3BlLXdlc3QxLmdjcC5jbG91ZC5lcy5pbyQxZDFlYTk5Njg4Nzc0NWE2YTJiN2NiNzkzMTUzNDhhMyQyOTk1MDI3MzZmZGQ0OTI5OTE5M2UzNjdlOTk3ZmU3Nw==";
+        Elasticsearch.Node httpHost = decodeCloudId(cloudId);
+
+        assertThat(httpHost.getHost(), is("1d1ea996887745a6a2b7cb79315348a3.europe-west1.gcp.cloud.es.io"));
+        assertThat(httpHost.getPort(), is(443));
+        assertThat(httpHost.getScheme(), is(Elasticsearch.Node.Scheme.HTTPS));
+    }
+}

--- a/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/UploadApi.java
+++ b/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/UploadApi.java
@@ -44,6 +44,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
 
+import static fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchClient.decodeCloudId;
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.buildUrl;
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.localDateTimeToDate;
 
@@ -114,6 +115,9 @@ public class UploadApi extends RestApi {
                     .source(DocParser.toJson(doc), XContentType.JSON));
             // Elasticsearch entity coordinates (we use the first node address)
             Elasticsearch.Node node = settings.getElasticsearch().getNodes().get(0);
+            if (node.getCloudId() != null) {
+                node = decodeCloudId(node.getCloudId());
+            }
             url = buildUrl(
                     node.getScheme().toLowerCase(), node.getHost(), node.getPort()) + "/" +
                     settings.getElasticsearch().getIndex() + "/" +

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Elasticsearch.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Elasticsearch.java
@@ -28,6 +28,7 @@ import fr.pilato.elasticsearch.crawler.fs.framework.TimeValue;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
 public class Elasticsearch {
 
@@ -186,29 +187,27 @@ public class Elasticsearch {
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
-
             Node node = (Node) o;
-
-            if (port != node.port) return false;
-            return !(host != null ? !host.equals(node.host) : node.host != null);
-
+            return active == node.active &&
+                    Objects.equals(cloudId, node.cloudId) &&
+                    Objects.equals(host, node.host) &&
+                    Objects.equals(port, node.port) &&
+                    scheme == node.scheme;
         }
 
         @Override
         public int hashCode() {
-            int result = host != null ? host.hashCode() : 0;
-            result = 31 * result + port;
-            return result;
+            return Objects.hash(cloudId, host, port, active, scheme);
         }
 
         @Override
         public String toString() {
-            String sb = "Node{" + "active=" + active +
+            return "Node{" + "cloudId='" + cloudId + '\'' +
                     ", host='" + host + '\'' +
                     ", port=" + port +
+                    ", active=" + active +
                     ", scheme=" + scheme +
                     '}';
-            return sb;
         }
     }
 
@@ -374,10 +373,22 @@ public class Elasticsearch {
         result = 31 * result + (index != null ? index.hashCode() : 0);
         result = 31 * result + (indexFolder != null ? indexFolder.hashCode() : 0);
         result = 31 * result + (username != null ? username.hashCode() : 0);
-        result = 31 * result + (password != null ? password.hashCode() : 0);
         result = 31 * result + (pipeline != null ? pipeline.hashCode() : 0);
         result = 31 * result + bulkSize;
         result = 31 * result + (flushInterval != null ? flushInterval.hashCode() : 0);
         return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Elasticsearch{" + "nodes=" + nodes +
+                ", index='" + index + '\'' +
+                ", indexFolder='" + indexFolder + '\'' +
+                ", bulkSize=" + bulkSize +
+                ", flushInterval=" + flushInterval +
+                ", byteSize=" + byteSize +
+                ", username='" + username + '\'' +
+                ", pipeline='" + pipeline + '\'' +
+                '}';
     }
 }

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Elasticsearch.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Elasticsearch.java
@@ -88,8 +88,13 @@ public class Elasticsearch {
             this.scheme = scheme;
         }
 
+        private Node(String cloudId) {
+            this.cloudId = cloudId;
+        }
+
+        private String cloudId;
         private String host;
-        private int port;
+        private Integer port;
         private boolean active;
         private Scheme scheme;
 
@@ -101,11 +106,11 @@ public class Elasticsearch {
             this.host = host;
         }
 
-        public int getPort() {
+        public Integer getPort() {
             return port;
         }
 
-        public void setPort(int port) {
+        public void setPort(Integer port) {
             this.port = port;
         }
 
@@ -125,6 +130,14 @@ public class Elasticsearch {
             this.scheme = scheme;
         }
 
+        public String getCloudId() {
+            return cloudId;
+        }
+
+        public void setCloudId(String cloudId) {
+            this.cloudId = cloudId;
+        }
+
         public static Builder builder() {
             return new Builder();
         }
@@ -133,6 +146,17 @@ public class Elasticsearch {
             private String host;
             private int port;
             private Scheme scheme = Scheme.HTTP;
+            private String cloudId = null;
+
+            /**
+             * This can be used in the context of Elasticsearch service by elastic
+             * @param cloudId The cloud id as given on cloud console
+             * @return self
+             */
+            public Builder setCloudId(String cloudId) {
+                this.cloudId = cloudId;
+                return this;
+            }
 
             public Builder setHost(String host) {
                 this.host = host;
@@ -150,7 +174,11 @@ public class Elasticsearch {
             }
 
             public Node build() {
-                return new Node(host, port, scheme);
+                if (cloudId != null) {
+                    return new Node(cloudId);
+                } else {
+                    return new Node(host, port, scheme);
+                }
             }
         }
 

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Fs.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Fs.java
@@ -472,4 +472,30 @@ public class Fs {
         result = 31 * result + (pdfOcr ? 1 : 0);
         return result;
     }
+
+    @Override
+    public String toString() {
+        return "Fs{" + "url='" + url + '\'' +
+                ", updateRate=" + updateRate +
+                ", includes=" + includes +
+                ", excludes=" + excludes +
+                ", jsonSupport=" + jsonSupport +
+                ", filenameAsId=" + filenameAsId +
+                ", addFilesize=" + addFilesize +
+                ", removeDeleted=" + removeDeleted +
+                ", addAsInnerObject=" + addAsInnerObject +
+                ", storeSource=" + storeSource +
+                ", indexContent=" + indexContent +
+                ", indexedChars=" + indexedChars +
+                ", attributesSupport=" + attributesSupport +
+                ", rawMetadata=" + rawMetadata +
+                ", xmlSupport=" + xmlSupport +
+                ", checksum='" + checksum + '\'' +
+                ", indexFolders=" + indexFolders +
+                ", langDetect=" + langDetect +
+                ", continueOnError=" + continueOnError +
+                ", pdfOcr=" + pdfOcr +
+                ", ocr=" + ocr +
+                '}';
+    }
 }

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettings.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettings.java
@@ -145,4 +145,16 @@ public class FsSettings {
         result = 31 * result + (elasticsearch != null ? elasticsearch.hashCode() : 0);
         return result;
     }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("FsSettings{");
+        sb.append("name='").append(name).append('\'');
+        sb.append(", fs=").append(fs);
+        sb.append(", server=").append(server);
+        sb.append(", elasticsearch=").append(elasticsearch);
+        sb.append(", rest=").append(rest);
+        sb.append('}');
+        return sb.toString();
+    }
 }

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettings.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettings.java
@@ -148,13 +148,11 @@ public class FsSettings {
 
     @Override
     public String toString() {
-        final StringBuffer sb = new StringBuffer("FsSettings{");
-        sb.append("name='").append(name).append('\'');
-        sb.append(", fs=").append(fs);
-        sb.append(", server=").append(server);
-        sb.append(", elasticsearch=").append(elasticsearch);
-        sb.append(", rest=").append(rest);
-        sb.append('}');
-        return sb.toString();
+        return "FsSettings{" + "name='" + name + '\'' +
+                ", fs=" + fs +
+                ", server=" + server +
+                ", elasticsearch=" + elasticsearch +
+                ", rest=" + rest +
+                '}';
     }
 }

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Server.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Server.java
@@ -169,9 +169,18 @@ public class Server {
         int result = hostname != null ? hostname.hashCode() : 0;
         result = 31 * result + port;
         result = 31 * result + (username != null ? username.hashCode() : 0);
-        result = 31 * result + (password != null ? password.hashCode() : 0);
         result = 31 * result + (protocol != null ? protocol.hashCode() : 0);
         result = 31 * result + (pemPath != null ? pemPath.hashCode() : 0);
         return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Server{" + "hostname='" + hostname + '\'' +
+                ", port=" + port +
+                ", username='" + username + '\'' +
+                ", protocol='" + protocol + '\'' +
+                ", pemPath='" + pemPath + '\'' +
+                '}';
     }
 }

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsParserTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsParserTest.java
@@ -231,6 +231,20 @@ public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
     }
 
     @Test
+    public void testParseSettingsElasticsearchCloudId() throws IOException {
+        String cloudId = "fscrawler:ZXVyb3BlLXdlc3QxLmdjcC5jbG91ZC5lcy5pbyQxZDFlYTk5Njg4Nzc0NWE2YTJiN2NiNzkzMTUzNDhhMyQyOTk1MDI3MzZmZGQ0OTI5OTE5M2UzNjdlOTk3ZmU3Nw==";
+        settingsTester(
+                FsSettings.builder(getCurrentTestName())
+                        .setElasticsearch(Elasticsearch.builder()
+                                .addNode(Elasticsearch.Node.builder()
+                                        .setCloudId(cloudId)
+                                        .build())
+                                .build())
+                        .build()
+        );
+    }
+
+    @Test
     public void testParseSettingsElasticsearchIndexSettings() throws IOException {
         settingsTester(
                 FsSettings.builder(getCurrentTestName())


### PR DESCRIPTION
As documented per https://www.elastic.co/guide/en/cloud/current/ec-cloud-id.html,
we can now support using a `Cloud ID`:

```json
{
 "name" : "test",
 "elasticsearch" : {
   "username" : "elastic",
   "password" : "changeme",
   "nodes" : [
     { "cloud_id" : "fscrawler:ZXVyb3BlLXdlc3QxLmdjcC5jbG91ZC5lcy5pbyQxZDFlYTk5Njg4Nzc0NWE2YTJiN2NiNzkzMTUzNDhhMyQyOTk1MDI3MzZmZGQ0OTI5OTE5M2UzNjdlOTk3ZmU3Nw==" }
   ]
 }
}
```

Note that you can also use `tests.cluster.cloud_id` to run integration tests against an Elasticsearch service provided by Elastic:

```sh
mvn verify \
    -Dtests.cluster.user=elastic \
    -Dtests.cluster.pass=changeme \
    -Dtests.cluster.cloud_id=fscrawler:ZXVyb3BlLXdlc3QxLmdjcC5jbG91ZC5lcy5pbyQxZDFlYTk5Njg4Nzc0NWE2YTJiN2NiNzkzMTUzNDhhMyQyOTk1MDI3MzZmZGQ0OTI5OTE5M2UzNjdlOTk3ZmU3Nw==
```

Closes #467.