### PR TITLE
Replace OSS tests by Security enabled tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
   - sudo sysctl -w vm.max_map_count=262144
 script:
   - mvn --batch-mode clean verify
-  - mvn --batch-mode clean verify -Poss
+  - mvn --batch-mode clean verify -Psecurity
 after_success:
   - ./travis.sh
 cache:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,13 +30,12 @@ Unless a node is already running at this address, integration tests use by defau
 which starts a local node running at [127.0.0.1:9200](http://127.0.0.1:9200).
 The elasticsearch version used is defined in the `pom.xml` file.
 
-By default, it will run integration tests against elasticsearch 6.x series cluster running under
-an elastic basic license and agains 5.x series with X-Pack plugin.
+By default, it will run integration tests against elasticsearch 7.x, 6.x and 5.x series.
 
-You can also run test against the OSS version by using the `oss` maven profile:
+You can also run test using security feature by using the `security` maven profile:
 
 ```sh
-mvn install -Poss
+mvn install -Psecurity
 ```
 
 ### Running tests against an external cluster

--- a/docs/source/dev/build.rst
+++ b/docs/source/dev/build.rst
@@ -95,6 +95,24 @@ the tests start.
             -Dtests.cluster.pass=changeme \
             -Dtests.cluster.cloud_id=fscrawler:ZXVyb3BlLXdlc3QxLmdjcC5jbG91ZC5lcy5pbyQxZDFlYTk5Njg4Nzc0NWE2YTJiN2NiNzkzMTUzNDhhMyQyOTk1MDI3MzZmZGQ0OTI5OTE5M2UzNjdlOTk3ZmU3Nw==
 
+Using security feature
+""""""""""""""""""""""
+
+Integration tests are run by default against a standard Elasticsearch cluster, which means
+with no security feature activated.
+
+.. versionadded:: 2.7
+
+You can run all the integration tests against a secured cluster by using the ``security`` profile::
+
+    mvn verify -Psecurity
+
+Note that secured tests are using by default ``changeme`` as the password.
+You can change this by using ``tests.cluster.pass`` option::
+
+    mvn verify -Psecurity -Dtests.cluster.pass=mystrongpassword
+
+
 Tests options
 """""""""""""
 

--- a/integration-tests/it-v5/pom.xml
+++ b/integration-tests/it-v5/pom.xml
@@ -163,37 +163,38 @@
             </build>
         </profile>
         <profile>
-            <!-- There is no OSS specific version in 5.x as it's packaged with x-pack by default -->
-            <id>oss</id>
-            <properties>
-                <integ.elasticsearch.image>docker.elastic.co/elasticsearch/elasticsearch-oss</integ.elasticsearch.image>
-            </properties>
+            <id>security</id>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>start-elasticsearch</id>
-                                <phase>none</phase>
-                            </execution>
-                            <execution>
-                                <id>stop-elasticsearch</id>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>com.carrotsearch.randomizedtesting</groupId>
-                        <artifactId>junit4-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <!-- We can skip that IT execution -->
-                                <id>integration-tests</id>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <alias>elasticsearch-it</alias>
+                                    <name>dadoonet/docker-elasticsearch:${project.version}</name>
+                                    <build>
+                                        <from>${integ.elasticsearch.image}:${integ.elasticsearch.version}</from>
+                                        <env>
+                                            <discovery.type>single-node</discovery.type>
+                                        </env>
+                                    </build>
+                                    <run>
+                                        <ports>
+                                            <port>integ.elasticsearch.port:9200</port>
+                                        </ports>
+                                        <wait>
+                                            <http>
+                                                <url>http://localhost:${integ.elasticsearch.port}/</url>
+                                                <status>200..499</status>
+                                            </http>
+                                            <time>60000</time>
+                                        </wait>
+                                    </run>
+                                </image>
+                            </images>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/integration-tests/it-v6/pom.xml
+++ b/integration-tests/it-v6/pom.xml
@@ -162,5 +162,45 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>security</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <alias>elasticsearch-it</alias>
+                                    <name>dadoonet/docker-elasticsearch:${project.version}</name>
+                                    <build>
+                                        <from>${integ.elasticsearch.image}:${integ.elasticsearch.version}</from>
+                                        <env>
+                                            <discovery.type>single-node</discovery.type>
+                                            <xpack.license.self_generated.type>trial</xpack.license.self_generated.type>
+                                            <xpack.security.enabled>true</xpack.security.enabled>
+                                            <ELASTIC_PASSWORD>${integ.security.password}</ELASTIC_PASSWORD>
+                                        </env>
+                                    </build>
+                                    <run>
+                                        <ports>
+                                            <port>integ.elasticsearch.port:9200</port>
+                                        </ports>
+                                        <wait>
+                                            <http>
+                                                <url>http://localhost:${integ.elasticsearch.port}/</url>
+                                                <status>200..499</status>
+                                            </http>
+                                            <time>60000</time>
+                                        </wait>
+                                    </run>
+                                </image>
+                            </images>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/integration-tests/it-v7/pom.xml
+++ b/integration-tests/it-v7/pom.xml
@@ -162,5 +162,45 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>security</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <images>
+                                <image>
+                                    <alias>elasticsearch-it</alias>
+                                    <name>dadoonet/docker-elasticsearch:${project.version}</name>
+                                    <build>
+                                        <from>${integ.elasticsearch.image}:${integ.elasticsearch.version}</from>
+                                        <env>
+                                            <discovery.type>single-node</discovery.type>
+                                            <xpack.license.self_generated.type>trial</xpack.license.self_generated.type>
+                                            <xpack.security.enabled>true</xpack.security.enabled>
+                                            <ELASTIC_PASSWORD>${integ.security.password}</ELASTIC_PASSWORD>
+                                        </env>
+                                    </build>
+                                    <run>
+                                        <ports>
+                                            <port>integ.elasticsearch.port:9200</port>
+                                        </ports>
+                                        <wait>
+                                            <http>
+                                                <url>http://localhost:${integ.elasticsearch.port}/</url>
+                                                <status>200..499</status>
+                                            </http>
+                                            <time>60000</time>
+                                        </wait>
+                                    </run>
+                                </image>
+                            </images>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -762,12 +762,6 @@
             </activation>
         </profile>
         <profile>
-            <id>oss</id>
-            <properties>
-                <integ.elasticsearch.image>docker.elastic.co/elasticsearch/elasticsearch-oss</integ.elasticsearch.image>
-            </properties>
-        </profile>
-        <profile>
             <id>check_cve_anonymous</id>
             <activation>
                 <property>


### PR DESCRIPTION
I does not make a lot of sense to test elasticsearch OSS image vs the standard one.
Instead we would like to test FSCrawler when security is activated and when it's not.

We can test with a password.

Closes #685