### PR TITLE
Check Elasticsearch 6 minor version

### DIFF
--- a/elasticsearch-client/elasticsearch-client-v6/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v6/ElasticsearchClientV6.java
+++ b/elasticsearch-client/elasticsearch-client-v6/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v6/ElasticsearchClientV6.java
@@ -171,6 +171,25 @@ public class ElasticsearchClientV6 implements ElasticsearchClient {
         return ESVersion.fromString(version.toString());
     }
 
+    /**
+     * For Elasticsearch 6, we need to make sure we are running at least Elasticsearch 6.4
+     * @throws IOException when something is wrong while asking the version of the node.
+     */
+    @Override
+    public void checkVersion() throws IOException {
+        ESVersion esVersion = getVersion();
+        if (esVersion.major != compatibleVersion()) {
+            throw new RuntimeException("The Elasticsearch client version [" +
+                    compatibleVersion() + "] is not compatible with the Elasticsearch cluster version [" +
+                    esVersion.toString() + "].");
+        }
+        if (esVersion.minor < 4) {
+            throw new RuntimeException("This version of FSCrawler is not compatible with " +
+                    "Elasticsearch version [" +
+                    esVersion.toString() + "]. Please upgrade Elasticsearch to at least a 6.4.x version.");
+        }
+    }
+
     class DebugListener implements BulkProcessor.Listener {
         private final Logger logger;
 


### PR DESCRIPTION
With fscrawler 2.5, we introduced `_doc` as the type name to use in 6.x clusters.
Unfortunately this type name is not supported in early 6.x versions like 6.1.

As we tested 2.5 from 6.4, we are adding a control which makes that explicit when starting the Elasticsearch 6 client.

Closes #614.