### PR TITLE
Allow path partial matching

### DIFF
--- a/docs/source/admin/fs/elasticsearch.rst
+++ b/docs/source/admin/fs/elasticsearch.rst
@@ -314,6 +314,9 @@ The following example uses a ``french`` analyzer to index the
                       "type": "text",
                       "analyzer": "fscrawler_path",
                       "fielddata": true
+                    },
+                    "fulltext": {
+                      "type": "text"
                     }
                   }
                 },
@@ -327,6 +330,9 @@ The following example uses a ``french`` analyzer to index the
                       "type": "text",
                       "analyzer": "fscrawler_path",
                       "fielddata": true
+                    },
+                    "fulltext": {
+                      "type": "text"
                     }
                   }
                 }

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerTestSubDirsIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerTestSubDirsIT.java
@@ -22,6 +22,7 @@ package fr.pilato.elasticsearch.crawler.fs.test.integration;
 import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
@@ -64,6 +65,12 @@ public class FsCrawlerTestSubDirsIT extends AbstractFsCrawlerITCase {
                     .get(fr.pilato.elasticsearch.crawler.fs.beans.Path.FIELD_NAMES.VIRTUAL);
             assertThat(virtual, isOneOf("/subdir/roottxtfile_multi_feed.txt", "/roottxtfile.txt"));
         }
+
+        // Try to search within part of the full path, ie subdir
+        countTestHelper(new SearchRequest(getCrawlerName()).source(new SearchSourceBuilder()
+                .query(QueryBuilders.termQuery("path.virtual.fulltext", "subdir"))), 1L, null);
+        countTestHelper(new SearchRequest(getCrawlerName()).source(new SearchSourceBuilder()
+                .query(QueryBuilders.termQuery("path.real.fulltext", "subdir"))), 1L, null);
     }
 
     @Test

--- a/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/2/_settings.json
+++ b/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/2/_settings.json
@@ -164,6 +164,9 @@
                 "tree": {
                   "type": "string",
                   "analyzer": "fscrawler_path"
+                },
+                "fulltext": {
+                  "type": "string"
                 }
               }
             },
@@ -178,6 +181,9 @@
                 "tree": {
                   "type": "string",
                   "analyzer": "fscrawler_path"
+                },
+                "fulltext": {
+                  "type": "string"
                 }
               }
             }

--- a/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/5/_settings.json
+++ b/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/5/_settings.json
@@ -185,6 +185,9 @@
                   "type": "text",
                   "analyzer": "fscrawler_path",
                   "fielddata": true
+                },
+                "fulltext": {
+                  "type": "text"
                 }
               }
             },
@@ -198,6 +201,9 @@
                   "type": "text",
                   "analyzer": "fscrawler_path",
                   "fielddata": true
+                },
+                "fulltext": {
+                  "type": "text"
                 }
               }
             }

--- a/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/6/_settings.json
+++ b/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/6/_settings.json
@@ -185,6 +185,9 @@
                   "type": "text",
                   "analyzer": "fscrawler_path",
                   "fielddata": true
+                },
+                "fulltext": {
+                  "type": "text"
                 }
               }
             },
@@ -198,6 +201,9 @@
                   "type": "text",
                   "analyzer": "fscrawler_path",
                   "fielddata": true
+                },
+                "fulltext": {
+                  "type": "text"
                 }
               }
             }

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsMappingTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsMappingTest.java
@@ -228,6 +228,9 @@ public class FsMappingTest extends AbstractFSCrawlerMetadataTestCase {
                 "                \"tree\": {\n" +
                 "                  \"type\": \"string\",\n" +
                 "                  \"analyzer\": \"fscrawler_path\"\n" +
+                "                },\n" +
+                "                \"fulltext\": {\n" +
+                "                  \"type\": \"string\"\n" +
                 "                }\n" +
                 "              }\n" +
                 "            },\n" +
@@ -242,6 +245,9 @@ public class FsMappingTest extends AbstractFSCrawlerMetadataTestCase {
                 "                \"tree\": {\n" +
                 "                  \"type\": \"string\",\n" +
                 "                  \"analyzer\": \"fscrawler_path\"\n" +
+                "                },\n" +
+                "                \"fulltext\": {\n" +
+                "                  \"type\": \"string\"\n" +
                 "                }\n" +
                 "              }\n" +
                 "            }\n" +
@@ -515,6 +521,9 @@ public class FsMappingTest extends AbstractFSCrawlerMetadataTestCase {
                 "                  \"type\": \"text\",\n" +
                 "                  \"analyzer\": \"fscrawler_path\",\n" +
                 "                  \"fielddata\": true\n" +
+                "                },\n" +
+                "                \"fulltext\": {\n" +
+                "                  \"type\": \"text\"\n" +
                 "                }\n" +
                 "              }\n" +
                 "            },\n" +
@@ -528,6 +537,9 @@ public class FsMappingTest extends AbstractFSCrawlerMetadataTestCase {
                 "                  \"type\": \"text\",\n" +
                 "                  \"analyzer\": \"fscrawler_path\",\n" +
                 "                  \"fielddata\": true\n" +
+                "                },\n" +
+                "                \"fulltext\": {\n" +
+                "                  \"type\": \"text\"\n" +
                 "                }\n" +
                 "              }\n" +
                 "            }\n" +
@@ -786,6 +798,9 @@ public class FsMappingTest extends AbstractFSCrawlerMetadataTestCase {
                 "                  \"type\": \"text\",\n" +
                 "                  \"analyzer\": \"fscrawler_path\",\n" +
                 "                  \"fielddata\": true\n" +
+                "                },\n" +
+                "                \"fulltext\": {\n" +
+                "                  \"type\": \"text\"\n" +
                 "                }\n" +
                 "              }\n" +
                 "            },\n" +
@@ -799,6 +814,9 @@ public class FsMappingTest extends AbstractFSCrawlerMetadataTestCase {
                 "                  \"type\": \"text\",\n" +
                 "                  \"analyzer\": \"fscrawler_path\",\n" +
                 "                  \"fielddata\": true\n" +
+                "                },\n" +
+                "                \"fulltext\": {\n" +
+                "                  \"type\": \"text\"\n" +
                 "                }\n" +
                 "              }\n" +
                 "            }\n" +


### PR DESCRIPTION
This change adds a subfield named `fulltext`, generated at index time
which will allow searching for parts of the path.

This adds the following:

* `path.real.fulltext`
* `path.virtual.fulltext`

Closes #528.