### PR TITLE
Allow running OCR but not on PDF files

### DIFF
--- a/docs/source/user/tips.rst
+++ b/docs/source/user/tips.rst
@@ -65,6 +65,8 @@ Here is a list of OCR settings (under ``fs.ocr`` prefix)`:
 +------------------------+---------------+------------------------------------+
 | Name                   | Default value | Documentation                      |
 +========================+===============+====================================+
+| ``fs.ocr.enabled``     | ``true``      | `Disable/Enable OCR`_              |
++------------------------+---------------+------------------------------------+
 | ``fs.ocr.language``    | ``"eng"``     | `OCR Language`_                    |
 +------------------------+---------------+------------------------------------+
 | ``fs.ocr.path``        | ``null``      | `OCR Path`_                        |
@@ -73,6 +75,25 @@ Here is a list of OCR settings (under ``fs.ocr`` prefix)`:
 +------------------------+---------------+------------------------------------+
 | ``fs.ocr.output_type`` | ``txt``       | `OCR Output Type`_                 |
 +------------------------+---------------+------------------------------------+
+
+Disable/Enable OCR
+^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 2.7
+
+You can completely disable using OCR by setting ``fs.ocr.enabled`` property in your
+``~/.fscrawler/test/_settings.yaml`` file:
+
+.. code:: yaml
+
+   name: "test"
+   fs:
+     url: "/path/to/data/dir"
+     ocr:
+       enabled: false
+
+By default, OCR is activated if tesseract can be found on your system.
+
 
 OCR Language
 ^^^^^^^^^^^^

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Ocr.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Ocr.java
@@ -30,6 +30,8 @@ public class Ocr {
     private String dataPath = null;
     // Output Type. Can be txt (default) or hocr. null means the default value.
     private String outputType = null;
+    // Is OCR enabled or disabled in general
+    private boolean enabled = true;
 
     public static Builder builder() {
         return new Builder();
@@ -41,6 +43,7 @@ public class Ocr {
         private String path = null;
         private String dataPath = null;
         private String outputType = null;
+        private boolean enabled = true;
 
         public Builder setLanguage(String language) {
             this.language = language;
@@ -62,8 +65,13 @@ public class Ocr {
             return this;
         }
 
+        public Builder setEnabled(boolean enabled) {
+            this.enabled = enabled;
+            return this;
+        }
+
         public Ocr build() {
-            return new Ocr(language, path, dataPath, outputType);
+            return new Ocr(language, path, dataPath, outputType, enabled);
         }
 
     }
@@ -72,11 +80,12 @@ public class Ocr {
 
     }
 
-    private Ocr(String language, String path, String dataPath, String outputType) {
+    private Ocr(String language, String path, String dataPath, String outputType, boolean enabled) {
         this.language = language;
         this.path = path;
         this.dataPath = dataPath;
         this.outputType = outputType;
+        this.enabled = enabled;
     }
 
     public String getLanguage() {
@@ -111,12 +120,21 @@ public class Ocr {
         this.outputType = outputType;
     }
 
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Ocr ocr = (Ocr) o;
-        return Objects.equals(language, ocr.language) &&
+        return enabled == ocr.enabled &&
+                Objects.equals(language, ocr.language) &&
                 Objects.equals(path, ocr.path) &&
                 Objects.equals(dataPath, ocr.dataPath) &&
                 Objects.equals(outputType, ocr.outputType);
@@ -124,7 +142,7 @@ public class Ocr {
 
     @Override
     public int hashCode() {
-        return Objects.hash(language, path, dataPath, outputType);
+        return Objects.hash(language, path, dataPath, outputType, enabled);
     }
 
     @Override
@@ -133,6 +151,7 @@ public class Ocr {
                 ", path='" + path + '\'' +
                 ", dataPath='" + dataPath + '\'' +
                 ", outputType='" + outputType + '\'' +
+                ", enabled=" + enabled +
                 '}';
     }
 }

--- a/tika/src/test/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParserTest.java
+++ b/tika/src/test/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParserTest.java
@@ -660,9 +660,20 @@ public class TikaDocParserTest extends DocParserTestCase {
         doc = extractFromFile("test-ocr.pdf");
         assertThat(doc.getContent(), containsString("This file contains some words."));
 
-        // Test with OCR Off
+        // Test with PDF OCR Off but OCR On
         FsSettings fsSettings = FsSettings.builder(getCurrentTestName())
                 .setFs(Fs.builder().setPdfOcr(false).build())
+                .build();
+        doc = extractFromFile("test-ocr.png", fsSettings);
+        assertThat(doc.getContent(), containsString("This file contains some words."));
+        doc = extractFromFile("test-ocr.pdf", fsSettings);
+        assertThat(doc.getContent(), is("\n\n"));
+
+        // Test with OCR Off
+        fsSettings = FsSettings.builder(getCurrentTestName())
+                .setFs(Fs.builder().setOcr(Ocr.builder()
+                        .setEnabled(false)
+                        .build()).build())
                 .build();
         doc = extractFromFile("test-ocr.png", fsSettings);
         assertThat(doc.getContent(), isEmptyString());


### PR DESCRIPTION
We introduce a new setting which explicitly enable or disable OCR:

```yml
name: "test"
  fs:
    url: "/path/to/data/dir"
    ocr:
      enabled: false
```

Closes #691.