### PR TITLE
Fix Maven Central and Sonatype links

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -236,8 +236,10 @@ rst_prolog = rst_prolog + """
 .. |JPEG2000_version| replace:: jai-imageio-jpeg2000:{fmt_jpeg_version}
 .. |Download_URL_V5| replace:: fscrawler-es5-{fmt_release}
 .. |Download_URL_V6| replace:: fscrawler-es6-{fmt_release}
-.. |Maven_Central| replace:: Maven Central
-.. |Sonatype| replace:: Sonatype
+.. |Maven_Central_V5| replace:: fscrawler-es5-*
+.. |Maven_Central_V6| replace:: fscrawler-es6-*
+.. |Sonatype_V5| replace:: fscrawler-es5-*
+.. |Sonatype_V6| replace:: fscrawler-es6-*
 
 .. _Tika: http://tika.apache.org/{fmt_tika_version}/
 .. _ES: https://www.elastic.co/products/elasticsearch
@@ -250,8 +252,10 @@ rst_prolog = rst_prolog + """
 .. _JPEG2000_version: http://repo1.maven.org/maven2/com/github/jai-imageio/jai-imageio-jpeg2000/{fmt_jpeg_version}/
 .. _Download_URL_V5: {fmt_downloadUrl_V5}
 .. _Download_URL_V6: {fmt_downloadUrl_V6}
-.. _Maven_Central: https://repo1.maven.org/maven2/fr/pilato/elasticsearch/crawler/fscrawler/
-.. _Sonatype: https://oss.sonatype.org/content/repositories/snapshots/fr/pilato/elasticsearch/crawler/fscrawler/
+.. _Maven_Central_V5: https://repo1.maven.org/maven2/fr/pilato/elasticsearch/crawler/fscrawler-es5/
+.. _Maven_Central_V6: https://repo1.maven.org/maven2/fr/pilato/elasticsearch/crawler/fscrawler-es6/
+.. _Sonatype_V5: https://oss.sonatype.org/content/repositories/snapshots/fr/pilato/elasticsearch/crawler/fscrawler-es5/
+.. _Sonatype_V6: https://oss.sonatype.org/content/repositories/snapshots/fr/pilato/elasticsearch/crawler/fscrawler-es6/
 """.format(
 fmt_tika_version=config.get('3rdParty', 'TikaVersion'),
 fmt_es_version=config.get('3rdParty', 'ElasticsearchVersion'),

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -14,7 +14,10 @@ Download FSCrawler
     .. warning::
 
         This is a **SNAPSHOT** version.
-        You can also download a **stable** version from |Maven_Central|_.
+        You can also download a **stable** version from Maven Central:
+
+        * |Maven_Central_V6|_ for Elasticsearch V6.
+        * |Maven_Central_V5|_ for Elasticsearch V5.
 
 .. ifconfig:: release == version
 
@@ -27,9 +30,15 @@ Download FSCrawler
     .. tip::
 
         This is a **stable** version.
-        You can choose another version than |version| in |Maven_Central|_.
+        You can choose another version than |version| from Maven Central:
 
-        You can also download a **SNAPSHOT** version from |Sonatype|_.
+        * |Maven_Central_V6|_ for Elasticsearch V6.
+        * |Maven_Central_V5|_ for Elasticsearch V5.
+
+        You can also download a **SNAPSHOT** version from Sonatype:
+
+        * |Sonatype_V6|_ for Elasticsearch V6.
+        * |Sonatype_V5|_ for Elasticsearch V5.
 
 The distribution contains:
 


### PR DESCRIPTION
With the new distribution packages, the link we were providing needs
now to be 2 links instead of a single one.

Closes #667.