### PR TITLE
Update Guava transitive dependency to 27.0.1-jre

### DIFF
--- a/tika/pom.xml
+++ b/tika/pom.xml
@@ -99,6 +99,11 @@
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-langdetect</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>27.0.1-jre</version>
+        </dependency>
         <!--Dependency for parsing remote ssh directory [http://www.jcraft.com/jsch/]-->
         <dependency>
             <groupId>com.jcraft</groupId>


### PR DESCRIPTION
As reported by a recent build we should avoid using the transitive dependency of Guava 17.0 and use a newer version.

See https://ossindex.sonatype.org/vuln/24585a7f-eb6b-4d8d-a2a9-a6f16cc7c1d0