### PR TITLE
Force the default number of shards to be 1

### DIFF
--- a/docs/source/admin/fs/elasticsearch.rst
+++ b/docs/source/admin/fs/elasticsearch.rst
@@ -128,6 +128,7 @@ The following example uses a ``french`` analyzer to index the
 
     {
       "settings": {
+        "number_of_shards": 1,
         "index.mapping.total_fields.limit": 2000,
         "analysis": {
           "analyzer": {

--- a/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/6/_settings.json
+++ b/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/6/_settings.json
@@ -1,5 +1,6 @@
 {
   "settings": {
+    "number_of_shards": 1,
     "index.mapping.total_fields.limit": 2000,
     "analysis": {
       "analyzer": {

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsMappingTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsMappingTest.java
@@ -613,6 +613,7 @@ public class FsMappingTest extends AbstractFSCrawlerMetadataTestCase {
         logger.info("Settings used for doc index v6 : " + settings);
         assertThat(settings, is("{\n" +
                 "  \"settings\": {\n" +
+                "    \"number_of_shards\": 1,\n" +
                 "    \"index.mapping.total_fields.limit\": 2000,\n" +
                 "    \"analysis\": {\n" +
                 "      \"analyzer\": {\n" +


### PR DESCRIPTION
This removes the deprecation notice for the default number of shards:

```
#! Deprecation: the default number of shards will change from [5] to [1] in 7.0.0; if you wish to continue using the default of [5] shards, you must manage this on the create index request or with an index template
```

Closes #606.