### PR TITLE
Add Cross-Origin Resource Sharing (CORS) headers to RestServer

### DIFF
--- a/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
+++ b/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
@@ -27,7 +27,13 @@ import fr.pilato.elasticsearch.crawler.fs.client.ESVersion;
 import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil;
 import fr.pilato.elasticsearch.crawler.fs.framework.MetaFileHandler;
 import fr.pilato.elasticsearch.crawler.fs.rest.RestServer;
-import fr.pilato.elasticsearch.crawler.fs.settings.*;
+import fr.pilato.elasticsearch.crawler.fs.settings.Elasticsearch;
+import fr.pilato.elasticsearch.crawler.fs.settings.Fs;
+import fr.pilato.elasticsearch.crawler.fs.settings.FsCrawlerValidator;
+import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
+import fr.pilato.elasticsearch.crawler.fs.settings.FsSettingsFileHandler;
+import fr.pilato.elasticsearch.crawler.fs.settings.FsSettingsParser;
+import fr.pilato.elasticsearch.crawler.fs.settings.Rest;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -224,7 +230,6 @@ public class FsCrawlerCli {
                 fsSettings = FsSettings.builder(commands.jobName.get(0))
                         .setFs(Fs.DEFAULT)
                         .setElasticsearch(Elasticsearch.DEFAULT())
-                        .setRest(Rest.DEFAULT)
                         .build();
                 fsSettingsFileHandler.write(fsSettings);
 

--- a/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
+++ b/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
@@ -27,12 +27,7 @@ import fr.pilato.elasticsearch.crawler.fs.client.ESVersion;
 import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil;
 import fr.pilato.elasticsearch.crawler.fs.framework.MetaFileHandler;
 import fr.pilato.elasticsearch.crawler.fs.rest.RestServer;
-import fr.pilato.elasticsearch.crawler.fs.settings.Elasticsearch;
-import fr.pilato.elasticsearch.crawler.fs.settings.Fs;
-import fr.pilato.elasticsearch.crawler.fs.settings.FsCrawlerValidator;
-import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
-import fr.pilato.elasticsearch.crawler.fs.settings.FsSettingsFileHandler;
-import fr.pilato.elasticsearch.crawler.fs.settings.FsSettingsParser;
+import fr.pilato.elasticsearch.crawler.fs.settings.*;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -229,6 +224,7 @@ public class FsCrawlerCli {
                 fsSettings = FsSettings.builder(commands.jobName.get(0))
                         .setFs(Fs.DEFAULT)
                         .setElasticsearch(Elasticsearch.DEFAULT())
+                        .setRest(Rest.DEFAULT)
                         .build();
                 fsSettingsFileHandler.write(fsSettings);
 

--- a/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
+++ b/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
@@ -33,7 +33,6 @@ import fr.pilato.elasticsearch.crawler.fs.settings.FsCrawlerValidator;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettingsFileHandler;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettingsParser;
-import fr.pilato.elasticsearch.crawler.fs.settings.Rest;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/docs/source/admin/fs/rest.rst
+++ b/docs/source/admin/fs/rest.rst
@@ -55,7 +55,8 @@ It will give you a response similar to:
          "username" : "elastic"
        },
        "rest" : {
-         "url" : "http://127.0.0.1:8080/fscrawler"
+         "url" : "http://127.0.0.1:8080/fscrawler",
+         "enable_cors": false
        }
      }
    }
@@ -250,16 +251,39 @@ The field ``external`` doesn't necessarily be a flat structure. This is a more a
 
 .. attention:: Only standard :ref:`FSCrawler fields <generated_fields>` can be set outside ``external`` field name.
 
+Enabling CORS
+~~~~~~~~~~~~~
+To enable Cross-Origin Request Sharing you will need to set ``enable_cors: true``
+under ``rest`` in your job settings. Doing so will enable the relevant access headers
+on all REST service resource responses (for example ``/fscrawler`` and ``/fscrawler/_upload``).
+
+You can check if CORS is enabled with:
+
+.. code:: sh
+
+   curl -I http://127.0.0.1:8080/fscrawler/
+
+The response header should contain ``Access-Control-Allow-*`` parameters like:
+
+::
+   Access-Control-Allow-Origin: *
+   Access-Control-Allow-Headers: origin, content-type, accept, authorization
+   Access-Control-Allow-Credentials: true
+   Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD
+
 REST settings
 ~~~~~~~~~~~~~
 
 Here is a list of REST service settings (under ``rest.`` prefix)`:
 
-+--------------+-------------------------------------+-----------------------+
-| Name         | Default value                       | Documentation         |
-+==============+=====================================+=======================+
-| ``rest.url`` | ``http://127.0.0.1:8080/fscrawler`` | Rest Service URL      |
-+--------------+-------------------------------------+-----------------------+
++----------------------+-------------------------------------+-------------------------------------------------------+
+| Name                 | Default value                       | Documentation                                         |
++======================+=====================================+=======================================================+
+| ``rest.url``         | ``http://127.0.0.1:8080/fscrawler`` | Rest Service URL                                      |
++----------------------+-------------------------------------+-------------------------------------------------------+
+| ``rest.enable_cors`` | ``false``                           | Enables or disables Cross-Origin Resource Sharing     |
+|                      |                                     | globally for all resources                            |
++----------------------+-------------------------------------+-------------------------------------------------------+
 
 .. tip::
 

--- a/docs/source/admin/fs/rest.rst
+++ b/docs/source/admin/fs/rest.rst
@@ -264,8 +264,8 @@ You can check if CORS is enabled with:
    curl -I http://127.0.0.1:8080/fscrawler/
 
 The response header should contain ``Access-Control-Allow-*`` parameters like:
-
 ::
+
    Access-Control-Allow-Origin: *
    Access-Control-Allow-Headers: origin, content-type, accept, authorization
    Access-Control-Allow-Credentials: true

--- a/docs/source/user/rest.rst
+++ b/docs/source/user/rest.rst
@@ -44,4 +44,7 @@ elasticsearch URL for the created document, like:
      "url" : "http://127.0.0.1:9200/fscrawler-rest-tests_doc/doc/dd18bf3a8ea2a3e53e2661c7fb53534"
    }
 
+To enable CORS (Cross-Origin Request Sharing) functionality you will
+need to set ``enable_cors: true`` in your job settings.
+
 Read the :ref:`rest-service` chapter for more information.

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractFsCrawlerITCase.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractFsCrawlerITCase.java
@@ -23,11 +23,7 @@ import fr.pilato.elasticsearch.crawler.fs.FsCrawlerImpl;
 import fr.pilato.elasticsearch.crawler.fs.beans.FsJobFileHandler;
 import fr.pilato.elasticsearch.crawler.fs.client.ESSearchRequest;
 import fr.pilato.elasticsearch.crawler.fs.framework.TimeValue;
-import fr.pilato.elasticsearch.crawler.fs.settings.Elasticsearch;
-import fr.pilato.elasticsearch.crawler.fs.settings.Fs;
-import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
-import fr.pilato.elasticsearch.crawler.fs.settings.Server;
-import fr.pilato.elasticsearch.crawler.fs.settings.ServerUrl;
+import fr.pilato.elasticsearch.crawler.fs.settings.*;
 import org.junit.After;
 import org.junit.Before;
 
@@ -92,7 +88,7 @@ public abstract class AbstractFsCrawlerITCase extends AbstractITCase {
         return startCrawler(jobName, fs, elasticsearch, server, null, TimeValue.timeValueSeconds(10));
     }
 
-    FsCrawlerImpl startCrawler(final String jobName, Fs fs, Elasticsearch elasticsearch, Server server, ServerUrl rest, TimeValue duration)
+    FsCrawlerImpl startCrawler(final String jobName, Fs fs, Elasticsearch elasticsearch, Server server, Rest rest, TimeValue duration)
             throws Exception {
         logger.info("  --> starting crawler [{}]", jobName);
 

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractFsCrawlerITCase.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractFsCrawlerITCase.java
@@ -23,7 +23,11 @@ import fr.pilato.elasticsearch.crawler.fs.FsCrawlerImpl;
 import fr.pilato.elasticsearch.crawler.fs.beans.FsJobFileHandler;
 import fr.pilato.elasticsearch.crawler.fs.client.ESSearchRequest;
 import fr.pilato.elasticsearch.crawler.fs.framework.TimeValue;
-import fr.pilato.elasticsearch.crawler.fs.settings.*;
+import fr.pilato.elasticsearch.crawler.fs.settings.Elasticsearch;
+import fr.pilato.elasticsearch.crawler.fs.settings.Fs;
+import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
+import fr.pilato.elasticsearch.crawler.fs.settings.Rest;
+import fr.pilato.elasticsearch.crawler.fs.settings.Server;
 import org.junit.After;
 import org.junit.Before;
 

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
@@ -33,7 +33,6 @@ import fr.pilato.elasticsearch.crawler.fs.framework.TimeValue;
 import fr.pilato.elasticsearch.crawler.fs.rest.RestJsonProvider;
 import fr.pilato.elasticsearch.crawler.fs.settings.Elasticsearch;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
-import fr.pilato.elasticsearch.crawler.fs.settings.Rest;
 import fr.pilato.elasticsearch.crawler.fs.settings.ServerUrl;
 import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
 import fr.pilato.elasticsearch.crawler.fs.test.framework.TestContainerThreadFilter;

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
@@ -33,6 +33,7 @@ import fr.pilato.elasticsearch.crawler.fs.framework.TimeValue;
 import fr.pilato.elasticsearch.crawler.fs.rest.RestJsonProvider;
 import fr.pilato.elasticsearch.crawler.fs.settings.Elasticsearch;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
+import fr.pilato.elasticsearch.crawler.fs.settings.Rest;
 import fr.pilato.elasticsearch.crawler.fs.settings.ServerUrl;
 import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
 import fr.pilato.elasticsearch.crawler.fs.test.framework.TestContainerThreadFilter;
@@ -116,6 +117,8 @@ public abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
     private final static String testClusterPass = System.getProperty("tests.cluster.pass", DEFAULT_PASSWORD);
     final static int testRestPort = Integer.parseInt(System.getProperty("tests.rest.port", DEFAULT_TEST_REST_PORT.toString()));
     static Elasticsearch elasticsearchWithSecurity;
+
+    static Rest restConfig;
 
     static WebTarget target;
     static Client client;

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
@@ -116,10 +116,8 @@ public abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
     private final static String testClusterUser = System.getProperty("tests.cluster.user", DEFAULT_USERNAME);
     private final static String testClusterPass = System.getProperty("tests.cluster.pass", DEFAULT_PASSWORD);
     final static int testRestPort = Integer.parseInt(System.getProperty("tests.rest.port", DEFAULT_TEST_REST_PORT.toString()));
+
     static Elasticsearch elasticsearchWithSecurity;
-
-    static Rest restConfig;
-
     static WebTarget target;
     static Client client;
 

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractRestITCase.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractRestITCase.java
@@ -24,6 +24,7 @@ import fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchClientUtil;
 import fr.pilato.elasticsearch.crawler.fs.rest.RestServer;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsCrawlerValidator;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
+import fr.pilato.elasticsearch.crawler.fs.settings.Rest;
 import fr.pilato.elasticsearch.crawler.fs.settings.ServerUrl;
 import org.junit.After;
 import org.junit.Before;
@@ -37,7 +38,7 @@ public abstract class AbstractRestITCase extends AbstractITCase {
     @Before
     public void startRestServer() throws Exception {
         FsSettings fsSettings = FsSettings.builder(getCrawlerName())
-                .setRest(new ServerUrl("http://127.0.0.1:" + testRestPort + "/fscrawler"))
+                .setRest(new Rest("http://127.0.0.1:" + testRestPort + "/fscrawler"))
                 .setElasticsearch(elasticsearchWithSecurity)
                 .build();
         fsSettings.getElasticsearch().setIndex(getCrawlerName());

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractRestITCase.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractRestITCase.java
@@ -25,7 +25,6 @@ import fr.pilato.elasticsearch.crawler.fs.rest.RestServer;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsCrawlerValidator;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
 import fr.pilato.elasticsearch.crawler.fs.settings.Rest;
-import fr.pilato.elasticsearch.crawler.fs.settings.ServerUrl;
 import org.junit.After;
 import org.junit.Before;
 

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerTestRestOnlyIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerTestRestOnlyIT.java
@@ -25,6 +25,7 @@ import fr.pilato.elasticsearch.crawler.fs.framework.TimeValue;
 import fr.pilato.elasticsearch.crawler.fs.rest.RestServer;
 import fr.pilato.elasticsearch.crawler.fs.rest.UploadResponse;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
+import fr.pilato.elasticsearch.crawler.fs.settings.Rest;
 import fr.pilato.elasticsearch.crawler.fs.settings.ServerUrl;
 import org.junit.Test;
 
@@ -54,7 +55,7 @@ public class FsCrawlerTestRestOnlyIT extends AbstractFsCrawlerITCase {
                     .setElasticsearch(endCrawlerDefinition(getCrawlerName()))
                     .setFs(startCrawlerDefinition().build())
                     .setServer(null)
-                    .setRest(new ServerUrl("http://127.0.0.1:" + (testRestPort+1) + "/fscrawler")).build();
+                    .setRest(new Rest("http://127.0.0.1:" + (testRestPort+1) + "/fscrawler")).build();
             crawler = new FsCrawlerImpl(
                     metadataDir,
                     fsSettings,

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerTestRestOnlyIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerTestRestOnlyIT.java
@@ -26,7 +26,6 @@ import fr.pilato.elasticsearch.crawler.fs.rest.RestServer;
 import fr.pilato.elasticsearch.crawler.fs.rest.UploadResponse;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
 import fr.pilato.elasticsearch.crawler.fs.settings.Rest;
-import fr.pilato.elasticsearch.crawler.fs.settings.ServerUrl;
 import org.junit.Test;
 
 import javax.ws.rs.client.WebTarget;

--- a/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/CORSFilter.java
+++ b/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/CORSFilter.java
@@ -1,0 +1,31 @@
+package fr.pilato.elasticsearch.crawler.fs.rest;
+
+import fr.pilato.elasticsearch.crawler.fs.settings.Rest;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+
+@Provider
+public class CORSFilter implements ContainerResponseFilter {
+    private Rest rest;
+
+    public CORSFilter(Rest rest) {
+        this.rest = rest;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext request, ContainerResponseContext response) throws IOException {
+
+        if (rest != null && rest.isEnableCors()) {
+            response.getHeaders().add("Access-Control-Allow-Origin", "*");
+            response.getHeaders().add(
+                    "Access-Control-Allow-Headers", "origin, content-type, accept, authorization"
+            );
+            response.getHeaders().add("Access-Control-Allow-Credentials", "true");
+            response.getHeaders().add("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, HEAD");
+        }
+    }
+}

--- a/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/CORSFilter.java
+++ b/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/CORSFilter.java
@@ -6,7 +6,6 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.ext.Provider;
-import java.io.IOException;
 
 @Provider
 public class CORSFilter implements ContainerResponseFilter {
@@ -17,15 +16,13 @@ public class CORSFilter implements ContainerResponseFilter {
     }
 
     @Override
-    public void filter(ContainerRequestContext request, ContainerResponseContext response) throws IOException {
+    public void filter(ContainerRequestContext request, ContainerResponseContext response) {
 
         if (rest != null && rest.isEnableCors()) {
             response.getHeaders().add("Access-Control-Allow-Origin", "*");
-            response.getHeaders().add(
-                    "Access-Control-Allow-Headers", "origin, content-type, accept, authorization"
-            );
+            response.getHeaders().add("Access-Control-Allow-Headers", "origin, content-type, accept, authorization");
             response.getHeaders().add("Access-Control-Allow-Credentials", "true");
-            response.getHeaders().add("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, HEAD");
+            response.getHeaders().add("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD");
         }
     }
 }

--- a/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/RestServer.java
+++ b/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/RestServer.java
@@ -53,12 +53,13 @@ public class RestServer {
                     .register(MultiPartFeature.class)
                     .register(RestJsonProvider.class)
                     .register(JacksonFeature.class)
+                    .register(new CORSFilter(settings.getRest()))
                     .packages("fr.pilato.elasticsearch.crawler.fs.rest");
 
             // create and start a new instance of grizzly http server
             // exposing the Jersey application at BASE_URI
-            httpServer = GrizzlyHttpServerFactory.createHttpServer(URI.create(settings.getRest().decodedUrl()), rc);
-            logger.info("FS crawler Rest service started on [{}]", settings.getRest().decodedUrl());
+            httpServer = GrizzlyHttpServerFactory.createHttpServer(URI.create(settings.getRest().getUrl()), rc);
+            logger.info("FS crawler Rest service started on [{}]", settings.getRest().getUrl());
         }
     }
 

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsCrawlerValidator.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsCrawlerValidator.java
@@ -108,8 +108,8 @@ public class FsCrawlerValidator {
 
         // Check that REST settings are available when we start with rest option
         if (rest && settings.getRest() == null) {
-            logger.warn("`rest` settings are not defined. Falling back to default: [{}].", FsSettings.REST_DEFAULT);
-            settings.setRest(FsSettings.REST_DEFAULT);
+            logger.warn("`rest` settings are not defined. Falling back to default: [{}].", Rest.URL_DEFAULT);
+            settings.setRest(Rest.DEFAULT);
         }
 
         return false;

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettings.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettings.java
@@ -24,18 +24,17 @@ import java.util.Objects;
 @SuppressWarnings("SameParameterValue")
 public class FsSettings {
 
-    public static final ServerUrl REST_DEFAULT = new ServerUrl("http://127.0.0.1:8080/fscrawler");
     private String name;
     private Fs fs;
     private Server server;
     private Elasticsearch elasticsearch;
-    private ServerUrl rest;
+    private Rest rest;
 
     public FsSettings() {
 
     }
 
-    private FsSettings(String name, Fs fs, Server server, Elasticsearch elasticsearch, ServerUrl rest) {
+    private FsSettings(String name, Fs fs, Server server, Elasticsearch elasticsearch, Rest rest) {
         this.name = name;
         this.fs = fs;
         this.server = server;
@@ -52,7 +51,7 @@ public class FsSettings {
         private Fs fs = Fs.DEFAULT;
         private Server server = null;
         private Elasticsearch elasticsearch = Elasticsearch.DEFAULT();
-        private ServerUrl rest = REST_DEFAULT;
+        private Rest rest = null;
 
         private Builder setName(String name) {
             this.name = name;
@@ -74,7 +73,7 @@ public class FsSettings {
             return this;
         }
 
-        public Builder setRest(ServerUrl rest) {
+        public Builder setRest(Rest rest) {
             this.rest = rest;
             return this;
         }
@@ -116,11 +115,11 @@ public class FsSettings {
         this.elasticsearch = elasticsearch;
     }
 
-    public ServerUrl getRest() {
+    public Rest getRest() {
         return rest;
     }
 
-    public void setRest(ServerUrl rest) {
+    public void setRest(Rest rest) {
         this.rest = rest;
     }
 

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Rest.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Rest.java
@@ -1,0 +1,85 @@
+package fr.pilato.elasticsearch.crawler.fs.settings;
+
+import java.util.Objects;
+
+public class Rest {
+    public static final String URL_DEFAULT = "http://127.0.0.1:8080/fscrawler";
+    public static final boolean CORS_ENABLE_DEFAULT = false;
+    public static final Rest DEFAULT = Rest.builder().setUrl(URL_DEFAULT).setEnableCors(CORS_ENABLE_DEFAULT).build();
+
+    private String url;
+    private boolean enableCors;
+
+    public Rest() {
+
+    }
+
+    public Rest(String url) {
+        this(url, CORS_ENABLE_DEFAULT);
+    }
+
+    public Rest(String url, boolean enableCors) {
+        this.url = url;
+        this.enableCors = enableCors;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setEnableCors(boolean enableCors) {
+        this.enableCors = enableCors;
+    }
+
+    public boolean isEnableCors() {
+        return enableCors;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String url = URL_DEFAULT;
+        private boolean enableCors = CORS_ENABLE_DEFAULT;
+
+        public Builder setUrl(String url) {
+            this.url = url;
+            return this;
+        }
+
+        public Builder setEnableCors(boolean enableCors) {
+            this.enableCors = enableCors;
+            return this;
+        }
+
+        public Rest build() {
+            return new Rest(url, enableCors);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Rest rest = (Rest) o;
+        return enableCors == rest.enableCors &&
+                Objects.equals(url, rest.url);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enableCors, url);
+    }
+
+    @Override
+    public String toString() {
+        return "Rest{" + "url='" + url + '\'' +
+                ", enableCors=" + enableCors +
+                '}';
+    }
+}

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/ServerUrl.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/ServerUrl.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 /**
  * This class represents a ServerUrl which is basically just a String which
  * can be either a url or a cloud id.
- * This is used in Rest and Elasticsearch.Node classes.
+ * This is used in the Elasticsearch.Node class.
  */
 public class ServerUrl {
 

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsCrawlerValidatorTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsCrawlerValidatorTest.java
@@ -42,6 +42,7 @@ public class FsCrawlerValidatorTest extends AbstractFSCrawlerTestCase {
         assertThat(settings.getElasticsearch().getIndex(), is(getCurrentTestName()));
         assertThat(settings.getElasticsearch().getIndexFolder(), is(getCurrentTestName() + INDEX_SUFFIX_FOLDER));
         assertThat(settings.getServer(), nullValue());
+        assertThat(settings.getRest(), nullValue());
 
         // Checking default values
         settings = buildSettings(null, null, null, null);
@@ -51,6 +52,7 @@ public class FsCrawlerValidatorTest extends AbstractFSCrawlerTestCase {
         assertThat(settings.getElasticsearch().getIndex(), is(getCurrentTestName()));
         assertThat(settings.getElasticsearch().getIndexFolder(), is(getCurrentTestName() + INDEX_SUFFIX_FOLDER));
         assertThat(settings.getServer(), nullValue());
+        assertThat(settings.getRest(), nullValue());
 
         // Checking Checksum Algorithm
         settings = buildSettings(Fs.builder().setChecksum("FSCRAWLER").build(), null, null, null);
@@ -82,7 +84,7 @@ public class FsCrawlerValidatorTest extends AbstractFSCrawlerTestCase {
         assertThat(settings.getRest(), notNullValue());
     }
 
-    private FsSettings buildSettings(Fs fs, Elasticsearch elasticsearch, Server server, ServerUrl rest) {
+    private FsSettings buildSettings(Fs fs, Elasticsearch elasticsearch, Server server, Rest rest) {
         FsSettings.Builder settingsBuilder = FsSettings.builder(getCurrentTestName());
         settingsBuilder.setFs(fs == null ? Fs.DEFAULT : fs);
         settingsBuilder.setElasticsearch(elasticsearch == null ? Elasticsearch.DEFAULT() : elasticsearch);

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsParserTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsParserTest.java
@@ -77,7 +77,11 @@ public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
             .setProtocol("SSH")
             .setPemPath("/path/to/pemfile")
             .build();
-    private static final ServerUrl REST_FULL = new ServerUrl("http://127.0.0.1:8080/fscrawler");
+    private static final Rest REST_EMPTY = Rest.builder().build();
+    private static final Rest REST_FULL = Rest.builder()
+            .setEnableCors(false)
+            .setUrl(Rest.URL_DEFAULT)
+            .build();
 
     private void settingsTester(FsSettings source) throws IOException {
         String yaml = FsSettingsParser.toYaml(source);

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsParserTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsParserTest.java
@@ -77,7 +77,6 @@ public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
             .setProtocol("SSH")
             .setPemPath("/path/to/pemfile")
             .build();
-    private static final Rest REST_EMPTY = Rest.builder().build();
     private static final Rest REST_FULL = Rest.builder()
             .setEnableCors(false)
             .setUrl(Rest.URL_DEFAULT)


### PR DESCRIPTION
I thought about making the Access-Control-* headers individual options but decided to just keep it simple and either allow all or not.

Haven't added any new tests - just made sure this passed the existing ones. 

Also the docs will need to be updated to reflect the `enable_cors` setting (default `false`).
```
rest:
  url: "http://127.0.0.1:8080/fscrawler"
  enable_cors: false
```

Closes #654.