### PR TITLE
Add option to ignore symbolic links

### DIFF
--- a/crawler/crawler-fs/src/main/java/fr/pilato/elasticsearch/crawler/fs/crawler/fs/FileAbstractorFile.java
+++ b/crawler/crawler-fs/src/main/java/fr/pilato/elasticsearch/crawler/fs/crawler/fs/FileAbstractorFile.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -72,7 +73,11 @@ public class FileAbstractorFile extends FileAbstractor<File> {
     @Override
     public Collection<FileAbstractModel> getFiles(String dir) {
         logger.debug("Listing local files from {}", dir);
-        File[] files = new File(dir).listFiles();
+
+        File[] files = new File(dir).listFiles(file -> {
+            if (fsSettings.getFs().isFollowSymlinks()) return true;
+            return !Files.isSymbolicLink(file.toPath());
+        });
         Collection<FileAbstractModel> result;
 
         if (files != null) {

--- a/docs/source/admin/fs/local-fs.rst
+++ b/docs/source/admin/fs/local-fs.rst
@@ -52,6 +52,8 @@ Here is a list of Local FS settings (under ``fs.`` prefix)`:
 +----------------------------+-----------------------+---------------------------------+
 | ``fs.checksum``            | ``null``              | `File Checksum`_                |
 +----------------------------+-----------------------+---------------------------------+
+| ``fs.follow_symlinks``     | ``false``             | `Follow Symlinks`_              |
++----------------------------+-----------------------+---------------------------------+
 
 .. _root-directory:
 
@@ -731,3 +733,17 @@ such as ``MD5`` or ``SHA-1``.
    name: "test"
    fs:
      checksum: "MD5"
+
+Follow Symlinks
+^^^^^^^^^^^^^^^
+
+.. versionadded:: 2.7
+
+If you want FSCrawler to follow the symbolic links, you need to be explicit about it and set
+``follow_symlink`` to ``true``. Starting from version 2.7, symbolic links are not followed anymore.
+
+.. code:: yaml
+
+   name: "test"
+   fs:
+     follow_symlink: true

--- a/docs/source/fscrawler.ini
+++ b/docs/source/fscrawler.ini
@@ -2,10 +2,10 @@
 Version=2.7-SNAPSHOT
 
 [3rdParty]
-TikaVersion=1.20
+TikaVersion=1.21
 ElasticsearchVersion5=5.6.15
 ElasticsearchVersion6=6.8.0
-ElasticsearchVersion7=7.1.0
+ElasticsearchVersion7=7.1.1
 LevigoVersion=2.0
 TiffVersion=1.4.0
 JpegVersion=1.3.0

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -341,4 +341,5 @@ Upgrade to 2.7
 - The elasticsearch 6.x implementation does not support elasticsearch versions prior to 6.7.
 If you are using an older version, it's better to upgrade or you need to "hack" the distribution
 and replace all elasticsearch/lucene jars to the 6.6 version.
-
+- FSCrawler does not follow symbolic links anymore. You need to set explicitly ``fs.follow_symlink``
+to ``true`` if you wish revert to the previous behavior.

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerTestFollowSymlinksIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/FsCrawlerTestFollowSymlinksIT.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package fr.pilato.elasticsearch.crawler.fs.test.integration;
+
+import fr.pilato.elasticsearch.crawler.fs.client.ESSearchRequest;
+import fr.pilato.elasticsearch.crawler.fs.settings.Fs;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Test with symlinks
+ */
+public class FsCrawlerTestFollowSymlinksIT extends AbstractFsCrawlerITCase {
+
+    @Test
+    public void test_follow_symlinks_disabled() throws Exception {
+        // We create a symlink
+        Path source = currentTestResourceDir.resolve("roottxtfile.txt");
+        Path link = currentTestResourceDir.resolve("link_roottxtfile.txt");
+        Files.createSymbolicLink(link, source);
+
+        Fs fs = startCrawlerDefinition()
+                .setFollowSymlinks(false)
+                .build();
+        startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+
+        // We should have two docs first
+        countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, currentTestResourceDir);
+    }
+
+    @Test
+    public void test_follow_symlinks_enabled() throws Exception {
+        // We create a symlink
+        Path source = currentTestResourceDir.resolve("roottxtfile.txt");
+        Path link = currentTestResourceDir.resolve("link_roottxtfile.txt");
+        Files.createSymbolicLink(link, source);
+
+        Fs fs = startCrawlerDefinition()
+                .setFollowSymlinks(true)
+                .build();
+        startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+
+        // We should have two docs first
+        countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 2L, currentTestResourceDir);
+    }
+}

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Fs.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Fs.java
@@ -57,6 +57,7 @@ public class Fs {
     private boolean continueOnError = false;
     private Ocr ocr = new Ocr();
     private ByteSizeValue ignoreAbove = null;
+    private boolean followSymlinks = false;
 
     public static Builder builder() {
         return new Builder();
@@ -89,6 +90,7 @@ public class Fs {
         private boolean continueOnError = false;
         private Ocr ocr = new Ocr();
         private ByteSizeValue ignoreAbove = null;
+        private boolean followSymlinks = false;
 
         public Builder setUrl(String url) {
             this.url = url;
@@ -239,10 +241,15 @@ public class Fs {
             return this;
         }
 
+        public Builder setFollowSymlinks(boolean followSymlinks) {
+            this.followSymlinks = followSymlinks;
+            return this;
+        }
+
         public Fs build() {
             return new Fs(url, updateRate, includes, excludes, filters, jsonSupport, filenameAsId, addFilesize,
                     removeDeleted, addAsInnerObject, storeSource, indexedChars, indexContent, attributesSupport, rawMetadata,
-                    checksum, xmlSupport, indexFolders, langDetect, continueOnError, ocr, ignoreAbove);
+                    checksum, xmlSupport, indexFolders, langDetect, continueOnError, ocr, ignoreAbove, followSymlinks);
         }
     }
 
@@ -253,7 +260,7 @@ public class Fs {
     private Fs(String url, TimeValue updateRate, List<String> includes, List<String> excludes, List<String> filters, boolean jsonSupport,
                boolean filenameAsId, boolean addFilesize, boolean removeDeleted, boolean addAsInnerObject, boolean storeSource,
                Percentage indexedChars, boolean indexContent, boolean attributesSupport, boolean rawMetadata, String checksum, boolean xmlSupport,
-               boolean indexFolders, boolean langDetect, boolean continueOnError, Ocr ocr, ByteSizeValue ignoreAbove) {
+               boolean indexFolders, boolean langDetect, boolean continueOnError, Ocr ocr, ByteSizeValue ignoreAbove, boolean followSymlinks) {
         this.url = url;
         this.updateRate = updateRate;
         this.includes = includes;
@@ -276,6 +283,7 @@ public class Fs {
         this.continueOnError = continueOnError;
         this.ocr = ocr;
         this.ignoreAbove = ignoreAbove;
+        this.followSymlinks = followSymlinks;
     }
 
     public String getUrl() {
@@ -470,6 +478,14 @@ public class Fs {
         this.ignoreAbove = ignoreAbove;
     }
 
+    public boolean isFollowSymlinks() {
+        return followSymlinks;
+    }
+
+    public void setFollowSymlinks(boolean followSymlinks) {
+        this.followSymlinks = followSymlinks;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -488,6 +504,7 @@ public class Fs {
                 indexFolders == fs.indexFolders &&
                 langDetect == fs.langDetect &&
                 continueOnError == fs.continueOnError &&
+                followSymlinks == fs.followSymlinks &&
                 Objects.equals(url, fs.url) &&
                 Objects.equals(updateRate, fs.updateRate) &&
                 Objects.equals(includes, fs.includes) &&
@@ -502,7 +519,8 @@ public class Fs {
     @Override
     public int hashCode() {
         return Objects.hash(url, updateRate, includes, excludes, filters, jsonSupport, filenameAsId, addFilesize,
-                removeDeleted, addAsInnerObject, storeSource, indexContent, indexedChars, attributesSupport, rawMetadata, xmlSupport, checksum, indexFolders, langDetect, continueOnError, ocr, ignoreAbove);
+                removeDeleted, addAsInnerObject, storeSource, indexContent, indexedChars, attributesSupport, rawMetadata, xmlSupport,
+                checksum, indexFolders, langDetect, continueOnError, ocr, ignoreAbove, followSymlinks);
     }
 
     @Override
@@ -529,6 +547,7 @@ public class Fs {
                 ", continueOnError=" + continueOnError +
                 ", ocr=" + ocr +
                 ", ignoreAbove=" + ignoreAbove +
+                ", followSymlinks=" + followSymlinks +
                 '}';
     }
 }


### PR DESCRIPTION
This commit changes the default behavior of elasticsearch. Previously we were following all the symbolic links which could cause some troubles on some OS.

If you want to revert to the previous behavior, configure `fs.follow_symlink` to `true`.

```yml
name: "test"
fs:
  follow_symlink: true
```

Closes #752.