### PR TITLE
Disable raw metadata by default

### DIFF
--- a/docs/source/admin/fs/local-fs.rst
+++ b/docs/source/admin/fs/local-fs.rst
@@ -401,15 +401,15 @@ and ``attributes.permissions``, you can set ``attributes_support`` to ``true``.
 Disabling raw metadata
 ^^^^^^^^^^^^^^^^^^^^^^
 
-By default, FSCrawler will extract all found metadata within
-``meta.raw`` object. If you want to disable this feature, you can set
-``raw_metadata`` to ``false``.
+FSCrawler can extract all found metadata within a ``meta.raw`` object in addition
+to the standard metadata fields.
+If you want to enable this feature, you can set ``raw_metadata`` to ``true``.
 
 .. code:: yaml
 
    name: "test"
    fs:
-     raw_metadata: false
+     raw_metadata: true
 
 Generated raw metadata depends on the file format itself.
 
@@ -508,6 +508,13 @@ Where a MP3 file would generate:
 .. note::
     Note that dots in metadata names will be replaced by a ``:``. For
     example ``PTEX.Fullbanner`` will be indexed as ``PTEX:Fullbanner``.
+
+.. note::
+    Note that if you have a lot of different type of files, that can generate a lot of
+    raw metadata which can make you hit the total number of field limit in elasticsearch
+    mappings. In which case you will need to change the index settings ``foo``.
+
+    See `elasticsearch documentation <https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html#mapping-limit-settings>`__
 
 Disabling file size field
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerRestIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerRestIT.java
@@ -131,7 +131,7 @@ public class FsCrawlerRestIT extends AbstractRestITCase {
             assertThat(hit.getSourceAsMap(), hasKey("file"));
             assertThat((Map<String, Object>) hit.getSourceAsMap().get("file"), hasKey("extension"));
             assertThat(hit.getSourceAsMap(), hasKey("meta"));
-            assertThat((Map<String, Object>) hit.getSourceAsMap().get("meta"), hasKey("raw"));
+            assertThat((Map<String, Object>) hit.getSourceAsMap().get("meta"), not(hasKey("raw")));
 
             assertThat(hit.getSourceAsMap(), hasKey("external"));
             Map<String, Object> external = (Map<String, Object>) hit.getSourceAsMap().get("external");
@@ -171,7 +171,7 @@ public class FsCrawlerRestIT extends AbstractRestITCase {
             assertThat(hit.getSourceAsMap(), hasKey("file"));
             assertThat((Map<String, Object>) hit.getSourceAsMap().get("file"), hasKey("extension"));
             assertThat(hit.getSourceAsMap(), hasKey("meta"));
-            assertThat((Map<String, Object>) hit.getSourceAsMap().get("meta"), hasKey("raw"));
+            assertThat((Map<String, Object>) hit.getSourceAsMap().get("meta"), not(hasKey("raw")));
 
             assertThat(hit.getSourceAsMap(), hasKey("external"));
             Map<String, Object> external = (Map<String, Object>) hit.getSourceAsMap().get("external");
@@ -211,7 +211,7 @@ public class FsCrawlerRestIT extends AbstractRestITCase {
             assertThat(hit.getSourceAsMap(), hasKey("file"));
             assertThat((Map<String, Object>) hit.getSourceAsMap().get("file"), hasKey("extension"));
             assertThat(hit.getSourceAsMap(), hasKey("meta"));
-            assertThat((Map<String, Object>) hit.getSourceAsMap().get("meta"), hasKey("raw"));
+            assertThat((Map<String, Object>) hit.getSourceAsMap().get("meta"), not(hasKey("raw")));
 
             assertThat(hit.getSourceAsMap(), not(hasKey("external")));
         });

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerTestRawIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerTestRawIT.java
@@ -74,10 +74,12 @@ public class FsCrawlerTestRawIT extends AbstractFsCrawlerITCase {
 
     @Test
     public void test_disable_raw() throws Exception {
-        Fs fs = startCrawlerDefinition()
-                .setRawMetadata(false)
-                .build();
-        startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        Fs.Builder builder = startCrawlerDefinition();
+        if (rarely()) {
+            // Sometimes we explicitly disable it but this is also the default value
+            builder.setRawMetadata(false);
+        }
+        startCrawler(getCrawlerName(), builder.build(), endCrawlerDefinition(getCrawlerName()), null);
         ESSearchResponse searchResponse = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
         for (ESSearchHit hit : searchResponse.getHits()) {
             assertThat(extractFromPath(hit.getSourceAsMap(), Doc.FIELD_NAMES.META).get("raw"), nullValue());
@@ -86,12 +88,10 @@ public class FsCrawlerTestRawIT extends AbstractFsCrawlerITCase {
 
     @Test
     public void test_enable_raw() throws Exception {
-        Fs.Builder builder = startCrawlerDefinition();
-        if (rarely()) {
-            // Sometimes we explicitly set it but this is also the default value
-            builder.setRawMetadata(true);
-        }
-        startCrawler(getCrawlerName(), builder.build(), endCrawlerDefinition(getCrawlerName()), null);
+        Fs fs = startCrawlerDefinition()
+                .setRawMetadata(true)
+                .build();
+        startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
         ESSearchResponse searchResponse = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
         for (ESSearchHit hit : searchResponse.getHits()) {
             assertThat(extractFromPath(hit.getSourceAsMap(), Doc.FIELD_NAMES.META).get("raw"), notNullValue());

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Fs.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Fs.java
@@ -81,7 +81,7 @@ public class Fs {
         private boolean indexContent = true;
         private Percentage indexedChars = null;
         private boolean attributesSupport = false;
-        private boolean rawMetadata = true;
+        private boolean rawMetadata = false;
         private String checksum = null;
         private boolean xmlSupport = false;
         private boolean indexFolders = true;

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsParserTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsParserTest.java
@@ -144,7 +144,7 @@ public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
         assertThat(settings.getFs().isIndexFolders(), is(true));
         assertThat(settings.getFs().isJsonSupport(), is(false));
         assertThat(settings.getFs().isLangDetect(), is(false));
-        assertThat(settings.getFs().isRawMetadata(), is(true));
+        assertThat(settings.getFs().isRawMetadata(), is(false));
         assertThat(settings.getFs().isRemoveDeleted(), is(true));
         assertThat(settings.getFs().isStoreSource(), is(false));
         assertThat(settings.getFs().isXmlSupport(), is(false));

--- a/tika/src/test/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParserTest.java
+++ b/tika/src/test/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParserTest.java
@@ -113,7 +113,10 @@ public class TikaDocParserTest extends DocParserTestCase {
      */
     @Test
     public void testXmlIssue163() throws IOException {
-        Doc doc = extractFromFile("issue-163.xml");
+        FsSettings fsSettings = FsSettings.builder(getCurrentTestName())
+                .setFs(Fs.builder().setRawMetadata(true).build())
+                .build();
+        Doc doc = extractFromFile("issue-163.xml", fsSettings);
 
         // Extracted content
         assertThat(doc.getContent(), is("   \n"));
@@ -747,7 +750,10 @@ public class TikaDocParserTest extends DocParserTestCase {
     }
 
     private Doc extractFromFileExtension(String extension) throws IOException {
-        return extractFromFile("test." + extension);
+        FsSettings fsSettings = FsSettings.builder(getCurrentTestName())
+                .setFs(Fs.builder().setRawMetadata(true).build())
+                .build();
+        return extractFromFile("test." + extension, fsSettings);
     }
 
     private Doc extractFromFile(String filename) throws IOException {


### PR DESCRIPTION
This seems to be an advanced use case and should not be activated by default.

Related to #702 discussion.