### PR TITLE
Add support for Elasticsearch 7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You need to install a version matching your Elasticsearch version:
 
 |    Elasticsearch   |  FS Crawler | Released |                                       Docs                                   |
 |--------------------|-------------|----------|------------------------------------------------------------------------------|
-| 2.x, 5.x, 6.x      | 2.7-SNAPSHOT|          |[2.6-SNAPSHOT](https://fscrawler.readthedocs.io/en/latest/)                   |
+| 2.x, 5.x, 6.x, 7.x | 2.7-SNAPSHOT|          |[2.7-SNAPSHOT](https://fscrawler.readthedocs.io/en/latest/)                   |
 | 2.x, 5.x, 6.x      | 2.6         |2019-01-09|[2.6](https://fscrawler.readthedocs.io/en/fscrawler-2.6)                      |
 | 2.x, 5.x, 6.x      | 2.5         |2018-08-04|[2.5](https://fscrawler.readthedocs.io/en/fscrawler-2.5)                      |
 | 2.x, 5.x, 6.x      | **2.4**     |2017-08-11|[2.4](https://github.com/dadoonet/fscrawler/blob/fscrawler-2.4/README.md)     |

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
@@ -79,12 +79,6 @@ public abstract class FsParserAbstract extends FsParser {
     private final Integer loop;
     private final MessageDigest messageDigest;
 
-    /**
-     * This is a temporary value we need to support both v5 and newer versions.
-     * V5 does not allow a type named _doc but V6 recommends using it.
-     */
-    private final String typeName;
-
     private ScanStatistic stats;
 
     FsParserAbstract(FsSettings fsSettings, Path config, ElasticsearchClient esClient, Integer loop) {
@@ -106,8 +100,6 @@ public abstract class FsParserAbstract extends FsParser {
         } else {
             messageDigest = null;
         }
-
-        typeName = esClient.getDefaultTypeName();
     }
 
     protected abstract FileAbstractor buildFileAbstractor();
@@ -197,7 +189,6 @@ public abstract class FsParserAbstract extends FsParser {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private LocalDateTime getLastDateFromMeta(String jobName) throws IOException {
         try {
             FsJob fsJob = fsJobFileHandler.read(jobName);
@@ -577,26 +568,26 @@ public abstract class FsParserAbstract extends FsParser {
     /**
      * Add to bulk an IndexRequest in JSon format
      */
-    void esIndex(String index, String id, String json, String pipeline) {
-        logger.debug("Indexing {}/{}/{}?pipeline={}", index, typeName, id, pipeline);
+    private void esIndex(String index, String id, String json, String pipeline) {
+        logger.debug("Indexing {}/{}?pipeline={}", index, id, pipeline);
         logger.trace("JSon indexed : {}", json);
 
         if (!closed) {
-            esClient.index(index, typeName, id, json, pipeline);
+            esClient.index(index, id, json, pipeline);
         } else {
-            logger.warn("trying to add new file while closing crawler. Document [{}]/[{}]/[{}] has been ignored", index, typeName, id);
+            logger.warn("trying to add new file while closing crawler. Document [{}]/[{}] has been ignored", index, id);
         }
     }
 
     /**
      * Add to bulk a DeleteRequest
      */
-    void esDelete(String index, String id) {
-        logger.debug("Deleting {}/{}/{}", index, typeName, id);
+    private void esDelete(String index, String id) {
+        logger.debug("Deleting {}/{}", index, id);
         if (!closed) {
-            esClient.delete(index, typeName, id);
+            esClient.delete(index, id);
         } else {
-            logger.warn("trying to remove a file while closing crawler. Document [{}]/[{}]/[{}] has been ignored", index, typeName, id);
+            logger.warn("trying to remove a file while closing crawler. Document [{}]/[{}] has been ignored", index, id);
         }
     }
 

--- a/distribution/es7/pom.xml
+++ b/distribution/es7/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>fr.pilato.elasticsearch.crawler</groupId>
+        <artifactId>fscrawler-distribution</artifactId>
+        <version>2.7-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>fscrawler-es7</artifactId>
+    <name>FSCrawler ZIP Distribution for Elasticsearch 7.x</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>fr.pilato.elasticsearch.crawler</groupId>
+            <artifactId>fscrawler-elasticsearch-client-v7</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/distribution/es7/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawler.java
+++ b/distribution/es7/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawler.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package fr.pilato.elasticsearch.crawler.fs.cli;
+
+/**
+ * Main entry point to launch FsCrawler
+ */
+public class FsCrawler extends FsCrawlerCli {
+
+}

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -14,6 +14,7 @@
     <packaging>pom</packaging>
 
     <modules>
+        <module>es7</module>
         <module>es6</module>
         <module>es5</module>
     </modules>

--- a/docs/source/admin/fs/elasticsearch.rst
+++ b/docs/source/admin/fs/elasticsearch.rst
@@ -69,16 +69,16 @@ Mappings
 
 When FSCrawler needs to create the doc index, it applies some default
 settings and mappings which are read from
-``~/.fscrawler/_default/6/_settings.json``. You can read its content
+``~/.fscrawler/_default/7/_settings.json``. You can read its content
 from `the
-source <https://github.com/dadoonet/fscrawler/blob/master/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/6/_settings.json>`__.
+source <https://github.com/dadoonet/fscrawler/blob/master/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/7/_settings.json>`__.
 
 Settings define an analyzer named ``fscrawler_path`` which uses a `path
 hierarchy
 tokenizer <https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-pathhierarchy-tokenizer.html>`__.
 
 FSCrawler applies as well a mapping automatically for the folders which can also be
-read from `the source <https://github.com/dadoonet/fscrawler/blob/master/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/6/_settings_folder.json>`__.
+read from `the source <https://github.com/dadoonet/fscrawler/blob/master/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/7/_settings_folder.json>`__.
 
 You can also display the index mapping being used with Kibana:
 
@@ -106,6 +106,8 @@ Or fall back to the command line:
     -  ``5/_settings_folder.json``: for elasticsearch 5.x series folder index settings
     -  ``6/_settings.json``: for elasticsearch 6.x series document index settings
     -  ``6/_settings_folder.json``: for elasticsearch 6.x series folder index settings
+    -  ``7/_settings.json``: for elasticsearch 7.x series document index settings
+    -  ``7/_settings_folder.json``: for elasticsearch 7.x series folder index settings
 
 .. note::
 
@@ -117,7 +119,7 @@ Creating your own mapping (analyzers)
 
 If you want to define your own index settings and mapping to set
 analyzers for example, you can either create the index and push the
-mapping or define a ``~/.fscrawler/_default/6/_settings.json`` document
+mapping or define a ``~/.fscrawler/_default/7/_settings.json`` document
 which contains the index settings and mappings you wish **before
 starting the FSCrawler**.
 
@@ -364,8 +366,8 @@ documents against an elasticsearch cluster running version ``6.x``.
 If you create the following files, they will be picked up at job start
 time instead of the :ref:`default ones <mappings>`:
 
--  ``~/.fscrawler/{job_name}/_mappings/6/_settings.json``
--  ``~/.fscrawler/{job_name}/_mappings/6/_settings_folder.json``
+-  ``~/.fscrawler/{job_name}/_mappings/7/_settings.json``
+-  ``~/.fscrawler/{job_name}/_mappings/7/_settings_folder.json``
 
 .. tip::
     You can do the same for other elasticsearch versions with:
@@ -374,6 +376,8 @@ time instead of the :ref:`default ones <mappings>`:
     -  ``~/.fscrawler/{job_name}/_mappings/2/_settings_folder.json`` for 2.x series (deprecated)
     -  ``~/.fscrawler/{job_name}/_mappings/5/_settings.json`` for 5.x series
     -  ``~/.fscrawler/{job_name}/_mappings/5/_settings_folder.json`` for 5.x series
+    -  ``~/.fscrawler/{job_name}/_mappings/6/_settings.json`` for 6.x series
+    -  ``~/.fscrawler/{job_name}/_mappings/6/_settings_folder.json`` for 6.x series
 
 Replace existing mapping
 """"""""""""""""""""""""

--- a/docs/source/admin/fs/index.rst
+++ b/docs/source/admin/fs/index.rst
@@ -57,10 +57,7 @@ The job file must comply to the following ``json`` specifications:
        "password" : "password"
      },
      "rest" : {
-       "scheme" : "HTTP",
-       "host" : "127.0.0.1",
-       "port" : 8080,
-       "endpoint" : "fscrawler"
+       "url" : "https://127.0.0.1:8080/fscrawler"
      }
    }
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -236,10 +236,13 @@ rst_prolog = rst_prolog + """
 .. |JPEG2000_version| replace:: jai-imageio-jpeg2000:{fmt_jpeg_version}
 .. |Download_URL_V5| replace:: fscrawler-es5-{fmt_release}
 .. |Download_URL_V6| replace:: fscrawler-es6-{fmt_release}
+.. |Download_URL_V7| replace:: fscrawler-es7-{fmt_release}
 .. |Maven_Central_V5| replace:: fscrawler-es5-*
 .. |Maven_Central_V6| replace:: fscrawler-es6-*
+.. |Maven_Central_V7| replace:: fscrawler-es7-*
 .. |Sonatype_V5| replace:: fscrawler-es5-*
 .. |Sonatype_V6| replace:: fscrawler-es6-*
+.. |Sonatype_V7| replace:: fscrawler-es7-*
 
 .. _Tika: http://tika.apache.org/{fmt_tika_version}/
 .. _ES: https://www.elastic.co/products/elasticsearch
@@ -252,10 +255,13 @@ rst_prolog = rst_prolog + """
 .. _JPEG2000_version: http://repo1.maven.org/maven2/com/github/jai-imageio/jai-imageio-jpeg2000/{fmt_jpeg_version}/
 .. _Download_URL_V5: {fmt_downloadUrl_V5}
 .. _Download_URL_V6: {fmt_downloadUrl_V6}
+.. _Download_URL_V7: {fmt_downloadUrl_V7}
 .. _Maven_Central_V5: https://repo1.maven.org/maven2/fr/pilato/elasticsearch/crawler/fscrawler-es5/
 .. _Maven_Central_V6: https://repo1.maven.org/maven2/fr/pilato/elasticsearch/crawler/fscrawler-es6/
+.. _Maven_Central_V7: https://repo1.maven.org/maven2/fr/pilato/elasticsearch/crawler/fscrawler-es7/
 .. _Sonatype_V5: https://oss.sonatype.org/content/repositories/snapshots/fr/pilato/elasticsearch/crawler/fscrawler-es5/
 .. _Sonatype_V6: https://oss.sonatype.org/content/repositories/snapshots/fr/pilato/elasticsearch/crawler/fscrawler-es6/
+.. _Sonatype_V7: https://oss.sonatype.org/content/repositories/snapshots/fr/pilato/elasticsearch/crawler/fscrawler-es7/
 """.format(
 fmt_tika_version=config.get('3rdParty', 'TikaVersion'),
 fmt_es_version=config.get('3rdParty', 'ElasticsearchVersion'),
@@ -264,5 +270,6 @@ fmt_tiff_version=config.get('3rdParty', 'TiffVersion'),
 fmt_jpeg_version=config.get('3rdParty', 'JpegVersion'),
 fmt_downloadUrl_V5=downloadUrlV5,
 fmt_downloadUrl_V6=downloadUrlV6,
+fmt_downloadUrl_V7=downloadUrlV7,
 fmt_release=release
 )

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,10 +52,12 @@ release = read_version()
 
 downloadUrlV5 = "https://repo1.maven.org/maven2/fr/pilato/elasticsearch/crawler/fscrawler-es5/%s/fscrawler-es5-%s.zip" % (version, version)
 downloadUrlV6 = "https://repo1.maven.org/maven2/fr/pilato/elasticsearch/crawler/fscrawler-es6/%s/fscrawler-es6-%s.zip" % (version, version)
+downloadUrlV7 = "https://repo1.maven.org/maven2/fr/pilato/elasticsearch/crawler/fscrawler-es7/%s/fscrawler-es7-%s.zip" % (version, version)
 
 if release.endswith('-SNAPSHOT'):
     downloadUrlV5 = "https://oss.sonatype.org/content/repositories/snapshots/fr/pilato/elasticsearch/crawler/fscrawler-es5/%s/" % release
     downloadUrlV6 = "https://oss.sonatype.org/content/repositories/snapshots/fr/pilato/elasticsearch/crawler/fscrawler-es6/%s/" % release
+    downloadUrlV7 = "https://oss.sonatype.org/content/repositories/snapshots/fr/pilato/elasticsearch/crawler/fscrawler-es7/%s/" % release
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/source/dev/build.rst
+++ b/docs/source/dev/build.rst
@@ -46,6 +46,7 @@ Run tests from your IDE
 To run integration tests from your IDE, you need to start tests in ``fscrawler-it-common`` module.
 But you need first to specify the Maven profile to use and rebuild the project.
 
+* ``es-7x`` for Elasticsearch 7.x
 * ``es-6x`` for Elasticsearch 6.x
 * ``es-5x`` for Elasticsearch 5.x
 
@@ -55,13 +56,14 @@ Run tests with an external cluster
 
 To run the test suite against an elasticsearch instance running locally, just run::
 
-    mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it-v6
+    mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it-v7
 
 .. tip::
 
-    If you want to run against a version 5, run::
+    If you want to run against a version 5 or 6, run::
 
         mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it-v5
+        mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it-v6
 
 If elasticsearch is not running yet on ``http://localhost:9200``, FSCrawler project will run a Docker instance before
 the tests start.
@@ -70,7 +72,7 @@ the tests start.
 
     If you are using a secured instance, use ``tests.cluster.user``, ``tests.cluster.pass`` and ``tests.cluster.url``::
 
-        mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it-v6 \
+        mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it-v7 \
             -Dtests.cluster.user=elastic \
             -Dtests.cluster.pass=changeme \
             -Dtests.cluster.url=https://127.0.0.1:9200 \
@@ -81,14 +83,14 @@ the tests start.
     `Elasticsearch service by Elastic <https://www.elastic.co/cloud/elasticsearch-service>`_,
     you can also use ``tests.cluster.url`` to set where elasticsearch is running::
 
-        mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it-v6 \
+        mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it-v7 \
             -Dtests.cluster.user=elastic \
             -Dtests.cluster.pass=changeme \
             -Dtests.cluster.url=https://XYZ.es.io:9243
 
     Or even easier, you can use the ``Cloud ID`` available on you Cloud Console::
 
-        mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it-v6 \
+        mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it-v7 \
             -Dtests.cluster.user=elastic \
             -Dtests.cluster.pass=changeme \
             -Dtests.cluster.cloud_id=fscrawler:ZXVyb3BlLXdlc3QxLmdjcC5jbG91ZC5lcy5pbyQxZDFlYTk5Njg4Nzc0NWE2YTJiN2NiNzkzMTUzNDhhMyQyOTk1MDI3MzZmZGQ0OTI5OTE5M2UzNjdlOTk3ZmU3Nw==
@@ -111,7 +113,7 @@ Some options are available from the command line when running the tests:
 
 For example::
 
-  mvn install -rf :fscrawler-it -Pes-6x -Dtests.output=always
+  mvn install -rf :fscrawler-it -Dtests.output=always
 
 Check for vulnerabilities (CVE)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -6,6 +6,7 @@ Download FSCrawler
     Depending on your Elasticsearch cluster version, you can download
     FSCrawler |version| using the following links:
 
+    * |Download_URL_V7|_ for Elasticsearch V7.
     * |Download_URL_V6|_ for Elasticsearch V6.
     * |Download_URL_V5|_ for Elasticsearch V5.
 
@@ -16,6 +17,7 @@ Download FSCrawler
         This is a **SNAPSHOT** version.
         You can also download a **stable** version from Maven Central:
 
+        * |Maven_Central_V7|_ for Elasticsearch V7.
         * |Maven_Central_V6|_ for Elasticsearch V6.
         * |Maven_Central_V5|_ for Elasticsearch V5.
 
@@ -24,6 +26,7 @@ Download FSCrawler
     Depending on your Elasticsearch cluster version, you can download
     FSCrawler |version| using the following links:
 
+    * |Download_URL_V7|_ for Elasticsearch V7.
     * |Download_URL_V6|_ for Elasticsearch V6.
     * |Download_URL_V5|_ for Elasticsearch V5.
 
@@ -32,11 +35,13 @@ Download FSCrawler
         This is a **stable** version.
         You can choose another version than |version| from Maven Central:
 
+        * |Maven_Central_V7|_ for Elasticsearch V7.
         * |Maven_Central_V6|_ for Elasticsearch V6.
         * |Maven_Central_V5|_ for Elasticsearch V5.
 
         You can also download a **SNAPSHOT** version from Sonatype:
 
+        * |Sonatype_V7|_ for Elasticsearch V7.
         * |Sonatype_V6|_ for Elasticsearch V6.
         * |Sonatype_V5|_ for Elasticsearch V5.
 
@@ -327,4 +332,9 @@ Upgrade to 2.6
 - ``elasticsearch.nodes`` settings using ``host``, ``port`` or ``scheme`` have been replaced by
   an easier notation using ``url`` setting like ``http://127.0.0.1:9200``. You will need to modify
   your existing settings and use the new notation if warned.
+
+Upgrade to 2.7
+~~~~~~~~~~~~~~
+
+- FSCrawler comes now with an elasticsearch 7.x implementation.
 

--- a/elasticsearch-client/elasticsearch-client-base/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/elasticsearch-client/elasticsearch-client-base/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -115,29 +115,26 @@ public interface ElasticsearchClient extends Closeable {
     /**
      * Index a document using a BulkProcessor behind the scenes
      * @param index     Index name
-     * @param type      Type name
      * @param id        Document ID
      * @param json      JSON
      * @param pipeline  Pipeline (can be null)
      */
-    void index(String index, String type, String id, String json, String pipeline);
+    void index(String index, String id, String json, String pipeline);
 
     /**
      * Index a document (for test purposes only)
      * @param index     Index name
-     * @param type      Type name
      * @param id        Document ID
      * @param json      JSON
      */
-    void indexSingle(String index, String type, String id, String json) throws IOException;
+    void indexSingle(String index, String id, String json) throws IOException;
 
     /**
      * Delete a document using a BulkProcessor behind the scenes
      * @param index     Index name
-     * @param type      Type name
      * @param id        Document ID
      */
-    void delete(String index, String type, String id);
+    void delete(String index, String id);
 
     /**
      * Create all needed indices
@@ -181,22 +178,20 @@ public interface ElasticsearchClient extends Closeable {
     /**
      * Get a document by its ID
      * @param index Index name
-     * @param type  Type
      * @param id    Document id
      * @return A Search Hit
      * @throws IOException In case of error
      */
-    ESSearchHit get(String index, String type, String id) throws IOException;
+    ESSearchHit get(String index, String id) throws IOException;
 
     /**
      * Check that a document exists
      * @param index Index name
-     * @param type  Type
      * @param id    Document id
      * @return true if it exists, false otherwise
      * @throws IOException In case of error
      */
-    boolean exists(String index, String type, String id) throws IOException;
+    boolean exists(String index, String id) throws IOException;
 
     default void checkVersion() throws IOException {
         ESVersion esVersion = getVersion();

--- a/elasticsearch-client/elasticsearch-client-base/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClientUtil.java
+++ b/elasticsearch-client/elasticsearch-client-base/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClientUtil.java
@@ -46,7 +46,7 @@ public abstract class ElasticsearchClientUtil {
 
         Objects.requireNonNull(settings, "settings can not be null");
 
-        for (int i = 6; i >= 1; i--) {
+        for (int i = 7; i >= 1; i--) {
             logger.debug("Trying to find a client version {}", i);
 
             try {

--- a/elasticsearch-client/elasticsearch-client-base/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClientDummyBase.java
+++ b/elasticsearch-client/elasticsearch-client-base/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClientDummyBase.java
@@ -19,6 +19,8 @@
 
 package fr.pilato.elasticsearch.crawler.fs.client;
 
+import java.io.IOException;
+
 public abstract class ElasticsearchClientDummyBase implements ElasticsearchClient {
 
     @Override
@@ -82,17 +84,17 @@ public abstract class ElasticsearchClientDummyBase implements ElasticsearchClien
     }
 
     @Override
-    public void index(String index, String type, String id, String json, String pipeline) {
+    public void index(String index, String id, String json, String pipeline) {
         // Testing purpose only
     }
 
     @Override
-    public void indexSingle(String index, String type, String id, String json) {
+    public void indexSingle(String index, String id, String json) throws IOException {
         // Testing purpose only
     }
 
     @Override
-    public void delete(String index, String type, String id) {
+    public void delete(String index, String id) {
         // Testing purpose only
     }
 
@@ -122,12 +124,12 @@ public abstract class ElasticsearchClientDummyBase implements ElasticsearchClien
     }
 
     @Override
-    public ESSearchHit get(String index, String type, String id) {
+    public ESSearchHit get(String index, String id) throws IOException {
         return null;
     }
 
     @Override
-    public boolean exists(String index, String type, String id) {
+    public boolean exists(String index, String id) throws IOException {
         return false;
     }
 

--- a/elasticsearch-client/elasticsearch-client-v5/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v5/ElasticsearchClientV5.java
+++ b/elasticsearch-client/elasticsearch-client-v5/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v5/ElasticsearchClientV5.java
@@ -371,20 +371,20 @@ public class ElasticsearchClientV5 implements ElasticsearchClient {
     }
 
     @Override
-    public void index(String index, String type, String id, String json, String pipeline) {
-        bulkProcessor.add(new IndexRequest(index, type, id).setPipeline(pipeline).source(json, XContentType.JSON));
+    public void index(String index, String id, String json, String pipeline) {
+        bulkProcessor.add(new IndexRequest(index, getDefaultTypeName(), id).setPipeline(pipeline).source(json, XContentType.JSON));
     }
 
     @Override
-    public void indexSingle(String index, String type, String id, String json) throws IOException {
-        IndexRequest request = new IndexRequest(index, type, id);
+    public void indexSingle(String index, String id, String json) throws IOException {
+        IndexRequest request = new IndexRequest(index, getDefaultTypeName(), id);
         request.source(json, XContentType.JSON);
         client.index(request);
     }
 
     @Override
-    public void delete(String index, String type, String id) {
-        bulkProcessor.add(new DeleteRequest(index, type, id));
+    public void delete(String index, String id) {
+        bulkProcessor.add(new DeleteRequest(index, getDefaultTypeName(), id));
     }
 
     @Override
@@ -585,8 +585,8 @@ public class ElasticsearchClientV5 implements ElasticsearchClient {
     }
 
     @Override
-    public ESSearchHit get(String index, String type, String id) throws IOException {
-        GetRequest request = new GetRequest(index, type, id);
+    public ESSearchHit get(String index, String id) throws IOException {
+        GetRequest request = new GetRequest(index, getDefaultTypeName(), id);
         GetResponse response = client.get(request);
         ESSearchHit hit = new ESSearchHit();
         hit.setIndex(response.getIndex());
@@ -597,8 +597,8 @@ public class ElasticsearchClientV5 implements ElasticsearchClient {
     }
 
     @Override
-    public boolean exists(String index, String type, String id) throws IOException {
-        return client.exists(new GetRequest(index, type, id));
+    public boolean exists(String index, String id) throws IOException {
+        return client.exists(new GetRequest(index, getDefaultTypeName(), id));
     }
 
     private void createIndex(Path jobMappingDir, String elasticsearchVersion, String indexSettingsFile, String indexName) throws Exception {

--- a/elasticsearch-client/elasticsearch-client-v6/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v6/ElasticsearchClientV6.java
+++ b/elasticsearch-client/elasticsearch-client-v6/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v6/ElasticsearchClientV6.java
@@ -367,20 +367,20 @@ public class ElasticsearchClientV6 implements ElasticsearchClient {
     }
 
     @Override
-    public void index(String index, String type, String id, String json, String pipeline) {
-        bulkProcessor.add(new IndexRequest(index, type, id).setPipeline(pipeline).source(json, XContentType.JSON));
+    public void index(String index, String id, String json, String pipeline) {
+        bulkProcessor.add(new IndexRequest(index, getDefaultTypeName(), id).setPipeline(pipeline).source(json, XContentType.JSON));
     }
 
     @Override
-    public void indexSingle(String index, String type, String id, String json) throws IOException {
-        IndexRequest request = new IndexRequest(index, type, id);
+    public void indexSingle(String index, String id, String json) throws IOException {
+        IndexRequest request = new IndexRequest(index, getDefaultTypeName(), id);
         request.source(json, XContentType.JSON);
         client.index(request, RequestOptions.DEFAULT);
     }
 
     @Override
-    public void delete(String index, String type, String id) {
-        bulkProcessor.add(new DeleteRequest(index, type, id));
+    public void delete(String index, String id) {
+        bulkProcessor.add(new DeleteRequest(index, getDefaultTypeName(), id));
     }
 
     @Override
@@ -573,8 +573,8 @@ public class ElasticsearchClientV6 implements ElasticsearchClient {
     }
 
     @Override
-    public ESSearchHit get(String index, String type, String id) throws IOException {
-        GetRequest request = new GetRequest(index, type, id);
+    public ESSearchHit get(String index, String id) throws IOException {
+        GetRequest request = new GetRequest(index, getDefaultTypeName(), id);
         GetResponse response = client.get(request, RequestOptions.DEFAULT);
         ESSearchHit hit = new ESSearchHit();
         hit.setIndex(response.getIndex());
@@ -585,8 +585,8 @@ public class ElasticsearchClientV6 implements ElasticsearchClient {
     }
 
     @Override
-    public boolean exists(String index, String type, String id) throws IOException {
-        return client.exists(new GetRequest(index, type, id), RequestOptions.DEFAULT);
+    public boolean exists(String index, String id) throws IOException {
+        return client.exists(new GetRequest(index, getDefaultTypeName(), id), RequestOptions.DEFAULT);
     }
 
     private void createIndex(Path jobMappingDir, String elasticsearchVersion, String indexSettingsFile, String indexName) throws Exception {

--- a/elasticsearch-client/elasticsearch-client-v7/pom.xml
+++ b/elasticsearch-client/elasticsearch-client-v7/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>fr.pilato.elasticsearch.crawler</groupId>
+        <artifactId>fscrawler-elasticsearch-client</artifactId>
+        <version>2.7-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>fscrawler-elasticsearch-client-v7</artifactId>
+    <name>FSCrawler Elasticsearch Client V7</name>
+
+    <repositories>
+        <repository>
+            <id>elastic-lucene-snapshots</id>
+            <name>Elastic Lucene Snapshots</name>
+            <url>http://s3.amazonaws.com/download.elasticsearch.org/lucenesnapshots/774e9aefbc</url>
+            <releases><enabled>true</enabled></releases>
+            <snapshots><enabled>false</enabled></snapshots>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>fr.pilato.elasticsearch.crawler</groupId>
+            <artifactId>fscrawler-elasticsearch-client-base</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-high-level-client</artifactId>
+            <version>${elasticsearch7.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/elasticsearch-client/elasticsearch-client-v7/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v7/ElasticsearchClientV7.java
+++ b/elasticsearch-client/elasticsearch-client-v7/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v7/ElasticsearchClientV7.java
@@ -1,0 +1,609 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package fr.pilato.elasticsearch.crawler.fs.client.v7;
+
+
+import fr.pilato.elasticsearch.crawler.fs.client.ESBoolQuery;
+import fr.pilato.elasticsearch.crawler.fs.client.ESDocumentField;
+import fr.pilato.elasticsearch.crawler.fs.client.ESHighlightField;
+import fr.pilato.elasticsearch.crawler.fs.client.ESMatchQuery;
+import fr.pilato.elasticsearch.crawler.fs.client.ESPrefixQuery;
+import fr.pilato.elasticsearch.crawler.fs.client.ESQuery;
+import fr.pilato.elasticsearch.crawler.fs.client.ESRangeQuery;
+import fr.pilato.elasticsearch.crawler.fs.client.ESSearchHit;
+import fr.pilato.elasticsearch.crawler.fs.client.ESSearchRequest;
+import fr.pilato.elasticsearch.crawler.fs.client.ESSearchResponse;
+import fr.pilato.elasticsearch.crawler.fs.client.ESTermQuery;
+import fr.pilato.elasticsearch.crawler.fs.client.ESTermsAggregation;
+import fr.pilato.elasticsearch.crawler.fs.client.ESVersion;
+import fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchClient;
+import fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil;
+import fr.pilato.elasticsearch.crawler.fs.settings.Elasticsearch;
+import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
+import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.ingest.GetPipelineRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.common.document.DocumentField;
+import org.elasticsearch.common.text.Text;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.RangeQueryBuilder;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+
+import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.INDEX_SETTINGS_FILE;
+import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.INDEX_SETTINGS_FOLDER_FILE;
+import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.isNullOrEmpty;
+import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.readJsonFile;
+import static org.elasticsearch.action.support.IndicesOptions.LENIENT_EXPAND_OPEN;
+
+/**
+ * Elasticsearch Client for Clusters running v7.
+ */
+public class ElasticsearchClientV7 implements ElasticsearchClient {
+
+    private static final Logger logger = LogManager.getLogger(ElasticsearchClientV7.class);
+    private final Path config;
+    private final FsSettings settings;
+
+    private RestHighLevelClient client = null;
+    private BulkProcessor bulkProcessor = null;
+
+    /**
+     * Type name for Elasticsearch versions >= 6.0
+     * @deprecated Will be removed with Elasticsearch V8
+     */
+    @Deprecated
+    private static final String INDEX_TYPE_DOC = "_doc";
+
+    public ElasticsearchClientV7(Path config, FsSettings settings) {
+        this.config = config;
+        this.settings = settings;
+    }
+
+    @Override
+    public byte compatibleVersion() {
+        return 7;
+    }
+
+    @Override
+    public void start() throws IOException {
+        if (client != null) {
+            // The client has already been initialized. Let's skip this again
+            return;
+        }
+
+        try {
+            // Create an elasticsearch client
+            client = new RestHighLevelClient(buildRestClient(settings.getElasticsearch()));
+            checkVersion();
+            logger.info("Elasticsearch Client for version {}.x connected to a node running version {}", compatibleVersion(), getVersion());
+        } catch (Exception e) {
+            logger.warn("failed to create elasticsearch client, disabling crawler...");
+            throw e;
+        }
+
+        if (settings.getElasticsearch().getPipeline() != null) {
+            // Check that the pipeline exists
+            if (!isExistingPipeline(settings.getElasticsearch().getPipeline())) {
+                throw new RuntimeException("You defined pipeline:" + settings.getElasticsearch().getPipeline() +
+                        ", but it does not exist.");
+            }
+        }
+
+        BiConsumer<BulkRequest, ActionListener<BulkResponse>> bulkConsumer =
+                (request, bulkListener) -> client.bulkAsync(request, RequestOptions.DEFAULT, bulkListener);
+
+        bulkProcessor = BulkProcessor.builder(bulkConsumer, new DebugListener(logger))
+                .setBulkActions(settings.getElasticsearch().getBulkSize())
+                .setFlushInterval(TimeValue.timeValueMillis(settings.getElasticsearch().getFlushInterval().millis()))
+                .setBulkSize(new ByteSizeValue(settings.getElasticsearch().getByteSize().getBytes()))
+                .build();
+    }
+
+    @Override
+    public ESVersion getVersion() throws IOException {
+        Version version = client.info(RequestOptions.DEFAULT).getVersion();
+        return ESVersion.fromString(version.toString());
+    }
+
+    /**
+     * For Elasticsearch 6, we need to make sure we are running at least Elasticsearch 6.4
+     * @throws IOException when something is wrong while asking the version of the node.
+     */
+    @Override
+    public void checkVersion() throws IOException {
+        ESVersion esVersion = getVersion();
+        if (esVersion.major != compatibleVersion()) {
+            throw new RuntimeException("The Elasticsearch client version [" +
+                    compatibleVersion() + "] is not compatible with the Elasticsearch cluster version [" +
+                    esVersion.toString() + "].");
+        }
+    }
+
+    class DebugListener implements BulkProcessor.Listener {
+        private final Logger logger;
+
+        DebugListener(Logger logger) {
+            this.logger = logger;
+        }
+
+        @Override public void beforeBulk(long executionId, BulkRequest request) {
+            logger.trace("Sending a bulk request of [{}] requests", request.numberOfActions());
+        }
+
+        @Override public void afterBulk(long executionId, BulkRequest request, BulkResponse response) {
+            logger.trace("Executed bulk request with [{}] requests", request.numberOfActions());
+            if (response.hasFailures()) {
+                final int[] failures = {0};
+                response.iterator().forEachRemaining(bir -> {
+                    if (bir.isFailed()) {
+                        failures[0]++;
+                        logger.debug("Error caught for [{}]/[{}]/[{}]: {}", bir.getIndex(),
+                                bir.getType(), bir.getId(), bir.getFailureMessage());
+                    }
+                });
+                logger.warn("Got [{}] failures of [{}] requests", failures[0], request.numberOfActions());
+            }
+        }
+
+        @Override public void afterBulk(long executionId, BulkRequest request, Throwable failure) {
+            logger.warn("Got a hard failure when executing the bulk request", failure);
+        }
+    }
+
+    /**
+     * Create an index
+     * @param index index name
+     * @param ignoreErrors don't fail if the index already exists
+     * @param indexSettings index settings if any
+     * @throws IOException In case of error
+     */
+    public void createIndex(String index, boolean ignoreErrors, String indexSettings) throws IOException {
+        logger.debug("create index [{}]", index);
+        logger.trace("index settings: [{}]", indexSettings);
+        CreateIndexRequest cir = new CreateIndexRequest(index);
+        if (!isNullOrEmpty(indexSettings)) {
+            cir.source(indexSettings, XContentType.JSON);
+        }
+        try {
+            client.indices().create(cir, RequestOptions.DEFAULT);
+        } catch (ElasticsearchStatusException e) {
+            if (e.getMessage().contains("resource_already_exists_exception") && !ignoreErrors) {
+                throw new RuntimeException("index already exists");
+            }
+        }
+    }
+
+    /**
+     * Check if an index exists
+     * @param index index name
+     * @return true if the index exists, false otherwise
+     * @throws IOException In case of error
+     */
+    public boolean isExistingIndex(String index) throws IOException {
+        logger.debug("is existing index [{}]", index);
+        GetIndexRequest gir = new GetIndexRequest();
+        gir.indices(index);
+        return client.indices().exists(gir, RequestOptions.DEFAULT);
+    }
+
+    /**
+     * Check if a pipeline exists
+     * @param pipelineName pipeline name
+     * @return true if the pipeline exists, false otherwise
+     * @throws IOException In case of error
+     */
+    public boolean isExistingPipeline(String pipelineName) throws IOException {
+        logger.debug("is existing pipeline [{}]", pipelineName);
+        try {
+            return client.ingest().getPipeline(new GetPipelineRequest(pipelineName), RequestOptions.DEFAULT).isFound();
+        } catch (ElasticsearchStatusException e) {
+            if (e.status().getStatus() == 404) {
+                return false;
+            }
+            throw new IOException(e);
+        }
+    }
+
+    /**
+     * Refresh an index
+     * @param index index name
+     * @throws IOException In case of error
+     */
+    public void refresh(String index) throws IOException {
+        logger.debug("refresh index [{}]", index);
+        RefreshRequest request = new RefreshRequest();
+        if (!isNullOrEmpty(index)) {
+            request.indices(index);
+        }
+        RefreshResponse refresh = client.indices().refresh(request, RequestOptions.DEFAULT);
+        logger.trace("refresh response: {}", refresh);
+    }
+
+    /**
+     * Wait for an index to become at least yellow (all primaries assigned)
+     * @param index index name
+     * @throws IOException In case of error
+     */
+    public void waitForHealthyIndex(String index) throws IOException {
+        logger.debug("wait for yellow health on index [{}]", index);
+        ClusterHealthResponse health = client.cluster().health(new ClusterHealthRequest(index).waitForYellowStatus(),
+                RequestOptions.DEFAULT);
+        logger.trace("health response: {}", health);
+    }
+
+    /**
+     * Reindex data from one index/type to another index
+     * @param sourceIndex source index name
+     * @param sourceType source type name
+     * @param targetIndex target index name
+     * @return The number of documents that have been reindexed
+     * @throws IOException In case of error
+     */
+    public int reindex(String sourceIndex, String sourceType, String targetIndex) throws IOException {
+        logger.debug("reindex [{}]/[{}] -> [{}]/[doc]", sourceIndex, sourceType, targetIndex);
+
+        String reindexQuery = "{  \"source\": {\n" +
+                "    \"index\": \"" + sourceIndex + "\",\n" +
+                "    \"type\": \"" + sourceType + "\"\n" +
+                "  },\n" +
+                "  \"dest\": {\n" +
+                "    \"index\": \"" + targetIndex + "\",\n" +
+                "    \"type\": \"doc\"\n" +
+                "  }\n" +
+                "}\n";
+
+        logger.trace("{}", reindexQuery);
+
+        Request request = new Request("POST", "/_reindex");
+        request.setJsonEntity(reindexQuery);
+
+        Response restResponse = client.getLowLevelClient().performRequest(request);
+        Map<String, Object> response = asMap(restResponse);
+        logger.debug("reindex response: {}", response);
+
+        return (int) response.get("total");
+    }
+
+    /**
+     * Fully removes a type from an index (removes data)
+     * @param index index name
+     * @param type type
+     * @throws IOException In case of error
+     */
+    public void deleteByQuery(String index, String type) throws IOException {
+        logger.debug("deleteByQuery [{}]/[{}]", index, type);
+
+        String deleteByQuery = "{\n" +
+                "  \"query\": {\n" +
+                "    \"match_all\": {}\n" +
+                "  }\n" +
+                "}";
+
+        Request request = new Request("POST", "/" + index + "/" + type + "/_delete_by_query");
+        request.setJsonEntity(deleteByQuery);
+        Response restResponse = client.getLowLevelClient().performRequest(request);
+        Map<String, Object> response = asMap(restResponse);
+        logger.debug("reindex response: {}", response);
+    }
+
+    // Utility methods
+
+    public boolean isIngestSupported() {
+        return true;
+    }
+
+    public String getDefaultTypeName() {
+        return INDEX_TYPE_DOC;
+    }
+
+    @Override
+    public void index(String index, String type, String id, String json, String pipeline) {
+        bulkProcessor.add(new IndexRequest(index, type, id).setPipeline(pipeline).source(json, XContentType.JSON));
+    }
+
+    @Override
+    public void indexSingle(String index, String type, String id, String json) throws IOException {
+        IndexRequest request = new IndexRequest(index, type, id);
+        request.source(json, XContentType.JSON);
+        client.index(request, RequestOptions.DEFAULT);
+    }
+
+    @Override
+    public void delete(String index, String type, String id) {
+        bulkProcessor.add(new DeleteRequest(index, type, id));
+    }
+
+    @Override
+    public void close() throws IOException {
+        logger.debug("Closing Elasticsearch client manager");
+        if (bulkProcessor != null) {
+            try {
+                bulkProcessor.awaitClose(30, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                logger.warn("Did not succeed in closing the bulk processor for documents", e);
+                throw new IOException(e);
+            }
+        }
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    private static RestClientBuilder buildRestClient(Elasticsearch settings) {
+        List<HttpHost> hosts = new ArrayList<>(settings.getNodes().size());
+        settings.getNodes().forEach(node -> hosts.add(HttpHost.create(node.getDecodedUrl())));
+
+        RestClientBuilder builder = RestClient.builder(hosts.toArray(new HttpHost[hosts.size()]));
+
+        if (settings.getUsername() != null) {
+            CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+            credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(settings.getUsername(), settings.getPassword()));
+            builder.setHttpClientConfigCallback(httpClientBuilder ->
+                    httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider));
+        }
+
+        return builder;
+    }
+
+    public void createIndices() throws Exception {
+        String elasticsearchVersion;
+        Path jobMappingDir = config.resolve(settings.getName()).resolve("_mappings");
+
+        // Let's read the current version of elasticsearch cluster
+        Version version = client.info(RequestOptions.DEFAULT).getVersion();
+        logger.debug("FS crawler connected to an elasticsearch [{}] node.", version.toString());
+
+        elasticsearchVersion = Byte.toString(version.major);
+
+        // If needed, we create the new settings for this files index
+        if (!settings.getFs().isAddAsInnerObject() || (!settings.getFs().isJsonSupport() && !settings.getFs().isXmlSupport())) {
+            createIndex(jobMappingDir, elasticsearchVersion, INDEX_SETTINGS_FILE, settings.getElasticsearch().getIndex());
+        } else {
+            createIndex(settings.getElasticsearch().getIndex(), true, null);
+        }
+
+        // If needed, we create the new settings for this folder index
+        if (settings.getFs().isIndexFolders()) {
+            createIndex(jobMappingDir, elasticsearchVersion, INDEX_SETTINGS_FOLDER_FILE, settings.getElasticsearch().getIndexFolder());
+        } else {
+            createIndex(settings.getElasticsearch().getIndexFolder(), true, null);
+        }
+    }
+
+    @Override
+    public ESSearchResponse search(ESSearchRequest request) throws IOException {
+
+        SearchRequest searchRequest = new SearchRequest();
+        if (!isNullOrEmpty(request.getIndex())) {
+            searchRequest.indices(request.getIndex());
+        }
+
+        SearchSourceBuilder ssb = new SearchSourceBuilder();
+        if (request.getSize() != null) {
+            ssb.size(request.getSize());
+        }
+        if (!request.getFields().isEmpty()) {
+            ssb.storedFields(request.getFields());
+        }
+        if (request.getESQuery() != null) {
+            ssb.query(toElasticsearchQuery(request.getESQuery()));
+        }
+        if (!isNullOrEmpty(request.getSort())) {
+            ssb.sort(request.getSort());
+        }
+        for (String highlighter : request.getHighlighters()) {
+            ssb.highlighter(new HighlightBuilder().field(highlighter));
+        }
+        for (ESTermsAggregation aggregation : request.getAggregations()) {
+            ssb.aggregation(AggregationBuilders.terms(aggregation.getName()).field(aggregation.getField()));
+        }
+
+        searchRequest.source(ssb);
+        searchRequest.indicesOptions(LENIENT_EXPAND_OPEN);
+
+        SearchResponse response = client.search(searchRequest, RequestOptions.DEFAULT);
+        ESSearchResponse esSearchResponse = new ESSearchResponse();
+        if (response.getHits() != null) {
+            for (SearchHit hit : response.getHits()) {
+                ESSearchHit esSearchHit = new ESSearchHit();
+                if (!hit.getFields().isEmpty()) {
+                    Map<String, ESDocumentField> esFields = new HashMap<>();
+                    for (Map.Entry<String, DocumentField> entry : hit.getFields().entrySet()) {
+                        esFields.put(entry.getKey(), new ESDocumentField(entry.getKey(), entry.getValue().getValues()));
+                    }
+                    esSearchHit.setFields(esFields);
+                }
+                esSearchHit.setIndex(hit.getIndex());
+                esSearchHit.setId(hit.getId());
+                esSearchHit.setSourceAsMap(hit.getSourceAsMap());
+                esSearchHit.setSourceAsString(hit.getSourceAsString());
+
+                hit.getHighlightFields().forEach((key, value) -> {
+                    String[] texts = new String[value.fragments().length];
+                    for (int i = 0; i < value.fragments().length; i++) {
+                        Text fragment = value.fragments()[i];
+                        texts[i] = fragment.string();
+                    }
+                    esSearchHit.addHighlightField(key, new ESHighlightField(key, texts));
+                });
+
+                esSearchResponse.addHit(esSearchHit);
+            }
+
+            esSearchResponse.setTotalHits(response.getHits().getTotalHits().value);
+
+            if (response.getAggregations() != null) {
+                for (String name : response.getAggregations().asMap().keySet()) {
+                    Terms termsAgg = response.getAggregations().get(name);
+                    ESTermsAggregation aggregation = new ESTermsAggregation(name, null);
+                    for (Terms.Bucket bucket : termsAgg.getBuckets()) {
+                        aggregation.addBucket(new ESTermsAggregation.ESTermsBucket(bucket.getKeyAsString(), bucket.getDocCount()));
+                    }
+                    esSearchResponse.addAggregation(name, aggregation);
+                }
+            }
+        }
+
+        return esSearchResponse;
+    }
+
+    private QueryBuilder toElasticsearchQuery(ESQuery query) {
+        if (query instanceof ESTermQuery) {
+            ESTermQuery esQuery = (ESTermQuery) query;
+            return QueryBuilders.termQuery(esQuery.getField(), esQuery.getValue());
+        }
+        if (query instanceof ESMatchQuery) {
+            ESMatchQuery esQuery = (ESMatchQuery) query;
+            return QueryBuilders.matchQuery(esQuery.getField(), esQuery.getValue());
+        }
+        if (query instanceof ESPrefixQuery) {
+            ESPrefixQuery esQuery = (ESPrefixQuery) query;
+            return QueryBuilders.prefixQuery(esQuery.getField(), esQuery.getValue());
+        }
+        if (query instanceof ESRangeQuery) {
+            ESRangeQuery esQuery = (ESRangeQuery) query;
+            RangeQueryBuilder rangeQuery = QueryBuilders.rangeQuery(esQuery.getField());
+            if (esQuery.getFrom() != null) {
+                rangeQuery.from(esQuery.getFrom());
+            }
+            if (esQuery.getTo() != null) {
+                rangeQuery.to(esQuery.getTo());
+            }
+            return rangeQuery;
+        }
+        if (query instanceof ESBoolQuery) {
+            ESBoolQuery esQuery = (ESBoolQuery) query;
+            BoolQueryBuilder boolQuery = QueryBuilders.boolQuery();
+            for (ESQuery clause : esQuery.getMustClauses()) {
+                boolQuery.must(toElasticsearchQuery(clause));
+            }
+            return boolQuery;
+        }
+        throw new IllegalArgumentException("Query " + query.getClass().getSimpleName() + " not implemented yet");
+    }
+
+    @Override
+    public void deleteIndex(String index) throws IOException {
+        client.indices().delete(new DeleteIndexRequest(index), RequestOptions.DEFAULT);
+    }
+
+    @Override
+    public void flush() {
+        bulkProcessor.flush();
+    }
+
+    @Override
+    public void performLowLevelRequest(String method, String endpoint, String jsonEntity) throws IOException {
+        Request request = new Request(method, endpoint);
+        if (!isNullOrEmpty(jsonEntity)) {
+            request.setJsonEntity(jsonEntity);
+        }
+
+        client.getLowLevelClient().performRequest(request);
+    }
+
+    @Override
+    public ESSearchHit get(String index, String type, String id) throws IOException {
+        GetRequest request = new GetRequest(index, type, id);
+        GetResponse response = client.get(request, RequestOptions.DEFAULT);
+        ESSearchHit hit = new ESSearchHit();
+        hit.setIndex(response.getIndex());
+        hit.setId(response.getId());
+        hit.setVersion(response.getVersion());
+        hit.setSourceAsMap(response.getSourceAsMap());
+        return hit;
+    }
+
+    @Override
+    public boolean exists(String index, String type, String id) throws IOException {
+        return client.exists(new GetRequest(index, type, id), RequestOptions.DEFAULT);
+    }
+
+    private void createIndex(Path jobMappingDir, String elasticsearchVersion, String indexSettingsFile, String indexName) throws Exception {
+        try {
+            // If needed, we create the new settings for this files index
+            String indexSettings = readJsonFile(jobMappingDir, config, elasticsearchVersion, indexSettingsFile);
+
+            createIndex(indexName, true, indexSettings);
+        } catch (Exception e) {
+            logger.warn("failed to create index [{}], disabling crawler...", indexName);
+            throw e;
+        }
+    }
+
+    static Map<String, Object> asMap(Response response) {
+        try {
+            if (response.getEntity() == null) {
+                return null;
+            }
+            return JsonUtil.asMap(response.getEntity().getContent());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/elasticsearch-client/elasticsearch-client-v7/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v7/ElasticsearchClientV7.java
+++ b/elasticsearch-client/elasticsearch-client-v7/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v7/ElasticsearchClientV7.java
@@ -362,20 +362,20 @@ public class ElasticsearchClientV7 implements ElasticsearchClient {
     }
 
     @Override
-    public void index(String index, String type, String id, String json, String pipeline) {
-        bulkProcessor.add(new IndexRequest(index, type, id).setPipeline(pipeline).source(json, XContentType.JSON));
+    public void index(String index, String id, String json, String pipeline) {
+        bulkProcessor.add(new IndexRequest(index, getDefaultTypeName(), id).setPipeline(pipeline).source(json, XContentType.JSON));
     }
 
     @Override
-    public void indexSingle(String index, String type, String id, String json) throws IOException {
-        IndexRequest request = new IndexRequest(index, type, id);
+    public void indexSingle(String index, String id, String json) throws IOException {
+        IndexRequest request = new IndexRequest(index, getDefaultTypeName(), id);
         request.source(json, XContentType.JSON);
         client.index(request, RequestOptions.DEFAULT);
     }
 
     @Override
-    public void delete(String index, String type, String id) {
-        bulkProcessor.add(new DeleteRequest(index, type, id));
+    public void delete(String index, String id) {
+        bulkProcessor.add(new DeleteRequest(index, id));
     }
 
     @Override
@@ -568,8 +568,8 @@ public class ElasticsearchClientV7 implements ElasticsearchClient {
     }
 
     @Override
-    public ESSearchHit get(String index, String type, String id) throws IOException {
-        GetRequest request = new GetRequest(index, type, id);
+    public ESSearchHit get(String index, String id) throws IOException {
+        GetRequest request = new GetRequest(index, id);
         GetResponse response = client.get(request, RequestOptions.DEFAULT);
         ESSearchHit hit = new ESSearchHit();
         hit.setIndex(response.getIndex());
@@ -580,8 +580,8 @@ public class ElasticsearchClientV7 implements ElasticsearchClient {
     }
 
     @Override
-    public boolean exists(String index, String type, String id) throws IOException {
-        return client.exists(new GetRequest(index, type, id), RequestOptions.DEFAULT);
+    public boolean exists(String index, String id) throws IOException {
+        return client.exists(new GetRequest(index, id), RequestOptions.DEFAULT);
     }
 
     private void createIndex(Path jobMappingDir, String elasticsearchVersion, String indexSettingsFile, String indexName) throws Exception {

--- a/elasticsearch-client/elasticsearch-client-v7/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/v7/ElasticsearchClientV7Test.java
+++ b/elasticsearch-client/elasticsearch-client-v7/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/v7/ElasticsearchClientV7Test.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package fr.pilato.elasticsearch.crawler.fs.client.v7;
+
+import fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchClient;
+import fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchClientUtil;
+import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
+import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class ElasticsearchClientV7Test extends AbstractFSCrawlerTestCase {
+
+    @Test(expected = NullPointerException.class)
+    public void testGetInstanceWithNullSettings() {
+        ElasticsearchClientUtil.getInstance(null, null);
+    }
+
+    @Test
+    public void testGetInstance() {
+        ElasticsearchClient instance = ElasticsearchClientUtil.getInstance(null, FsSettings.builder("foo").build());
+        assertThat(instance, instanceOf(ElasticsearchClientV7.class));
+    }
+}

--- a/elasticsearch-client/elasticsearch-client-v7/src/test/resources/log4j2.xml
+++ b/elasticsearch-client/elasticsearch-client-v7/src/test/resources/log4j2.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="fatal">
+   <Appenders>
+      <Console name="CONSOLE" target="SYSTEM_OUT">
+         <PatternLayout pattern="%d{ABSOLUTE} %highlight{%-5p} [%c{1.}] %m%n"/>
+      </Console>
+   </Appenders>
+   <Loggers>
+      <Logger name="fr.pilato.elasticsearch.crawler.fs" level="info" additivity="false">
+         <AppenderRef ref="CONSOLE"/>
+      </Logger>
+      <Logger name="fr.pilato.elasticsearch.crawler.fs.client" level="info" additivity="false">
+         <AppenderRef ref="CONSOLE"/>
+      </Logger>
+      <Root level="info">
+         <AppenderRef ref="CONSOLE"/>
+      </Root>
+   </Loggers>
+</Configuration>

--- a/elasticsearch-client/pom.xml
+++ b/elasticsearch-client/pom.xml
@@ -15,6 +15,7 @@
 
     <modules>
         <module>elasticsearch-client-base</module>
+        <module>elasticsearch-client-v7</module>
         <module>elasticsearch-client-v6</module>
         <module>elasticsearch-client-v5</module>
     </modules>

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/FsCrawlerUtil.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/FsCrawlerUtil.java
@@ -425,7 +425,8 @@ public class FsCrawlerUtil {
     public static final String[] MAPPING_RESOURCES = {
             "2/_settings.json", "2/_settings_folder.json",
             "5/_settings.json", "5/_settings_folder.json",
-            "6/_settings.json", "6/_settings_folder.json"
+            "6/_settings.json", "6/_settings_folder.json",
+            "7/_settings.json", "7/_settings_folder.json"
     };
 
     /**

--- a/integration-tests/it-common/pom.xml
+++ b/integration-tests/it-common/pom.xml
@@ -67,6 +67,19 @@
     <profiles>
         <!-- We are building a profile that can be activated from the IDE -->
         <profile>
+            <id>es-7x</id>
+            <properties>
+                <integ.elasticsearch.version>${elasticsearch7.version}</integ.elasticsearch.version>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>fr.pilato.elasticsearch.crawler</groupId>
+                    <artifactId>fscrawler-elasticsearch-client-v7</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <!-- We are building a profile that can be activated from the IDE -->
+        <profile>
             <id>es-6x</id>
             <properties>
                 <integ.elasticsearch.version>${elasticsearch6.version}</integ.elasticsearch.version>

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
@@ -100,8 +100,6 @@ public abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
 
     static Path metadataDir = null;
 
-    static String typeName;
-
     FsCrawlerImpl crawler = null;
     Path currentTestResourceDir;
 
@@ -260,8 +258,6 @@ public abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
 
         // We make sure the cluster is running
         testClusterRunning();
-
-        typeName = esClient.getDefaultTypeName();
     }
 
     @BeforeClass

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/ElasticsearchClientIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/ElasticsearchClientIT.java
@@ -96,8 +96,8 @@ public class ElasticsearchClientIT extends AbstractITCase {
         esClient.createIndex(getCrawlerName(), false, null);
         esClient.waitForHealthyIndex(getCrawlerName());
 
-        esClient.indexSingle(getCrawlerName(), "doc", "1", "{ \"foo\": { \"bar\": \"bar\" } }");
-        esClient.indexSingle(getCrawlerName(), "doc", "2", "{ \"foo\": { \"bar\": \"baz\" } }");
+        esClient.indexSingle(getCrawlerName(), "1", "{ \"foo\": { \"bar\": \"bar\" } }");
+        esClient.indexSingle(getCrawlerName(), "2", "{ \"foo\": { \"bar\": \"baz\" } }");
 
         esClient.refresh(getCrawlerName());
 

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/ElasticsearchClientIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/ElasticsearchClientIT.java
@@ -57,9 +57,11 @@ public class ElasticsearchClientIT extends AbstractITCase {
     @Test
     public void testCreateIndexWithSettings() throws IOException {
         esClient.createIndex(getCrawlerName(), false, "{\n" +
-                "  \"number_of_shards\": 1,\n" +
-                "  \"number_of_replicas\": 1\n" +
-                "}");
+                "  \"settings\": {\n" +
+                "    \"number_of_shards\": 1,\n" +
+                "    \"number_of_replicas\": 1\n" +
+                "  }\n" +
+                "}\n");
         boolean exists = esClient.isExistingIndex(getCrawlerName());
         assertThat(exists, is(true));
     }
@@ -113,11 +115,21 @@ public class ElasticsearchClientIT extends AbstractITCase {
         ESVersion version = esClient.getVersion();
         logger.info("Current elasticsearch version: [{}]", version);
 
-        // If we did not use an external URL but the docker instance we can test for sure that the version is the expected one
-        if (System.getProperty("tests.cluster.host") == null) {
-            Properties properties = readPropertiesFromClassLoader("elasticsearch.version.properties");
-            assertThat(version.toString(), is(properties.getProperty("version")));
+        // TODO Remove that code when final 7.0.0 is out
+        // For now a 7.0.0-alpha2 says it's a 7.0.0 version
+        if (version.major == 7) {
+            // If we did not use an external URL but the docker instance we can test for sure that the version is the expected one
+            if (System.getProperty("tests.cluster.url") == null) {
+                assertThat(version.toString(), is("7.0.0"));
+            }
+        } else {
+            // If we did not use an external URL but the docker instance we can test for sure that the version is the expected one
+            if (System.getProperty("tests.cluster.url") == null) {
+                Properties properties = readPropertiesFromClassLoader("elasticsearch.version.properties");
+                assertThat(version.toString(), is(properties.getProperty("version")));
+            }
         }
+
     }
 
     @Test

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerTestFilenameAsIdIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerTestFilenameAsIdIT.java
@@ -46,7 +46,7 @@ public class FsCrawlerTestFilenameAsIdIT extends AbstractFsCrawlerITCase {
 
         assertThat("Document should exists with [roottxtfile.txt] id...", awaitBusy(() -> {
             try {
-                return esClient.exists(getCrawlerName(), typeName, "roottxtfile.txt");
+                return esClient.exists(getCrawlerName(), "roottxtfile.txt");
             } catch (IOException e) {
                 return false;
             }
@@ -69,14 +69,14 @@ public class FsCrawlerTestFilenameAsIdIT extends AbstractFsCrawlerITCase {
 
         assertThat("Document should exists with [id1.txt] id...", awaitBusy(() -> {
             try {
-                return esClient.exists(getCrawlerName(), typeName, "id1.txt");
+                return esClient.exists(getCrawlerName(), "id1.txt");
             } catch (IOException e) {
                 return false;
             }
         }), equalTo(true));
         assertThat("Document should exists with [id2.txt] id...", awaitBusy(() -> {
             try {
-                return esClient.exists(getCrawlerName(), typeName, "id2.txt");
+                return esClient.exists(getCrawlerName(), "id2.txt");
             } catch (IOException e) {
                 return false;
             }

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerTestRawIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerTestRawIT.java
@@ -67,8 +67,8 @@ public class FsCrawlerTestRawIT extends AbstractFsCrawlerITCase {
 
         // This will cause an Elasticsearch Exception as the String is not a Date
         // If the mapping is incorrect
-        esClient.index(getCrawlerName(), typeName, "1", json1, null);
-        esClient.index(getCrawlerName(), typeName, "2", json2, null);
+        esClient.index(getCrawlerName(), "1", json1, null);
+        esClient.index(getCrawlerName(), "2", json2, null);
         esClient.flush();
     }
 

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerTestRemoveDeletedIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerTestRemoveDeletedIT.java
@@ -232,7 +232,7 @@ public class FsCrawlerTestRemoveDeletedIT extends AbstractFsCrawlerITCase {
         for (ESSearchHit hit : response.getHits()) {
             // Read the document. This is needed since 5.0 as search does not return the _version field
             try {
-                ESSearchHit getHit = esClient.get(hit.getIndex(), typeName, hit.getId());
+                ESSearchHit getHit = esClient.get(hit.getIndex(), hit.getId());
                 assertThat(getHit.getVersion(), lessThanOrEqualTo(maxVersion));
             } catch (IOException e) {
                 fail("We got an IOException: " + e.getMessage());

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerTestUpgradeVersionIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerTestUpgradeVersionIT.java
@@ -50,10 +50,10 @@ public class FsCrawlerTestUpgradeVersionIT extends AbstractFsCrawlerITCase {
 
         // Create fake data
         for (int i = 0; i < nbDocs; i++) {
-            esClient.index(getCrawlerName(), "doc", "id" + i, "{\"foo\":\"bar\"}", null);
+            esClient.performLowLevelRequest("PUT", "/" + getCrawlerName() + "/doc/id" + i, "{\"foo\":\"bar\"}");
         }
         for (int i = 0; i < nbFolders; i++) {
-            esClient.index(getCrawlerName(), "folder", "id" + i, "{\"foo\":\"bar\"}", null);
+            esClient.performLowLevelRequest("PUT", "/" + getCrawlerName() + "/folder/id" + i, "{\"foo\":\"bar\"}");
         }
         esClient.flush();
 

--- a/integration-tests/it-v7/pom.xml
+++ b/integration-tests/it-v7/pom.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>fr.pilato.elasticsearch.crawler</groupId>
+        <artifactId>fscrawler-it</artifactId>
+        <version>2.7-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>fscrawler-it-v7</artifactId>
+    <name>FSCrawler Integration Tests for Elasticsearch 7.x</name>
+
+    <properties>
+        <integ.elasticsearch.version>${elasticsearch7.version}</integ.elasticsearch.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>fr.pilato.elasticsearch.crawler</groupId>
+            <artifactId>fscrawler-it-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>fr.pilato.elasticsearch.crawler</groupId>
+            <artifactId>fscrawler-elasticsearch-client-v7</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <!-- We don't deploy our IT artifact to maven central -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <!-- We don't deploy our IT artifact to maven central -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <!-- We don't deploy our IT artifact to maven central -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <!-- This is a hack because there's no direct support of dependenciesToScan.
+            See https://github.com/randomizedtesting/randomizedtesting/issues/254 -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>add-test-source</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>../it-common/src/main/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-resource</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>add-test-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>../it-common/src/main/resources</directory>
+                                    <filtering>true</filtering>
+                                </resource>
+                                <resource>
+                                    <directory>../it-common/src/main/resources-binary</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- To start Docker when running IT -->
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>com.carrotsearch.randomizedtesting</groupId>
+                <artifactId>junit4-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <!-- There is no unit test so we can skip that execution -->
+                        <id>unit-tests</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>skip-fabric8</id>
+            <activation>
+                <property>
+                    <name>tests.cluster.url</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>run-fabric8</id>
+            <activation>
+                <property>
+                    <name>!tests.cluster.url</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <skip>${skipIntegTests}</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -15,6 +15,7 @@
 
     <modules>
         <module>it-common</module>
+        <module>it-v7</module>
         <module>it-v6</module>
         <module>it-v5</module>
     </modules>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <!--suppress CheckTagEmptyBody -->
     <properties>
         <elasticsearch.version>6.5.3</elasticsearch.version>
+        <elasticsearch7.version>7.0.0-alpha2</elasticsearch7.version>
         <elasticsearch6.version>${elasticsearch.version}</elasticsearch6.version>
         <elasticsearch5.version>5.6.11</elasticsearch5.version>
 
@@ -247,6 +248,9 @@
                                 <name>dadoonet/docker-elasticsearch:${project.version}</name>
                                 <build>
                                     <from>${integ.elasticsearch.image}:${integ.elasticsearch.version}</from>
+                                    <env>
+                                        <discovery.type>single-node</discovery.type>
+                                    </env>
                                 </build>
                                 <run>
                                     <ports>
@@ -426,6 +430,11 @@
             <dependency>
                 <groupId>fr.pilato.elasticsearch.crawler</groupId>
                 <artifactId>fscrawler-elasticsearch-client-v6</artifactId>
+                <version>2.7-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>fr.pilato.elasticsearch.crawler</groupId>
+                <artifactId>fscrawler-elasticsearch-client-v7</artifactId>
                 <version>2.7-SNAPSHOT</version>
             </dependency>
             <dependency>

--- a/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/UploadApi.java
+++ b/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/UploadApi.java
@@ -115,7 +115,6 @@ public class UploadApi extends RestApi {
             doc = this.getMergedJsonDoc(doc, tags);
             esClient.index(
                     settings.getElasticsearch().getIndex(),
-                    esClient.getDefaultTypeName(),
                     id,
                     DocParser.toJson(doc),
                     settings.getElasticsearch().getPipeline());

--- a/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/7/_settings.json
+++ b/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/7/_settings.json
@@ -1,0 +1,216 @@
+{
+  "settings": {
+    "number_of_shards": 1,
+    "index.mapping.total_fields.limit": 2000,
+    "analysis": {
+      "analyzer": {
+        "fscrawler_path": {
+          "tokenizer": "fscrawler_path"
+        }
+      },
+      "tokenizer": {
+        "fscrawler_path": {
+          "type": "path_hierarchy"
+        }
+      }
+    }
+  },
+  "mappings": {
+    "_doc": {
+      "dynamic_templates": [
+        {
+          "raw_as_text": {
+            "path_match": "meta.raw.*",
+            "mapping": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            }
+          }
+        }
+      ],
+      "properties": {
+        "attachment": {
+          "type": "binary",
+          "doc_values": false
+        },
+        "attributes": {
+          "properties": {
+            "group": {
+              "type": "keyword"
+            },
+            "owner": {
+              "type": "keyword"
+            }
+          }
+        },
+        "content": {
+          "type": "text"
+        },
+        "file": {
+          "properties": {
+            "content_type": {
+              "type": "keyword"
+            },
+            "filename": {
+              "type": "keyword",
+              "store": true
+            },
+            "extension": {
+              "type": "keyword"
+            },
+            "filesize": {
+              "type": "long"
+            },
+            "indexed_chars": {
+              "type": "long"
+            },
+            "indexing_date": {
+              "type": "date",
+              "format": "dateOptionalTime"
+            },
+            "created": {
+              "type": "date",
+              "format": "dateOptionalTime"
+            },
+            "last_modified": {
+              "type": "date",
+              "format": "dateOptionalTime"
+            },
+            "last_accessed": {
+              "type": "date",
+              "format": "dateOptionalTime"
+            },
+            "checksum": {
+              "type": "keyword"
+            },
+            "url": {
+              "type": "keyword",
+              "index": false
+            }
+          }
+        },
+        "meta": {
+          "properties": {
+            "author": {
+              "type": "text"
+            },
+            "date": {
+              "type": "date",
+              "format": "dateOptionalTime"
+            },
+            "keywords": {
+              "type": "text"
+            },
+            "title": {
+              "type": "text"
+            },
+            "language": {
+              "type": "keyword"
+            },
+            "format": {
+              "type": "text"
+            },
+            "identifier": {
+              "type": "text"
+            },
+            "contributor": {
+              "type": "text"
+            },
+            "coverage": {
+              "type": "text"
+            },
+            "modifier": {
+              "type": "text"
+            },
+            "creator_tool": {
+              "type": "keyword"
+            },
+            "publisher": {
+              "type": "text"
+            },
+            "relation": {
+              "type": "text"
+            },
+            "rights": {
+              "type": "text"
+            },
+            "source": {
+              "type": "text"
+            },
+            "type": {
+              "type": "text"
+            },
+            "description": {
+              "type": "text"
+            },
+            "created": {
+              "type": "date",
+              "format": "dateOptionalTime"
+            },
+            "print_date": {
+              "type": "date",
+              "format": "dateOptionalTime"
+            },
+            "metadata_date": {
+              "type": "date",
+              "format": "dateOptionalTime"
+            },
+            "latitude": {
+              "type": "text"
+            },
+            "longitude": {
+              "type": "text"
+            },
+            "altitude": {
+              "type": "text"
+            },
+            "rating": {
+              "type": "byte"
+            },
+            "comments": {
+              "type": "text"
+            }
+          }
+        },
+        "path": {
+          "properties": {
+            "real": {
+              "type": "keyword",
+              "fields": {
+                "tree": {
+                  "type": "text",
+                  "analyzer": "fscrawler_path",
+                  "fielddata": true
+                },
+                "fulltext": {
+                  "type": "text"
+                }
+              }
+            },
+            "root": {
+              "type": "keyword"
+            },
+            "virtual": {
+              "type": "keyword",
+              "fields": {
+                "tree": {
+                  "type": "text",
+                  "analyzer": "fscrawler_path",
+                  "fielddata": true
+                },
+                "fulltext": {
+                  "type": "text"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/7/_settings_folder.json
+++ b/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/7/_settings_folder.json
@@ -1,0 +1,34 @@
+{
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "fscrawler_path": {
+          "tokenizer": "fscrawler_path"
+        }
+      },
+      "tokenizer": {
+        "fscrawler_path": {
+          "type": "path_hierarchy"
+        }
+      }
+    }
+  },
+  "mappings": {
+    "_doc": {
+      "properties" : {
+        "real" : {
+          "type" : "keyword",
+          "store" : true
+        },
+        "root" : {
+          "type" : "keyword",
+          "store" : true
+        },
+        "virtual" : {
+          "type" : "keyword",
+          "store" : true
+        }
+      }
+    }
+  }
+}

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsCopyResourcesTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsCopyResourcesTest.java
@@ -76,15 +76,16 @@ public class FsCopyResourcesTest extends AbstractFSCrawlerTestCase {
                     }
                 });
 
-        // We have 5 dirs for now:
+        // We have 6 dirs for now:
         // root test dir ".fscrawler-test-copy-resources"
         // "_default" dir
         // "2" for elasticsearch version 2
         // "5" for elasticsearch version 5
         // "6" for elasticsearch version 6
-        assertThat(dirCounter.get(), is(5));
+        // "7" for elasticsearch version 7
+        assertThat(dirCounter.get(), is(6));
 
         // We have 2 files that must be copied per version: _settings_folder.json and _settings_doc.json
-        assertThat(fileCounter.get(), is(6));
+        assertThat(fileCounter.get(), is(8));
     }
 }

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsMappingTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsMappingTest.java
@@ -46,7 +46,7 @@ public class FsMappingTest extends AbstractFSCrawlerMetadataTestCase {
     private static final String CLASSPATH_RESOURCES_ROOT = "/jobtest/";
 
     @BeforeClass
-    public static void generateSpecificJobMappings() throws IOException, URISyntaxException {
+    public static void generateSpecificJobMappings() throws IOException {
         Path targetResourceDir = metadataDir.resolve("jobtest").resolve("_mappings");
 
         for (String filename : MAPPING_RESOURCES) {
@@ -893,6 +893,284 @@ public class FsMappingTest extends AbstractFSCrawlerMetadataTestCase {
         } catch (IllegalArgumentException ignored) {
             assertThat(ignored.getMessage(), containsString("does not exist for elasticsearch version"));
         }
+    }
+
+    @Test
+    public void fsSettingsForDocVersion7() throws Exception {
+        String settings = readJsonFile(rootTmpDir, metadataDir, "7", INDEX_SETTINGS_FILE);
+        logger.info("Settings used for doc index v7 : " + settings);
+        assertThat(settings, is("{\n" +
+                "  \"settings\": {\n" +
+                "    \"number_of_shards\": 1,\n" +
+                "    \"index.mapping.total_fields.limit\": 2000,\n" +
+                "    \"analysis\": {\n" +
+                "      \"analyzer\": {\n" +
+                "        \"fscrawler_path\": {\n" +
+                "          \"tokenizer\": \"fscrawler_path\"\n" +
+                "        }\n" +
+                "      },\n" +
+                "      \"tokenizer\": {\n" +
+                "        \"fscrawler_path\": {\n" +
+                "          \"type\": \"path_hierarchy\"\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  },\n" +
+                "  \"mappings\": {\n" +
+                "    \"_doc\": {\n" +
+                "      \"dynamic_templates\": [\n" +
+                "        {\n" +
+                "          \"raw_as_text\": {\n" +
+                "            \"path_match\": \"meta.raw.*\",\n" +
+                "            \"mapping\": {\n" +
+                "              \"type\": \"text\",\n" +
+                "              \"fields\": {\n" +
+                "                \"keyword\": {\n" +
+                "                  \"type\": \"keyword\",\n" +
+                "                  \"ignore_above\": 256\n" +
+                "                }\n" +
+                "              }\n" +
+                "            }\n" +
+                "          }\n" +
+                "        }\n" +
+                "      ],\n" +
+                "      \"properties\": {\n" +
+                "        \"attachment\": {\n" +
+                "          \"type\": \"binary\",\n" +
+                "          \"doc_values\": false\n" +
+                "        },\n" +
+                "        \"attributes\": {\n" +
+                "          \"properties\": {\n" +
+                "            \"group\": {\n" +
+                "              \"type\": \"keyword\"\n" +
+                "            },\n" +
+                "            \"owner\": {\n" +
+                "              \"type\": \"keyword\"\n" +
+                "            }\n" +
+                "          }\n" +
+                "        },\n" +
+                "        \"content\": {\n" +
+                "          \"type\": \"text\"\n" +
+                "        },\n" +
+                "        \"file\": {\n" +
+                "          \"properties\": {\n" +
+                "            \"content_type\": {\n" +
+                "              \"type\": \"keyword\"\n" +
+                "            },\n" +
+                "            \"filename\": {\n" +
+                "              \"type\": \"keyword\",\n" +
+                "              \"store\": true\n" +
+                "            },\n" +
+                "            \"extension\": {\n" +
+                "              \"type\": \"keyword\"\n" +
+                "            },\n" +
+                "            \"filesize\": {\n" +
+                "              \"type\": \"long\"\n" +
+                "            },\n" +
+                "            \"indexed_chars\": {\n" +
+                "              \"type\": \"long\"\n" +
+                "            },\n" +
+                "            \"indexing_date\": {\n" +
+                "              \"type\": \"date\",\n" +
+                "              \"format\": \"dateOptionalTime\"\n" +
+                "            },\n" +
+                "            \"created\": {\n" +
+                "              \"type\": \"date\",\n" +
+                "              \"format\": \"dateOptionalTime\"\n" +
+                "            },\n" +
+                "            \"last_modified\": {\n" +
+                "              \"type\": \"date\",\n" +
+                "              \"format\": \"dateOptionalTime\"\n" +
+                "            },\n" +
+                "            \"last_accessed\": {\n" +
+                "              \"type\": \"date\",\n" +
+                "              \"format\": \"dateOptionalTime\"\n" +
+                "            },\n" +
+                "            \"checksum\": {\n" +
+                "              \"type\": \"keyword\"\n" +
+                "            },\n" +
+                "            \"url\": {\n" +
+                "              \"type\": \"keyword\",\n" +
+                "              \"index\": false\n" +
+                "            }\n" +
+                "          }\n" +
+                "        },\n" +
+                "        \"meta\": {\n" +
+                "          \"properties\": {\n" +
+                "            \"author\": {\n" +
+                "              \"type\": \"text\"\n" +
+                "            },\n" +
+                "            \"date\": {\n" +
+                "              \"type\": \"date\",\n" +
+                "              \"format\": \"dateOptionalTime\"\n" +
+                "            },\n" +
+                "            \"keywords\": {\n" +
+                "              \"type\": \"text\"\n" +
+                "            },\n" +
+                "            \"title\": {\n" +
+                "              \"type\": \"text\"\n" +
+                "            },\n" +
+                "            \"language\": {\n" +
+                "              \"type\": \"keyword\"\n" +
+                "            },\n" +
+                "            \"format\": {\n" +
+                "              \"type\": \"text\"\n" +
+                "            },\n" +
+                "            \"identifier\": {\n" +
+                "              \"type\": \"text\"\n" +
+                "            },\n" +
+                "            \"contributor\": {\n" +
+                "              \"type\": \"text\"\n" +
+                "            },\n" +
+                "            \"coverage\": {\n" +
+                "              \"type\": \"text\"\n" +
+                "            },\n" +
+                "            \"modifier\": {\n" +
+                "              \"type\": \"text\"\n" +
+                "            },\n" +
+                "            \"creator_tool\": {\n" +
+                "              \"type\": \"keyword\"\n" +
+                "            },\n" +
+                "            \"publisher\": {\n" +
+                "              \"type\": \"text\"\n" +
+                "            },\n" +
+                "            \"relation\": {\n" +
+                "              \"type\": \"text\"\n" +
+                "            },\n" +
+                "            \"rights\": {\n" +
+                "              \"type\": \"text\"\n" +
+                "            },\n" +
+                "            \"source\": {\n" +
+                "              \"type\": \"text\"\n" +
+                "            },\n" +
+                "            \"type\": {\n" +
+                "              \"type\": \"text\"\n" +
+                "            },\n" +
+                "            \"description\": {\n" +
+                "              \"type\": \"text\"\n" +
+                "            },\n" +
+                "            \"created\": {\n" +
+                "              \"type\": \"date\",\n" +
+                "              \"format\": \"dateOptionalTime\"\n" +
+                "            },\n" +
+                "            \"print_date\": {\n" +
+                "              \"type\": \"date\",\n" +
+                "              \"format\": \"dateOptionalTime\"\n" +
+                "            },\n" +
+                "            \"metadata_date\": {\n" +
+                "              \"type\": \"date\",\n" +
+                "              \"format\": \"dateOptionalTime\"\n" +
+                "            },\n" +
+                "            \"latitude\": {\n" +
+                "              \"type\": \"text\"\n" +
+                "            },\n" +
+                "            \"longitude\": {\n" +
+                "              \"type\": \"text\"\n" +
+                "            },\n" +
+                "            \"altitude\": {\n" +
+                "              \"type\": \"text\"\n" +
+                "            },\n" +
+                "            \"rating\": {\n" +
+                "              \"type\": \"byte\"\n" +
+                "            },\n" +
+                "            \"comments\": {\n" +
+                "              \"type\": \"text\"\n" +
+                "            }\n" +
+                "          }\n" +
+                "        },\n" +
+                "        \"path\": {\n" +
+                "          \"properties\": {\n" +
+                "            \"real\": {\n" +
+                "              \"type\": \"keyword\",\n" +
+                "              \"fields\": {\n" +
+                "                \"tree\": {\n" +
+                "                  \"type\": \"text\",\n" +
+                "                  \"analyzer\": \"fscrawler_path\",\n" +
+                "                  \"fielddata\": true\n" +
+                "                },\n" +
+                "                \"fulltext\": {\n" +
+                "                  \"type\": \"text\"\n" +
+                "                }\n" +
+                "              }\n" +
+                "            },\n" +
+                "            \"root\": {\n" +
+                "              \"type\": \"keyword\"\n" +
+                "            },\n" +
+                "            \"virtual\": {\n" +
+                "              \"type\": \"keyword\",\n" +
+                "              \"fields\": {\n" +
+                "                \"tree\": {\n" +
+                "                  \"type\": \"text\",\n" +
+                "                  \"analyzer\": \"fscrawler_path\",\n" +
+                "                  \"fielddata\": true\n" +
+                "                },\n" +
+                "                \"fulltext\": {\n" +
+                "                  \"type\": \"text\"\n" +
+                "                }\n" +
+                "              }\n" +
+                "            }\n" +
+                "          }\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}\n"));
+    }
+
+    @Test
+    public void fsSettingsForFolderVersion7() throws Exception {
+        String settings = readJsonFile(rootTmpDir, metadataDir, "7", INDEX_SETTINGS_FOLDER_FILE);
+        logger.info("Settings used for folder index v7 : " + settings);
+        assertThat(settings, is("{\n" +
+                "  \"settings\": {\n" +
+                "    \"analysis\": {\n" +
+                "      \"analyzer\": {\n" +
+                "        \"fscrawler_path\": {\n" +
+                "          \"tokenizer\": \"fscrawler_path\"\n" +
+                "        }\n" +
+                "      },\n" +
+                "      \"tokenizer\": {\n" +
+                "        \"fscrawler_path\": {\n" +
+                "          \"type\": \"path_hierarchy\"\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  },\n" +
+                "  \"mappings\": {\n" +
+                "    \"_doc\": {\n" +
+                "      \"properties\" : {\n" +
+                "        \"real\" : {\n" +
+                "          \"type\" : \"keyword\",\n" +
+                "          \"store\" : true\n" +
+                "        },\n" +
+                "        \"root\" : {\n" +
+                "          \"type\" : \"keyword\",\n" +
+                "          \"store\" : true\n" +
+                "        },\n" +
+                "        \"virtual\" : {\n" +
+                "          \"type\" : \"keyword\",\n" +
+                "          \"store\" : true\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}\n"));
+    }
+
+    @Test
+    public void fsSettingsForDocSpecificJobVersion7() throws Exception {
+        String settings = readJsonFile(metadataDir.resolve("jobtest").resolve("_mappings"), metadataDir, "7", INDEX_SETTINGS_FILE);
+        assertThat(settings, is("{\n" +
+                "  // This is settings for version 7\n" +
+                "}\n"));
+    }
+
+    @Test
+    public void fsSettingsForFolderSpecificJobVersion7() throws Exception {
+        String settings = readJsonFile(metadataDir.resolve("jobtest").resolve("_mappings"), metadataDir, "7", INDEX_SETTINGS_FOLDER_FILE);
+        assertThat(settings, is("{\n" +
+                "  // This is folder settings for version 7\n" +
+                "}\n"));
     }
 
     @Test

--- a/settings/src/test/resources/jobtest/7/_settings.json
+++ b/settings/src/test/resources/jobtest/7/_settings.json
@@ -1,0 +1,3 @@
+{
+  // This is settings for version 7
+}

--- a/settings/src/test/resources/jobtest/7/_settings_folder.json
+++ b/settings/src/test/resources/jobtest/7/_settings_folder.json
@@ -1,0 +1,3 @@
+{
+  // This is folder settings for version 7
+}

--- a/test-framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/framework/FsCrawlerUtilForTests.java
+++ b/test-framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/framework/FsCrawlerUtilForTests.java
@@ -33,7 +33,8 @@ class FsCrawlerUtilForTests {
     private static final String[] MAPPING_RESOURCES = {
             "2/_settings.json", "2/_settings_folder.json",
             "5/_settings.json", "5/_settings_folder.json",
-            "6/_settings.json", "6/_settings_folder.json"
+            "6/_settings.json", "6/_settings_folder.json",
+            "7/_settings.json", "7/_settings_folder.json"
     };
 
     private FsCrawlerUtilForTests() {


### PR DESCRIPTION
We can start supporting Elasticsearch 7.0 in FSCrawler.

TODO: replace deprecated methods (don't use types anymore).