### PR TITLE
Ignore files bigger than X

### DIFF
--- a/docs/source/admin/fs/local-fs.rst
+++ b/docs/source/admin/fs/local-fs.rst
@@ -46,6 +46,8 @@ Here is a list of Local FS settings (under ``fs.`` prefix)`:
 +----------------------------+-----------------------+---------------------------------+
 | ``fs.indexed_chars``       | ``100000.0``          | `Extracted characters`_         |
 +----------------------------+-----------------------+---------------------------------+
+| ``fs.ignore_above``        | ``null``              | `Ignore above`_                 |
++----------------------------+-----------------------+---------------------------------+
 | ``fs.checksum``            | ``null``              | `File Checksum`_                |
 +----------------------------+-----------------------+---------------------------------+
 
@@ -691,9 +693,30 @@ increase ``indexed_chars`` to more than ``"100%"``. For example,
 If you want to extract the full content, define ``indexed_chars`` to
 ``"-1"``.
 
-**Note**: Tika requires to allocate in memory a data structure to
-extract text. Setting ``indexed_chars`` to a high number will require
-more memory!
+.. note::
+
+    Tika requires to allocate in memory a data structure to
+    extract text. Setting ``indexed_chars`` to a high number will require
+    more memory!
+
+Ignore Above
+^^^^^^^^^^^^
+
+.. versionadded:: 2.5
+
+By default FSCrawler will send to Tika every single file, whatever its size.
+But some files on your file system might be a way too big to be parsed.
+
+Set ``ignore_above`` to the desired value of the limit.
+
+.. code:: json
+
+   {
+     "name": "test",
+     "fs": {
+       "ignore_above": "5mb"
+     }
+   }
 
 File checksum
 ^^^^^^^^^^^^^

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -253,5 +253,5 @@ The default mapping changed for FSCrawler for ``meta.raw.*`` fields.
 Might be better to reindex your data.
 
 - For new indices, FSCrawler now uses ``_doc`` as the default type name for clusters
-running elasticsearch 6.x or superior.
+  running elasticsearch 6.x or superior.
 

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/FsCrawlerUtil.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/FsCrawlerUtil.java
@@ -525,4 +525,24 @@ public class FsCrawlerUtil {
             }
         }
     }
+
+    /**
+     * Compare if a file size is strictly under a given limit
+     * @param limit Limit. If null, we consider that there is no limit and we return true.
+     * @param fileSizeAsBytes File size
+     * @return true if under the limit. false otherwise.
+     */
+    public static boolean isFileSizeUnderLimit(ByteSizeValue limit, long fileSizeAsBytes) {
+        boolean result = true;
+        if (limit != null) {
+            // We check the file size to avoid indexing too big files
+            ByteSizeValue fileSize = new ByteSizeValue(fileSizeAsBytes);
+            int compare = fileSize.compareTo(limit);
+            result = compare <= 0;
+            logger.debug("Comparing file size [{}] with current limit [{}] -> {}", fileSize, limit,
+                    result ? "under limit" : "above limit");
+        }
+
+        return result;
+    }
 }

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/FsCrawlerUtilTest.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/FsCrawlerUtilTest.java
@@ -32,9 +32,11 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Set;
 
+import static com.carrotsearch.randomizedtesting.RandomizedTest.randomIntBetween;
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.getFilePermissions;
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.getGroupName;
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.getOwnerName;
+import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.isFileSizeUnderLimit;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
@@ -72,5 +74,13 @@ public class FsCrawlerUtilTest extends AbstractFSCrawlerTestCase {
         assumeFalse("This test can not run on Windows.", OsValidator.WINDOWS);
         int permissions = getFilePermissions(file);
         assertThat(permissions, is(700));
+    }
+
+    @Test
+    public void testIsFileSizeUnderLimit() {
+        assertThat(isFileSizeUnderLimit(ByteSizeValue.parseBytesSizeValue("1mb"), 1), is(true));
+        assertThat(isFileSizeUnderLimit(ByteSizeValue.parseBytesSizeValue("1mb"), 1048576), is(true));
+        assertThat(isFileSizeUnderLimit(ByteSizeValue.parseBytesSizeValue("1mb"),
+                new ByteSizeValue(randomIntBetween(2, 100), ByteSizeUnit.MB).getBytes()), is(false));
     }
 }

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Fs.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Fs.java
@@ -19,6 +19,7 @@
 
 package fr.pilato.elasticsearch.crawler.fs.settings;
 
+import fr.pilato.elasticsearch.crawler.fs.framework.ByteSizeValue;
 import fr.pilato.elasticsearch.crawler.fs.framework.Percentage;
 import fr.pilato.elasticsearch.crawler.fs.framework.TimeValue;
 
@@ -49,6 +50,7 @@ public class Fs {
     private boolean continueOnError = false;
     private boolean pdfOcr = true;
     private Ocr ocr = new Ocr();
+    private ByteSizeValue ignoreAbove = null;
 
     public static Builder builder() {
         return new Builder();
@@ -80,6 +82,7 @@ public class Fs {
         private boolean continueOnError = false;
         private boolean pdfOcr = true;
         private Ocr ocr = new Ocr();
+        private ByteSizeValue ignoreAbove = null;
 
         public Builder setUrl(String url) {
             this.url = url;
@@ -212,10 +215,15 @@ public class Fs {
             return this;
         }
 
+        public Builder setIgnoreAbove(ByteSizeValue ignoreAbove) {
+            this.ignoreAbove = ignoreAbove;
+            return this;
+        }
+
         public Fs build() {
             return new Fs(url, updateRate, includes, excludes, jsonSupport, filenameAsId, addFilesize,
                     removeDeleted, addAsInnerObject, storeSource, indexedChars, indexContent, attributesSupport, rawMetadata,
-                    checksum, xmlSupport, indexFolders, langDetect, continueOnError, pdfOcr, ocr);
+                    checksum, xmlSupport, indexFolders, langDetect, continueOnError, pdfOcr, ocr, ignoreAbove);
         }
     }
 
@@ -226,7 +234,7 @@ public class Fs {
     private Fs(String url, TimeValue updateRate, List<String> includes, List<String> excludes, boolean jsonSupport,
                boolean filenameAsId, boolean addFilesize, boolean removeDeleted, boolean addAsInnerObject, boolean storeSource,
                Percentage indexedChars, boolean indexContent, boolean attributesSupport, boolean rawMetadata, String checksum, boolean xmlSupport,
-               boolean indexFolders, boolean langDetect, boolean continueOnError, boolean pdfOcr, Ocr ocr) {
+               boolean indexFolders, boolean langDetect, boolean continueOnError, boolean pdfOcr, Ocr ocr, ByteSizeValue ignoreAbove) {
         this.url = url;
         this.updateRate = updateRate;
         this.includes = includes;
@@ -248,6 +256,7 @@ public class Fs {
         this.continueOnError = continueOnError;
         this.pdfOcr = pdfOcr;
         this.ocr = ocr;
+        this.ignoreAbove = ignoreAbove;
     }
 
     public String getUrl() {
@@ -418,6 +427,14 @@ public class Fs {
         this.ocr = ocr;
     }
 
+    public ByteSizeValue getIgnoreAbove() {
+        return ignoreAbove;
+    }
+
+    public void setIgnoreAbove(ByteSizeValue ignoreAbove) {
+        this.ignoreAbove = ignoreAbove;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -439,6 +456,7 @@ public class Fs {
         if (langDetect != fs.langDetect) return false;
         if (continueOnError != fs.continueOnError) return false;
         if (pdfOcr != fs.pdfOcr) return false;
+        if (ignoreAbove != fs.ignoreAbove) return false;
         if (url != null ? !url.equals(fs.url) : fs.url != null) return false;
         if (updateRate != null ? !updateRate.equals(fs.updateRate) : fs.updateRate != null) return false;
         if (includes != null ? !includes.equals(fs.includes) : fs.includes != null) return false;
@@ -496,6 +514,7 @@ public class Fs {
                 ", continueOnError=" + continueOnError +
                 ", pdfOcr=" + pdfOcr +
                 ", ocr=" + ocr +
+                ", ignoreAbove=" + ignoreAbove +
                 '}';
     }
 }


### PR DESCRIPTION
By default FSCrawler will send to Tika every single file, whatever its size.
But some files on your file system might be a way too big to be parsed.

Set `fs.ignore_above` to the desired value of the limit.

```json
{
 "name": "test",
 "fs": {
   "ignore_above": "5mb"
 }
}
```

Closes #397.