### PR TITLE
FSCrawler 2.7 does not support Elasticsearch between 6.0.0 and 6.6.x

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -338,4 +338,7 @@ Upgrade to 2.7
 
 - FSCrawler comes now with an elasticsearch 7.x implementation.
 - FSCrawler also supports YAML format for jobs (default).
+- The elasticsearch 6.x implementation does not support elasticsearch versions prior to 6.7.
+If you are using an older version, it's better to upgrade or you need to "hack" the distribution
+and replace all elasticsearch/lucene jars to the 6.6 version.
 


### PR DESCRIPTION
Due to a change in 6.7 HLRest Client, FSCrawler ES6X distribution does not support anymore a version before 6.7.
This probably won't be fixed as per discussion in https://github.com/elastic/elasticsearch/issues/41647 so we need to document this breaking change.

Closes #713