### PR TITLE
Make default root dir Windows compatible

### DIFF
--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Fs.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Fs.java
@@ -23,6 +23,7 @@ import fr.pilato.elasticsearch.crawler.fs.framework.ByteSizeValue;
 import fr.pilato.elasticsearch.crawler.fs.framework.Percentage;
 import fr.pilato.elasticsearch.crawler.fs.framework.TimeValue;
 
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -58,7 +59,7 @@ public class Fs {
         return new Builder();
     }
 
-    public static final String DEFAULT_DIR = "/tmp/es";
+    public static final String DEFAULT_DIR = Paths.get("/tmp/es").toString();
     public static final List<String> DEFAULT_EXCLUDED = Collections.singletonList("*/~*");
     public static final Fs DEFAULT = Fs.builder().setUrl(DEFAULT_DIR).setExcludes(DEFAULT_EXCLUDED).build();
 


### PR DESCRIPTION
By default, we are generating a `url` for the configuration as `/tmp/es`.
When we run the first time the crawler, FSCrawler tries to index
this root dir in elasticsearch as the root dir.

When doing so in `FsParser.indexDirectory()`, we are comparing `/tmp/es` with `File.separator`.
On Windows, the `File.separator` is `\` which leads to an error like:

```
22:34:17,188 WARN  [f.p.e.c.f.FsParser] Full stacktrace
java.lang.StringIndexOutOfBoundsException: String index out of range: -1
	at java.lang.String.substring(Unknown Source) ~[?:1.8.0_181]
	at fr.pilato.elasticsearch.crawler.fs.FsParser.indexDirectory(FsParser.java:550) ~[fscrawler-core-2.5.jar:?]
	at fr.pilato.elasticsearch.crawler.fs.FsParser.run(FsParser.java:160) [fscrawler-core-2.5.jar:?]
	at java.lang.Thread.run(Unknown Source) [?:1.8.0_181]
```

This commit changes the default generated configuration to either `/tmp/es` on non Windows systems or to `c:\tmp\es` on Windows systems.

Closes #533.