### PR TITLE
Support XML reoccurring structures

### DIFF
--- a/test-documents/src/main/resources/documents/issue-592.xml
+++ b/test-documents/src/main/resources/documents/issue-592.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<dataset>
+    <object>
+        <id>1</id>
+        <name>foo</name>
+    </object>
+    <object>
+        <id>2</id>
+        <name>bar</name>
+    </object>
+</dataset>

--- a/tika/src/test/java/fr/pilato/elasticsearch/crawler/fs/tika/XmlDocParserTest.java
+++ b/tika/src/test/java/fr/pilato/elasticsearch/crawler/fs/tika/XmlDocParserTest.java
@@ -24,12 +24,23 @@ import org.junit.Test;
 import java.io.IOException;
 import java.io.InputStream;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class XmlDocParserTest extends DocParserTestCase {
 
     @Test
     public void testXml() throws IOException {
         String doc = extractFromFile("issue-163.xml");
-        logger.info("-> {}", doc);
+        assertThat(doc, is("{\"version\":\"1.0\",\"subscription-update\":{\"subscriptionid\":\"0\",\"requestid\":\"0\"," +
+                "\"last_push\":\"2016-06-03 06:21:34\",\"current_push\":\"2016-06-03 06:21:37\",\"exec\":\"0.002\"," +
+                "\"lineup\":{\"id\":\"0\",\"del\":\"no\"}}}"));
+    }
+
+    @Test
+    public void testXmlNestedObjects() throws IOException {
+        String doc = extractFromFile("issue-592.xml");
+        assertThat(doc, is("{\"object\":[{\"id\":\"1\",\"name\":\"foo\"},{\"id\":\"2\",\"name\":\"bar\"}]}"));
     }
 
     private String extractFromFile(String filename) throws IOException {


### PR DESCRIPTION
When you have an xml structure like:

```xml
<dataset>
  <object>
    <id>1</id>
    <name>foo</name>
  </object>
  <object>
    <id>2</id>
    <name>bar</name>
  </object>
</dataset>
```

It should create a document like:

```json
{
    "object": [{
        "id": 1,
        "name": "foo"
      },
      {
        "id": 2,
        "name": "bar"
      }
    ]
}
```

Before this patch, the created document was:

```json
{
  "object" : {
    "id" : 2,
    "name" : "bar"
  }
}
```

So first items were totally overwritten.

Closes #592.