### PR TITLE
Revisit Elasticsearch.Node and Rest settings

### DIFF
--- a/docs/source/admin/fs/elasticsearch.rst
+++ b/docs/source/admin/fs/elasticsearch.rst
@@ -467,9 +467,8 @@ Node settings
 ^^^^^^^^^^^^^
 
 FSCrawler is using elasticsearch REST layer to send data to your
-running cluster. By default, it connects to ``127.0.0.1`` on port
-``9200`` which are the default settings when running a local node on
-your machine.
+running cluster. By default, it connects to ``http://127.0.0.1:9200``
+which is the default when running a local node on your machine.
 
 Of course, in production, you would probably change this and connect to
 a production cluster:
@@ -480,7 +479,7 @@ a production cluster:
      "name" : "test",
      "elasticsearch" : {
        "nodes" : [
-         { "host" : "mynode1.mycompany.com", "port" : 9200, "scheme" : "HTTP" }
+         { "url" : "http://mynode1.mycompany.com:9200" }
        ]
      }
    }
@@ -514,9 +513,9 @@ You can define multiple nodes:
      "name" : "test",
      "elasticsearch" : {
        "nodes" : [
-         { "host" : "mynode1.mycompany.com", "port" : 9200, "scheme" : "HTTP" },
-         { "host" : "mynode2.mycompany.com", "port" : 9200, "scheme" : "HTTP" },
-         { "host" : "mynode3.mycompany.com", "port" : 9200, "scheme" : "HTTP" }
+         { "url" : "http://mynode1.mycompany.com:9200" },
+         { "url" : "http://mynode2.mycompany.com:9200" },
+         { "url" : "http://mynode3.mycompany.com:9200" }
        ]
      }
    }
@@ -530,7 +529,7 @@ You can define multiple nodes:
          "name" : "test",
          "elasticsearch" : {
            "nodes" : [
-             { "host" : "CLUSTERID.eu-west-1.aws.found.io", "port" : 9243, "scheme" : "HTTPS" }
+             { "url" : "https://CLUSTERID.eu-west-1.aws.found.io:9243" }
            ]
          }
        }
@@ -601,7 +600,7 @@ It will prompt you for the password. Enter the certificate password like ``chang
       "name" : "test",
       "elasticsearch" : {
         "nodes" : [
-          {"host" : "localhost", "port" : 9243, "scheme" : "HTTPS" }
+          { "url" : "https://localhost:9243" }
         ]
       }
     }

--- a/docs/source/admin/fs/index.rst
+++ b/docs/source/admin/fs/index.rst
@@ -46,10 +46,8 @@ The job file must comply to the following ``json`` specifications:
          // With Cloud ID
          "cloud_id" : "CLOUD_ID"
        }, {
-         // With scheme, host and port
-         "host" : "127.0.0.1",
-         "port" : 9200,
-         "scheme" : "HTTP"
+         // With URL
+         "url" : "http://127.0.0.1:9200"
        } ],
        "index" : "docs",
        "bulk_size" : 1000,

--- a/docs/source/admin/fs/rest.rst
+++ b/docs/source/admin/fs/rest.rst
@@ -55,10 +55,7 @@ It will give you a response similar to:
          "username" : "elastic"
        },
        "rest" : {
-         "scheme" : "HTTP",
-         "host" : "127.0.0.1",
-         "port" : 8080,
-         "endpoint" : "fscrawler"
+         "url" : "http://127.0.0.1:8080/fscrawler"
        }
      }
    }
@@ -258,18 +255,11 @@ REST settings
 
 Here is a list of REST service settings (under ``rest.`` prefix)`:
 
-+-----------------------+-----------------------+-----------------------+
-| Name                  | Default value         | Documentation         |
-+=======================+=======================+=======================+
-| ``rest.scheme``       | ``http``              | Scheme. Can be either |
-|                       |                       | ``http`` or ``https`` |
-+-----------------------+-----------------------+-----------------------+
-| ``rest.host``         | ``127.0.0.1``         | Bound host            |
-+-----------------------+-----------------------+-----------------------+
-| ``rest.port``         | ``8080``              | Bound port            |
-+-----------------------+-----------------------+-----------------------+
-| ``rest.endpoint``     | ``fscrawler``         | Endpoint              |
-+-----------------------+-----------------------+-----------------------+
++--------------+-------------------------------------+-----------------------+
+| Name         | Default value                       | Documentation         |
++==============+=====================================+=======================+
+| ``rest.url`` | ``http://127.0.0.1:8080/fscrawler`` | Rest Service URL      |
++--------------+-------------------------------------+-----------------------+
 
 .. tip::
 
@@ -287,12 +277,9 @@ You can change it using ``rest`` settings:
    {
      "name" : "test",
      "rest" : {
-       "scheme" : "HTTP",
-       "host" : "192.168.0.1",
-       "port" : 8180,
-       "endpoint" : "my_fscrawler"
+       "url" : "http://192.168.0.1:8180/my_fscrawler"
      }
    }
 
 It also means that if you are running more than one instance of FS
-crawler locally, you can (must) change the ``port``.
+crawler locally, you can (must) change the port as it will conflict.

--- a/docs/source/admin/fs/rest.rst
+++ b/docs/source/admin/fs/rest.rst
@@ -45,9 +45,7 @@ It will give you a response similar to:
        },
        "elasticsearch" : {
          "nodes" : [ {
-           "host" : "127.0.0.1",
-           "port" : 9200,
-           "scheme" : "HTTP"
+           "url" : "http://127.0.0.1:9200"
          } ],
          "index" : "fscrawler-rest-tests_doc",
          "index_folder" : "fscrawler-rest-tests_folder",

--- a/docs/source/dev/build.rst
+++ b/docs/source/dev/build.rst
@@ -68,26 +68,23 @@ the tests start.
 
 .. hint::
 
-    If you are using a secured instance, use ``tests.cluster.user``, ``tests.cluster.pass`` and ``tests.cluster.scheme``::
+    If you are using a secured instance, use ``tests.cluster.user``, ``tests.cluster.pass`` and ``tests.cluster.url``::
 
         mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it-v6 \
             -Dtests.cluster.user=elastic \
             -Dtests.cluster.pass=changeme \
-            -Dtests.cluster.scheme=HTTPS \
+            -Dtests.cluster.url=https://127.0.0.1:9200 \
 
 .. hint::
 
     To run tests against another instance (ie. running on
     `Elasticsearch service by Elastic <https://www.elastic.co/cloud/elasticsearch-service>`_,
-    you can also use ``tests.cluster.host`` and ``tests.cluster.port`` to set where elasticsearch
-    is running::
+    you can also use ``tests.cluster.url`` to set where elasticsearch is running::
 
         mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it-v6 \
             -Dtests.cluster.user=elastic \
             -Dtests.cluster.pass=changeme \
-            -Dtests.cluster.scheme=HTTPS \
-            -Dtests.cluster.host=XYZ.es.io:9243 \
-            -Dtests.cluster.port=9243
+            -Dtests.cluster.url=https://XYZ.es.io:9243
 
     Or even easier, you can use the ``Cloud ID`` available on you Cloud Console::
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -298,6 +298,10 @@ Upgrade to 2.5
 Upgrade to 2.6
 ~~~~~~~~~~~~~~
 
--   FSCrawler comes now with multiple distributions, depending on the elasticsearch
-    cluster you're targeting to run.
+- FSCrawler comes now with multiple distributions, depending on the elasticsearch
+  cluster you're targeting to run.
+
+- ``elasticsearch.nodes`` settings using ``host``, ``port`` or ``scheme`` have been replaced by
+  an easier notation using ``url`` setting like ``http://127.0.0.1:9200``. You will need to modify
+  your existing settings and use the new notation if warned.
 

--- a/elasticsearch-client/elasticsearch-client-v5/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v5/ElasticsearchClientV5.java
+++ b/elasticsearch-client/elasticsearch-client-v5/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v5/ElasticsearchClientV5.java
@@ -97,7 +97,6 @@ import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.INDEX_S
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.INDEX_SETTINGS_FOLDER_FILE;
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.isNullOrEmpty;
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.readJsonFile;
-import static fr.pilato.elasticsearch.crawler.fs.settings.Elasticsearch.Node;
 
 /**
  * Elasticsearch Client for Clusters running v5.
@@ -415,12 +414,7 @@ public class ElasticsearchClientV5 implements ElasticsearchClient {
                 // We have a cloud id which simplifies all
                 hosts.add(HttpHost.create(decodeCloudId(node.getCloudId())));
             } else {
-                Node.Scheme scheme = node.getScheme();
-                if (scheme == null) {
-                    // Default to HTTP. In case we are reading an old configuration
-                    scheme = Node.Scheme.HTTP;
-                }
-                hosts.add(new HttpHost(node.getHost(), node.getPort(), scheme.toLowerCase()));
+                hosts.add(HttpHost.create(node.getUrl()));
             }
         });
 

--- a/elasticsearch-client/elasticsearch-client-v6/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v6/ElasticsearchClientV6.java
+++ b/elasticsearch-client/elasticsearch-client-v6/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v6/ElasticsearchClientV6.java
@@ -99,7 +99,6 @@ import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.INDEX_S
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.INDEX_SETTINGS_FOLDER_FILE;
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.isNullOrEmpty;
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.readJsonFile;
-import static fr.pilato.elasticsearch.crawler.fs.settings.Elasticsearch.Node;
 import static org.elasticsearch.action.support.IndicesOptions.LENIENT_EXPAND_OPEN;
 
 /**
@@ -389,12 +388,7 @@ public class ElasticsearchClientV6 implements ElasticsearchClient {
                 // We have a cloud id which simplifies all
                 hosts.add(HttpHost.create(decodeCloudId(node.getCloudId())));
             } else {
-                Node.Scheme scheme = node.getScheme();
-                if (scheme == null) {
-                    // Default to HTTP. In case we are reading an old configuration
-                    scheme = Node.Scheme.HTTP;
-                }
-                hosts.add(new HttpHost(node.getHost(), node.getPort(), scheme.toLowerCase()));
+                hosts.add(HttpHost.create(node.getUrl()));
             }
         });
 

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/FsCrawlerUtil.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/FsCrawlerUtil.java
@@ -579,10 +579,6 @@ public class FsCrawlerUtil {
         }
     }
 
-    public static String buildUrl(String scheme, String host, int port) {
-        return scheme + "://" + host + ":" + port;
-    }
-
     public static boolean isNullOrEmpty(String string) {
         return string == null || string.isEmpty();
     }

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
@@ -33,7 +33,6 @@ import fr.pilato.elasticsearch.crawler.fs.framework.TimeValue;
 import fr.pilato.elasticsearch.crawler.fs.rest.RestJsonProvider;
 import fr.pilato.elasticsearch.crawler.fs.settings.Elasticsearch;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
-import fr.pilato.elasticsearch.crawler.fs.settings.Rest;
 import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
 import fr.pilato.elasticsearch.crawler.fs.test.framework.TestContainerThreadFilter;
 import org.apache.logging.log4j.Level;
@@ -273,7 +272,7 @@ public abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
                 .register(JacksonFeature.class)
                 .build();
 
-        target = client.target(Rest.builder().setPort(testRestPort).build().url());
+        target = client.target("http://127.0.0.1:" + testRestPort + "/fscrawler");
     }
 
     @AfterClass

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
@@ -36,7 +36,6 @@ import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
 import fr.pilato.elasticsearch.crawler.fs.settings.Rest;
 import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
 import fr.pilato.elasticsearch.crawler.fs.test.framework.TestContainerThreadFilter;
-import org.apache.http.HttpHost;
 import org.apache.logging.log4j.Level;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
@@ -250,10 +249,8 @@ public abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
 
         staticLogger.info("Starting a client against [{}]", testClusterUrl);
         // We build the elasticsearch High Level Client based on the parameters
-        HttpHost host = HttpHost.create(testClusterUrl);
         elasticsearchWithSecurity = Elasticsearch.builder()
-                .addNode(Elasticsearch.Node.builder()
-                        .setHost(host.getHostName()).setPort(host.getPort()).setScheme(Elasticsearch.Node.Scheme.parse(host.getSchemeName())).build())
+                .addNode(new Elasticsearch.Node(testClusterUrl))
                 .setUsername(testClusterUser)
                 .setPassword(testClusterPass)
                 .build();
@@ -317,9 +314,8 @@ public abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
 
     static Elasticsearch generateElasticsearchConfig(String indexName, String indexFolderName, int bulkSize,
                                                      TimeValue timeValue, ByteSizeValue byteSize) {
-        HttpHost host = HttpHost.create(testClusterUrl);
         Elasticsearch.Builder builder = Elasticsearch.builder()
-                .addNode(Elasticsearch.Node.builder().setHost(host.getHostName()).setPort(host.getPort()).setScheme(Elasticsearch.Node.Scheme.parse(host.getSchemeName())).build())
+                .addNode(new Elasticsearch.Node(testClusterUrl))
                 .setBulkSize(bulkSize);
 
         if (indexName != null) {

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractRestITCase.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractRestITCase.java
@@ -37,7 +37,7 @@ public abstract class AbstractRestITCase extends AbstractITCase {
     @Before
     public void startRestServer() throws Exception {
         FsSettings fsSettings = FsSettings.builder(getCrawlerName())
-                .setRest(Rest.builder().setPort(testRestPort).build())
+                .setRest(new Rest("http://127.0.0.1:" + testRestPort + "/fscrawler"))
                 .setElasticsearch(elasticsearchWithSecurity)
                 .build();
         fsSettings.getElasticsearch().setIndex(getCrawlerName());

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerTestRestOnlyIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerTestRestOnlyIT.java
@@ -54,7 +54,7 @@ public class FsCrawlerTestRestOnlyIT extends AbstractFsCrawlerITCase {
                     .setElasticsearch(endCrawlerDefinition(getCrawlerName()))
                     .setFs(startCrawlerDefinition().build())
                     .setServer(null)
-                    .setRest(Rest.builder().setPort(testRestPort+1).build()).build();
+                    .setRest(new Rest("http://127.0.0.1:" + (testRestPort+1) + "/fscrawler")).build();
             crawler = new FsCrawlerImpl(
                     metadataDir,
                     fsSettings,
@@ -69,7 +69,7 @@ public class FsCrawlerTestRestOnlyIT extends AbstractFsCrawlerITCase {
                 throw new RuntimeException(from + " doesn't seem to exist. Check your JUnit tests.");
             }
 
-            WebTarget target = client.target(Rest.builder().setPort(testRestPort + 1).build().url());
+            WebTarget target = client.target("http://127.0.0.1:" + (testRestPort+1) + "/fscrawler");
             Files.walk(from)
                     .filter(path -> Files.isRegularFile(path))
                     .forEach(path -> {

--- a/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/RestServer.java
+++ b/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/RestServer.java
@@ -57,8 +57,8 @@ public class RestServer {
 
             // create and start a new instance of grizzly http server
             // exposing the Jersey application at BASE_URI
-            httpServer = GrizzlyHttpServerFactory.createHttpServer(URI.create(settings.getRest().url()), rc);
-            logger.info("FS crawler Rest service started on [{}]", settings.getRest().url());
+            httpServer = GrizzlyHttpServerFactory.createHttpServer(URI.create(settings.getRest().getUrl()), rc);
+            logger.info("FS crawler Rest service started on [{}]", settings.getRest().getUrl());
         }
     }
 

--- a/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/UploadApi.java
+++ b/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/UploadApi.java
@@ -48,7 +48,6 @@ import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
 
 import static fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchClientUtil.decodeCloudId;
-import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.buildUrl;
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.localDateTimeToDate;
 
 @Path("/_upload")
@@ -127,7 +126,7 @@ public class UploadApi extends RestApi {
             if (node.getCloudId() != null) {
                 nodeUrl = decodeCloudId(node.getCloudId());
             } else {
-                nodeUrl = node.getScheme().toLowerCase() + "://" + node.getHost() + ":" + node.getPort();
+                nodeUrl = node.getUrl();
             }
             url = nodeUrl + "/" +
                     settings.getElasticsearch().getIndex() + "/" +

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Elasticsearch.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Elasticsearch.java
@@ -112,7 +112,7 @@ public class Elasticsearch {
         @Deprecated
         private Integer port;
         @Deprecated
-        private Scheme scheme;
+        private Scheme scheme = Scheme.HTTP;
 
         public void setHost(String host) {
             this.host = host;
@@ -136,7 +136,7 @@ public class Elasticsearch {
 
         public String getUrl() {
             // If we are using deprecated settings, let's warn the user to move to url param
-            if (host != null || port != null || scheme != null) {
+            if (host != null || port != null) {
                 String tmpUrl = scheme.toLowerCase() + "://" + host + ":" + port;
                 logger.warn("elasticsearch.nodes.[scheme, host, port] has been deprecated and will be removed in a coming version. " +
                         "Use elasticsearch.nodes: [ { \"url\": \"{}\" } ] instead", tmpUrl);

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Elasticsearch.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Elasticsearch.java
@@ -85,7 +85,6 @@ public class Elasticsearch {
         private Node(String host, int port, Scheme scheme) {
             this.host = host;
             this.port = port;
-            this.active = false;
             this.scheme = scheme;
         }
 
@@ -98,7 +97,6 @@ public class Elasticsearch {
         private String host;
         @Deprecated
         private Integer port;
-        private boolean active;
         @Deprecated
         private Scheme scheme;
 
@@ -116,14 +114,6 @@ public class Elasticsearch {
 
         public void setPort(Integer port) {
             this.port = port;
-        }
-
-        public boolean active() {
-            return active;
-        }
-
-        public void active(boolean active) {
-            this.active = active;
         }
 
         public Scheme getScheme() {
@@ -191,8 +181,7 @@ public class Elasticsearch {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             Node node = (Node) o;
-            return active == node.active &&
-                    Objects.equals(cloudId, node.cloudId) &&
+            return Objects.equals(cloudId, node.cloudId) &&
                     Objects.equals(host, node.host) &&
                     Objects.equals(port, node.port) &&
                     scheme == node.scheme;
@@ -200,7 +189,7 @@ public class Elasticsearch {
 
         @Override
         public int hashCode() {
-            return Objects.hash(cloudId, host, port, active, scheme);
+            return Objects.hash(cloudId, host, port, scheme);
         }
 
         @Override
@@ -208,7 +197,6 @@ public class Elasticsearch {
             return "Node{" + "cloudId='" + cloudId + '\'' +
                     ", host='" + host + '\'' +
                     ", port=" + port +
-                    ", active=" + active +
                     ", scheme=" + scheme +
                     '}';
         }

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Elasticsearch.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Elasticsearch.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import fr.pilato.elasticsearch.crawler.fs.framework.ByteSizeUnit;
 import fr.pilato.elasticsearch.crawler.fs.framework.ByteSizeValue;
 import fr.pilato.elasticsearch.crawler.fs.framework.TimeValue;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,6 +33,8 @@ import java.util.Locale;
 import java.util.Objects;
 
 public class Elasticsearch {
+
+    protected static final Logger logger = LogManager.getLogger(Elasticsearch.class);
 
     public Elasticsearch() {
 
@@ -76,23 +80,33 @@ public class Elasticsearch {
             }
         }
 
-        public static final Node DEFAULT = Node.builder().setHost("127.0.0.1").setPort(9200).setScheme(Scheme.HTTP).build();
+        public static final Node DEFAULT = new Node("http://127.0.0.1:9200");
 
         public Node() {
 
         }
 
-        private Node(String host, int port, Scheme scheme) {
+        @Deprecated
+        public Node(String host, int port, Scheme scheme) {
             this.host = host;
             this.port = port;
             this.scheme = scheme;
         }
 
-        private Node(String cloudId) {
-            this.cloudId = cloudId;
+        public Node(String urlOrCloudId) {
+            // We check if the String starts with https:// or http://
+            // In which case this is a URL, otherwise its a cloud id
+            String asLowerCase = urlOrCloudId.toLowerCase();
+            if (asLowerCase.startsWith("http://") || asLowerCase.startsWith("https://")) {
+                this.url = urlOrCloudId;
+            } else {
+                this.cloudId = urlOrCloudId;
+            }
         }
 
+        private String url;
         private String cloudId;
+
         @Deprecated
         private String host;
         @Deprecated
@@ -100,24 +114,12 @@ public class Elasticsearch {
         @Deprecated
         private Scheme scheme;
 
-        public String getHost() {
-            return host;
-        }
-
         public void setHost(String host) {
             this.host = host;
         }
 
-        public Integer getPort() {
-            return port;
-        }
-
         public void setPort(Integer port) {
             this.port = port;
-        }
-
-        public Scheme getScheme() {
-            return scheme;
         }
 
         public void setScheme(Scheme scheme) {
@@ -132,48 +134,19 @@ public class Elasticsearch {
             this.cloudId = cloudId;
         }
 
-        public static Builder builder() {
-            return new Builder();
+        public String getUrl() {
+            // If we are using deprecated settings, let's warn the user to move to url param
+            if (host != null || port != null || scheme != null) {
+                String tmpUrl = scheme.toLowerCase() + "://" + host + ":" + port;
+                logger.warn("elasticsearch.nodes.[scheme, host, port] has been deprecated and will be removed in a coming version. " +
+                        "Use elasticsearch.nodes: [ { \"url\": \"{}\" } ] instead", tmpUrl);
+                return tmpUrl;
+            }
+            return url;
         }
 
-        public static class Builder {
-            private String host;
-            private int port;
-            private Scheme scheme = Scheme.HTTP;
-            private String cloudId = null;
-
-            /**
-             * This can be used in the context of Elasticsearch service by elastic
-             * @param cloudId The cloud id as given on cloud console
-             * @return self
-             */
-            public Builder setCloudId(String cloudId) {
-                this.cloudId = cloudId;
-                return this;
-            }
-
-            public Builder setHost(String host) {
-                this.host = host;
-                return this;
-            }
-
-            public Builder setPort(int port) {
-                this.port = port;
-                return this;
-            }
-
-            public Builder setScheme(Scheme scheme) {
-                this.scheme = scheme;
-                return this;
-            }
-
-            public Node build() {
-                if (cloudId != null) {
-                    return new Node(cloudId);
-                } else {
-                    return new Node(host, port, scheme);
-                }
-            }
+        public void setUrl(String url) {
+            this.url = url;
         }
 
         @Override
@@ -182,22 +155,18 @@ public class Elasticsearch {
             if (o == null || getClass() != o.getClass()) return false;
             Node node = (Node) o;
             return Objects.equals(cloudId, node.cloudId) &&
-                    Objects.equals(host, node.host) &&
-                    Objects.equals(port, node.port) &&
-                    scheme == node.scheme;
+                    Objects.equals(url, node.url);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(cloudId, host, port, scheme);
+            return Objects.hash(cloudId, url);
         }
 
         @Override
         public String toString() {
             return "Node{" + "cloudId='" + cloudId + '\'' +
-                    ", host='" + host + '\'' +
-                    ", port=" + port +
-                    ", scheme=" + scheme +
+                    ", url=" + url +
                     '}';
         }
     }

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsCrawlerValidator.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsCrawlerValidator.java
@@ -108,7 +108,7 @@ public class FsCrawlerValidator {
 
         // Check that REST settings are available when we start with rest option
         if (rest && settings.getRest() == null) {
-            logger.warn("`rest` settings are not defined. Falling back to default: [{}].", Rest.DEFAULT.url());
+            logger.warn("`rest` settings are not defined. Falling back to default: [{}].", Rest.DEFAULT);
             settings.setRest(Rest.DEFAULT);
         }
 

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Rest.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Rest.java
@@ -19,9 +19,15 @@
 
 package fr.pilato.elasticsearch.crawler.fs.settings;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.Locale;
+import java.util.Objects;
 
 public class Rest {
+
+    protected static final Logger logger = LogManager.getLogger(Rest.class);
 
     public enum Scheme {
         HTTP,
@@ -36,50 +42,45 @@ public class Rest {
         }
     }
 
-    public static final Rest DEFAULT = Rest.builder().build();
+    public static final Rest DEFAULT = new Rest("http://127.0.0.1:8080/fscrawler");
 
     public Rest() {
 
     }
 
-    private Rest(Scheme scheme, String host, int port, String endpoint) {
+    public Rest(String url) {
+        this.url = url;
+    }
+
+    @Deprecated
+    public Rest(Scheme scheme, String host, int port, String endpoint) {
         this.scheme = scheme;
         this.host = host;
         this.port = port;
         this.endpoint = endpoint;
     }
 
-    private Scheme scheme;
-    private String host;
-    private int port;
-    private String endpoint;
+    private String url;
 
-    public String getHost() {
-        return host;
-    }
+    @Deprecated
+    private String endpoint;
+    @Deprecated
+    private Scheme scheme;
+    @Deprecated
+    private String host;
+    @Deprecated
+    private int port;
 
     public void setHost(String host) {
         this.host = host;
-    }
-
-    public int getPort() {
-        return port;
     }
 
     public void setPort(int port) {
         this.port = port;
     }
 
-    public Scheme getScheme() {
-        return scheme;
-    }
-
     public void setScheme(Scheme scheme) {
         this.scheme = scheme;
-    }
-
-    public String getEndpoint() {
-        return endpoint;
     }
 
     public void setEndpoint(String endpoint) {
@@ -90,66 +91,36 @@ public class Rest {
      * Get the server URL: Scheme://host:port/endpoint
      * @return the server URL
      */
-    public String url() {
-        return scheme.toLowerCase() + "://" + host + ":" + port + "/" + endpoint;
+    public String getUrl() {
+        // If we are using deprecated settings, let's warn the user to move to url param
+        if (host != null || scheme != null || endpoint != null) {
+            String tmpUrl = scheme.toLowerCase() + "://" + host + ":" + port + "/" + endpoint;
+            logger.warn("rest.[scheme, host, port, endpoint] has been deprecated and will be removed in a coming version. " +
+                    "Use rest: { \"url\": \"{}\" } instead", tmpUrl);
+            return tmpUrl;
+        }
+        return url;
     }
 
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    public static class Builder {
-        private Scheme scheme = Scheme.HTTP;
-        private String host = "127.0.0.1";
-        private int port = 8080;
-        private String endpoint = "fscrawler";
-
-        public Builder setScheme(Scheme scheme) {
-            this.scheme = scheme;
-            return this;
-        }
-
-        public Builder setHost(String host) {
-            this.host = host;
-            return this;
-        }
-
-        public Builder setPort(int port) {
-            this.port = port;
-            return this;
-        }
-
-        public Builder setEndpoint(String endpoint) {
-            this.endpoint = endpoint;
-            return this;
-        }
-
-        public Rest build() {
-            return new Rest(scheme, host, port, endpoint);
-        }
+    public void setUrl(String url) {
+        this.url = url;
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
-        Rest node = (Rest) o;
-
-        if (port != node.port) return false;
-        return !(host != null ? !host.equals(node.host) : node.host != null);
-
+        Rest rest = (Rest) o;
+        return url.equals(rest.url);
     }
 
     @Override
     public int hashCode() {
-        int result = host != null ? host.hashCode() : 0;
-        result = 31 * result + port;
-        return result;
+        return Objects.hash(url);
     }
 
     @Override
     public String toString() {
-        return url();
+        return url;
     }
 }

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Rest.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Rest.java
@@ -65,7 +65,7 @@ public class Rest {
     @Deprecated
     private String endpoint;
     @Deprecated
-    private Scheme scheme;
+    private Scheme scheme = Scheme.HTTP;
     @Deprecated
     private String host;
     @Deprecated
@@ -93,7 +93,7 @@ public class Rest {
      */
     public String getUrl() {
         // If we are using deprecated settings, let's warn the user to move to url param
-        if (host != null || scheme != null || endpoint != null) {
+        if (host != null || endpoint != null) {
             String tmpUrl = scheme.toLowerCase() + "://" + host + ":" + port + "/" + endpoint;
             logger.warn("rest.[scheme, host, port, endpoint] has been deprecated and will be removed in a coming version. " +
                     "Use rest: { \"url\": \"{}\" } instead", tmpUrl);

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Rest.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Rest.java
@@ -21,8 +21,6 @@ package fr.pilato.elasticsearch.crawler.fs.settings;
 
 import java.util.Locale;
 
-import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.buildUrl;
-
 public class Rest {
 
     public enum Scheme {
@@ -93,7 +91,7 @@ public class Rest {
      * @return the server URL
      */
     public String url() {
-        return buildUrl(scheme.toLowerCase(), host, port) + "/" + endpoint;
+        return scheme.toLowerCase() + "://" + host + ":" + port + "/" + endpoint;
     }
 
     public static Builder builder() {

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsParserTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsParserTest.java
@@ -23,6 +23,7 @@ import fr.pilato.elasticsearch.crawler.fs.framework.ByteSizeUnit;
 import fr.pilato.elasticsearch.crawler.fs.framework.ByteSizeValue;
 import fr.pilato.elasticsearch.crawler.fs.framework.Percentage;
 import fr.pilato.elasticsearch.crawler.fs.framework.TimeValue;
+import fr.pilato.elasticsearch.crawler.fs.settings.Elasticsearch.Node;
 import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
 import org.junit.Test;
 
@@ -59,10 +60,7 @@ public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
             .build();
     private static final Elasticsearch ELASTICSEARCH_EMPTY = Elasticsearch.builder().build();
     private static final Elasticsearch ELASTICSEARCH_FULL = Elasticsearch.builder()
-            .addNode(Elasticsearch.Node.builder()
-                    .setHost("127.0.0.1")
-                    .setPort(9200)
-                    .build())
+            .addNode(new Node("http://127.0.0.1"))
             .setUsername("elastic")
             .setPassword("changeme")
             .setBulkSize(1000)
@@ -116,9 +114,8 @@ public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
         assertThat(settings.getElasticsearch().getIndex(), is("test"));
         assertThat(settings.getElasticsearch().getIndexFolder(), is("test_folder"));
         assertThat(settings.getElasticsearch().getNodes(), iterableWithSize(1));
-        assertThat(settings.getElasticsearch().getNodes().get(0).getHost(), is("127.0.0.1"));
-        assertThat(settings.getElasticsearch().getNodes().get(0).getPort(), is(9200));
-        assertThat(settings.getElasticsearch().getNodes().get(0).getScheme(), is(Elasticsearch.Node.Scheme.HTTP));
+        assertThat(settings.getElasticsearch().getNodes().get(0).getUrl(), is("http://127.0.0.1:9200"));
+        assertThat(settings.getElasticsearch().getNodes().get(0).getCloudId(), is(nullValue()));
 
         assertThat(settings.getElasticsearch().getUsername(), is(nullValue()));
         assertThat(settings.getElasticsearch().getPassword(), is(nullValue()));
@@ -185,10 +182,7 @@ public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
         settingsTester(
                 FsSettings.builder(getCurrentTestName())
                         .setElasticsearch(Elasticsearch.builder()
-                                .addNode(Elasticsearch.Node.builder()
-                                        .setHost("127.0.0.1")
-                                        .setPort(9200)
-                                        .build())
+                                .addNode(new Node("http://127.0.0.1:9200"))
                                 .build())
                         .build()
         );
@@ -199,14 +193,8 @@ public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
         settingsTester(
                 FsSettings.builder(getCurrentTestName())
                         .setElasticsearch(Elasticsearch.builder()
-                                .addNode(Elasticsearch.Node.builder()
-                                        .setHost("127.0.0.1")
-                                        .setPort(9200)
-                                        .build())
-                                .addNode(Elasticsearch.Node.builder()
-                                        .setHost("localhost")
-                                        .setPort(9201)
-                                        .build())
+                                .addNode(new Node("http://127.0.0.1:9200"))
+                                .addNode(new Node("http://127.0.0.1:9201"))
                                 .build())
                         .build()
         );
@@ -217,15 +205,8 @@ public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
         settingsTester(
                 FsSettings.builder(getCurrentTestName())
                         .setElasticsearch(Elasticsearch.builder()
-                                .addNode(Elasticsearch.Node.builder()
-                                        .setHost("127.0.0.1")
-                                        .setPort(9200)
-                                        .build())
-                                .addNode(Elasticsearch.Node.builder()
-                                        .setHost("localhost")
-                                        .setPort(9243)
-                                        .setScheme(Elasticsearch.Node.Scheme.HTTPS)
-                                        .build())
+                                .addNode(new Node("http://127.0.0.1:9200"))
+                                .addNode(new Node("https://localhost:9243"))
                                 .build())
                         .build()
         );
@@ -237,9 +218,7 @@ public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
         settingsTester(
                 FsSettings.builder(getCurrentTestName())
                         .setElasticsearch(Elasticsearch.builder()
-                                .addNode(Elasticsearch.Node.builder()
-                                        .setCloudId(cloudId)
-                                        .build())
+                                .addNode(new Node(cloudId))
                                 .build())
                         .build()
         );
@@ -310,5 +289,22 @@ public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
         String filteredJson = FsSettingsParser.toJson(generated);
         assertThat(filteredJson, not(containsString(ELASTICSEARCH_FULL.getPassword())));
         assertThat(filteredJson, not(containsString(SERVER_FULL.getPassword())));
+    }
+
+    @Test
+    public void testDeprecatedSettings() throws IOException {
+        String json = "   {\n" +
+                "     \"name\" : \"test\",\n" +
+                "     \"elasticsearch\" : {\n" +
+                "       \"nodes\" : [\n" +
+                "         { \"host\" : \"127.0.0.1\", \"port\" : 9200, \"scheme\" : \"HTTP\" }\n" +
+                "       ]\n" +
+                "     }\n" +
+                "   }\n";
+
+        logger.info("-> testing settings: [{}]", json);
+        FsSettings generated = FsSettingsParser.fromJson(json);
+        assertThat(generated.getElasticsearch().getNodes().get(0).getCloudId(), is(nullValue()));
+        assertThat(generated.getElasticsearch().getNodes().get(0).getUrl(), is("http://127.0.0.1:9200"));
     }
 }

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsParserTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsParserTest.java
@@ -77,12 +77,7 @@ public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
             .setProtocol("SSH")
             .setPemPath("/path/to/pemfile")
             .build();
-    private static final Rest REST_FULL = Rest.builder()
-            .setHost("127.0.0.1")
-            .setPort(8080)
-            .setScheme(Rest.Scheme.HTTP)
-            .setEndpoint("fscrawler")
-            .build();
+    private static final Rest REST_FULL = new Rest("http://127.0.0.1:8080/fscrawler");
 
     private void settingsTester(FsSettings source) throws IOException {
         String json = FsSettingsParser.toJson(source);
@@ -292,7 +287,7 @@ public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
     }
 
     @Test
-    public void testDeprecatedSettings() throws IOException {
+    public void testDeprecatedElasticsearchSettings() throws IOException {
         String json = "   {\n" +
                 "     \"name\" : \"test\",\n" +
                 "     \"elasticsearch\" : {\n" +
@@ -306,5 +301,22 @@ public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
         FsSettings generated = FsSettingsParser.fromJson(json);
         assertThat(generated.getElasticsearch().getNodes().get(0).getCloudId(), is(nullValue()));
         assertThat(generated.getElasticsearch().getNodes().get(0).getUrl(), is("http://127.0.0.1:9200"));
+    }
+
+    @Test
+    public void testDeprecatedRestSettings() throws IOException {
+        String json = "   {\n" +
+                "     \"name\" : \"test\",\n" +
+                "     \"rest\" : {\n" +
+                "       \"scheme\" : \"HTTP\",\n" +
+                "       \"host\" : \"192.168.0.1\",\n" +
+                "       \"port\" : 8180,\n" +
+                "       \"endpoint\" : \"my_fscrawler\"\n" +
+                "     }\n" +
+                "   }\n";
+
+        logger.info("-> testing settings: [{}]", json);
+        FsSettings generated = FsSettingsParser.fromJson(json);
+        assertThat(generated.getRest().getUrl(), is("http://192.168.0.1:8180/my_fscrawler"));
     }
 }

--- a/tika/src/test/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParserTest.java
+++ b/tika/src/test/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParserTest.java
@@ -31,6 +31,7 @@ import java.io.InputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.Map;
 
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.localDateTimeToDate;
@@ -46,6 +47,7 @@ import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeNoException;
 import static org.junit.Assume.assumeTrue;
@@ -684,9 +686,9 @@ public class TikaDocParserTest extends DocParserTestCase {
                 .setFs(Fs.builder().setOcr(Ocr.builder().setOutputType("hocr").build()).build())
                 .build();
         doc = extractFromFile("test-ocr.png", fsSettings);
-        assertThat(doc.getContent(), containsString("This file contains some words."));
+        assertThat(doc.getContent(), stringContainsInOrder(Arrays.asList("This", "file", "contains", "some", "words.")));
         doc = extractFromFile("test-ocr.pdf", fsSettings);
-        assertThat(doc.getContent(), containsString("This file contains some words."));
+        assertThat(doc.getContent(), stringContainsInOrder(Arrays.asList("This", "file", "contains", "some", "words.")));
     }
 
     @Test


### PR DESCRIPTION
# Elasticsearch.Node settings

Replace `node.`(`host`, `port`, `scheme`) by `node.url`

With #616 we started to introduce in tests the notion of `url` instead of using `host`, `port`, `scheme` which should make configuration easier.
Let's do that as well within our settings.

Instead of writing the following settings:

```js
{
 "name" : "test",
 "elasticsearch" : {
   "nodes" : [
     { "host" : "mynode1.mycompany.com", "port" : 9200, "scheme" : "HTTP" }
   ]
 }
}
```

We can now write:

```js
{
 "name" : "test",
 "elasticsearch" : {
   "nodes" : [
     { "url" : "http://mynode1.mycompany.com:9200" }
   ]
 }
}
```

This will warn the user if still using deprecating settings. Such as:

```
05:21:40,097 WARN  [f.p.e.c.f.s.Elasticsearch] elasticsearch.nodes.host has been deprecated and will be removed in a coming version. Use elasticsearch.nodes: [ { "url": "http://127.0.0.1:9200" } ] instead
```

# Rest settings

Same applies for  `rest`.(`host`, `port`, `scheme`, `endpoint`) which is replaced by `rest.url`.

Instead of:

```js
{
 "name" : "test",
 "rest" : {
   "scheme" : "HTTP",
   "host" : "192.168.0.1",
   "port" : 8180,
   "endpoint" : "my_fscrawler"
 }
}
```

Users can now write:

```js
{
 "name" : "test",
 "rest" : {
   "url" : "http://192.168.0.1:8180/my_fscrawler"
 }
}
```

This will warn the user if still using deprecating settings. Such as:

```
16:08:48,935 WARN  [f.p.e.c.f.s.Rest] rest.[scheme, host, port, endpoint] has been deprecated and will be removed in a coming version. Use rest: { "url": "http://192.168.0.1:8180/my_fscrawler" } instead
```

Closes #617.
