### PR TITLE
Change log level and display logs only if filters on content

### DIFF
--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/FsCrawlerUtil.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/FsCrawlerUtil.java
@@ -256,8 +256,6 @@ public class FsCrawlerUtil {
      *                we consider it always matches.
      */
     public static boolean isIndexable(String content, List<String> filters) {
-        logger.debug("content = [{}], filters = {}", content, filters);
-
         if (isNullOrEmpty(content)) {
             logger.trace("Null or empty content always matches.");
             return true;
@@ -268,6 +266,7 @@ public class FsCrawlerUtil {
             return true;
         }
 
+        logger.trace("content = [{}], filters = {}", content, filters);
         for (String filter : filters) {
             Pattern pattern = Pattern.compile(filter, Pattern.MULTILINE | Pattern.UNIX_LINES);
             logger.trace("Testing filter [{}]", filter);


### PR DESCRIPTION
This has been reported by a user on discuss.elastic.co: https://discuss.elastic.co/t/fscrawler-qui-crash-elasticsearch/172759/9

We can see in the logs that have been shared privately that the OOM is produced by log4j when we try to log:

```java
logger.debug("content = [{}], filters = {}", content, filters);
```

This was done in the very first line of `isIndexable(String content, List<String> filters)` and with a `DEBUG` level.
That could lead to OOM so I'm moving it to `TRACE` which is less used and this is now called only if we do have filters.