### PR TITLE
Ignore dirs when `.fscrawlerignore` file is detected

### DIFF
--- a/docs/source/admin/fs/local-fs.rst
+++ b/docs/source/admin/fs/local-fs.rst
@@ -176,6 +176,10 @@ If you define the following ``fs.excludes`` property in your
 Then all files but the ones in ``/folderB/subfolderA``, ``/folderB/subfolderB`` and
 ``/folderB/subfolderC`` will be indexed.
 
+.. versionadded:: 2.6
+
+If a folder contains a file named ``.fscrawlerignore``, this folder and its subfolders will be entirely skipped.
+
 Filter content
 ^^^^^^^^^^^^^^
 

--- a/docs/source/user/getting_started.rst
+++ b/docs/source/user/getting_started.rst
@@ -79,3 +79,10 @@ something! ;-)
 
 See :ref:`search-examples` for more examples.
 
+Ignoring folders
+^^^^^^^^^^^^^^^^
+
+If you would like to ignore some folders to be scanned, just add a ``.fscrawlerignore`` file in it.
+The folder content and all sub folders will be ignored.
+
+For more information, read :ref:`includes_excludes`.

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerTestIncludesIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerTestIncludesIT.java
@@ -58,4 +58,12 @@ public class FsCrawlerTestIncludesIT extends AbstractFsCrawlerITCase {
         // We expect to have one file
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 2L, null);
     }
+
+    @Test
+    public void test_fscrawlerignore() throws Exception {
+        startCrawler();
+
+        // We expect to have 4 files as subdir1 should be ignored
+        countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 4L, null);
+    }
 }

--- a/integration-tests/it-common/src/main/resources-binary/samples/test_fscrawlerignore/roottxtfile.txt
+++ b/integration-tests/it-common/src/main/resources-binary/samples/test_fscrawlerignore/roottxtfile.txt
@@ -1,0 +1,1 @@
+This file contains some words.

--- a/integration-tests/it-common/src/main/resources-binary/samples/test_fscrawlerignore/subdir1/roottxtfile_multi_feed.txt
+++ b/integration-tests/it-common/src/main/resources-binary/samples/test_fscrawlerignore/subdir1/roottxtfile_multi_feed.txt
@@ -1,0 +1,1 @@
+This file contains some words. This testcase is used in multi feed crawlers !

--- a/integration-tests/it-common/src/main/resources-binary/samples/test_fscrawlerignore/subdir1/subdir11/roottxtfile.txt
+++ b/integration-tests/it-common/src/main/resources-binary/samples/test_fscrawlerignore/subdir1/subdir11/roottxtfile.txt
@@ -1,0 +1,1 @@
+This file contains some words.

--- a/integration-tests/it-common/src/main/resources-binary/samples/test_fscrawlerignore/subdir1/subdir12/roottxtfile.txt
+++ b/integration-tests/it-common/src/main/resources-binary/samples/test_fscrawlerignore/subdir1/subdir12/roottxtfile.txt
@@ -1,0 +1,1 @@
+This file contains some words.

--- a/integration-tests/it-common/src/main/resources-binary/samples/test_fscrawlerignore/subdir2/roottxtfile_multi_feed.txt
+++ b/integration-tests/it-common/src/main/resources-binary/samples/test_fscrawlerignore/subdir2/roottxtfile_multi_feed.txt
@@ -1,0 +1,1 @@
+This file contains some words. This testcase is used in multi feed crawlers !

--- a/integration-tests/it-common/src/main/resources-binary/samples/test_fscrawlerignore/subdir2/subdir21/roottxtfile.txt
+++ b/integration-tests/it-common/src/main/resources-binary/samples/test_fscrawlerignore/subdir2/subdir21/roottxtfile.txt
@@ -1,0 +1,1 @@
+This file contains some words.

--- a/integration-tests/it-common/src/main/resources-binary/samples/test_fscrawlerignore/subdir2/subdir22/roottxtfile.txt
+++ b/integration-tests/it-common/src/main/resources-binary/samples/test_fscrawlerignore/subdir2/subdir22/roottxtfile.txt
@@ -1,0 +1,1 @@
+This file contains some words.


### PR DESCRIPTION
This commit provides a stop file named `.fscrawlerignore` to exclude folder from crawling.

Closes #630.