### PR TITLE
Allow custom index name in the REST API

### DIFF
--- a/docs/source/admin/fs/rest.rst
+++ b/docs/source/admin/fs/rest.rst
@@ -254,7 +254,8 @@ The field ``external`` doesn't necessarily be a flat structure. This is a more a
 
 Specifying an elasticsearch index
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-By default, fscrawler creates document in the index defined in the _settings.yaml (or json) file.
+
+By default, fscrawler creates document in the index defined in the ``_settings.yaml`` file.
 However, using the REST service, it is possible to require fscrawler to use different indexes, by adding ``index=YOUR_INDEX`` in the form data:
 
 .. code:: sh

--- a/docs/source/admin/fs/rest.rst
+++ b/docs/source/admin/fs/rest.rst
@@ -251,10 +251,11 @@ The field ``external`` doesn't necessarily be a flat structure. This is a more a
 
 .. attention:: Only standard :ref:`FSCrawler fields <generated_fields>` can be set outside ``external`` field name.
 
+
 Specifying an elasticsearch index
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 By default, fscrawler creates document in the index defined in the _settings.yaml (or json) file.
-However, using the REST service, it is possible to require fscrawler to use different indexes, by adding ``index=YOUR_INDEXD`` in the form data:
+However, using the REST service, it is possible to require fscrawler to use different indexes, by adding ``index=YOUR_INDEX`` in the form data:
 
 .. code:: sh
 

--- a/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/UploadApi.java
+++ b/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/UploadApi.java
@@ -76,6 +76,7 @@ public class UploadApi extends RestApi {
             @QueryParam("debug") String debug,
             @QueryParam("simulate") String simulate,
             @FormDataParam("id") String id,
+            @FormDataParam("index") String index,
             @FormDataParam("tags") InputStream tags,
             @FormDataParam("file") InputStream filecontent,
             @FormDataParam("file") FormDataContentDisposition d) throws IOException, NoSuchAlgorithmException {
@@ -100,6 +101,11 @@ public class UploadApi extends RestApi {
             id = TIME_UUID_GENERATOR.getBase64UUID();
         }
 
+        //index
+        if (index == null) {
+            index = settings.getElasticsearch().getIndex();
+        }
+
         doc.getPath().setVirtual(filename);
         doc.getPath().setReal(filename);
         // Path
@@ -114,14 +120,14 @@ public class UploadApi extends RestApi {
             logger.debug("Sending document [{}] to elasticsearch.", filename);
             doc = this.getMergedJsonDoc(doc, tags);
             esClient.index(
-                    settings.getElasticsearch().getIndex(),
+                    index,
                     id,
                     DocParser.toJson(doc),
                     settings.getElasticsearch().getPipeline());
             // Elasticsearch entity coordinates (we use the first node address)
             ServerUrl node = settings.getElasticsearch().getNodes().get(0);
             url = node.getUrl() + "/" +
-                    settings.getElasticsearch().getIndex() + "/" +
+                    index + "/" +
                     esClient.getDefaultTypeName() + "/" +
                     id;
         }


### PR DESCRIPTION
As described in the ticket I simply added an input param to the rest endpoint to override the setting value, is the index param is not null. 