### PR TITLE
Exclude the PDFParser from the DefaultParser

### DIFF
--- a/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaInstance.java
+++ b/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaInstance.java
@@ -93,14 +93,13 @@ public class TikaInstance {
                     logger.debug("But Tesseract is not installed so we won't run OCR.");
                     pdfParser.setOcrStrategy("no_ocr");
                 }
-                defaultParser = new DefaultParser();
+                defaultParser = new DefaultParser(
+                        MediaTypeRegistry.getDefaultRegistry(),
+                        new ServiceLoader(),
+                        Collections.singletonList(PDFParser.class));
             }
 
-            Parser PARSERS[] = new Parser[2];
-            PARSERS[0] = defaultParser;
-            PARSERS[1] = pdfParser;
-
-            parser = new AutoDetectParser(PARSERS);
+            parser = new AutoDetectParser(defaultParser, pdfParser);
         }
 
     }


### PR DESCRIPTION
After [a discussion](https://lists.apache.org/thread.html/a070d34a038c7b3089ed7a3be357e9cbd209658ff090e774114c408d@%3Cuser.tika.apache.org%3E) with @tballison, I realized that I did not exclude the `PDFParser` from the `DefaultParser` while I'm using a custom `AutoDetectParser` which is using the `DefaultParser` and the `PDFParser`.

This change removes the `PDFParser` from the `DefaultParser`.