### PR TITLE
Dump stack when not able to close FSCrawler

### DIFF
--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsCrawlerImpl.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsCrawlerImpl.java
@@ -193,6 +193,9 @@ public class FsCrawlerImpl {
             while (fsCrawlerThread.isAlive()) {
                 // We check that the crawler has been closed effectively
                 logger.debug("FS crawler thread is still running");
+                if (logger.isDebugEnabled()) {
+                    Thread.dumpStack();
+                }
                 Thread.sleep(500);
             }
             logger.debug("FS crawler thread is now stopped");


### PR DESCRIPTION
This is dumping the current Stack when closing FSCrawler takes too long.
Note that this dump is only generated when running with `--debug` or `--trace` level.