### PR TITLE
Allow passing test parameters to Maven CLI

### DIFF
--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
@@ -238,7 +238,7 @@ public abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
     @BeforeClass
     public static void startElasticsearchRestClient() throws IOException {
         String testClusterCloudId = System.getProperty("tests.cluster.cloud_id");
-        if (testClusterCloudId != null) {
+        if (testClusterCloudId != null && !testClusterCloudId.isEmpty()) {
             testClusterUrl = decodeCloudId(testClusterCloudId);
             staticLogger.debug("Using cloud id [{}] meaning actually [{}]", testClusterCloudId, testClusterUrl);
         } else {

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
@@ -243,6 +243,10 @@ public abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
             staticLogger.debug("Using cloud id [{}] meaning actually [{}]", testClusterCloudId, testClusterUrl);
         } else {
             testClusterUrl = System.getProperty("tests.cluster.url", DEFAULT_TEST_CLUSTER_URL);
+            if (testClusterUrl.isEmpty()) {
+                // When running from Maven CLI, tests.cluster.url is empty and not null...
+                testClusterUrl = DEFAULT_TEST_CLUSTER_URL;
+            }
         }
 
         staticLogger.info("Starting a client against [{}]", testClusterUrl);

--- a/integration-tests/it-v6/pom.xml
+++ b/integration-tests/it-v6/pom.xml
@@ -180,7 +180,7 @@
                                             <discovery.type>single-node</discovery.type>
                                             <xpack.license.self_generated.type>trial</xpack.license.self_generated.type>
                                             <xpack.security.enabled>true</xpack.security.enabled>
-                                            <ELASTIC_PASSWORD>${integ.security.password}</ELASTIC_PASSWORD>
+                                            <ELASTIC_PASSWORD>${tests.cluster.pass}</ELASTIC_PASSWORD>
                                         </env>
                                     </build>
                                     <run>

--- a/integration-tests/it-v7/pom.xml
+++ b/integration-tests/it-v7/pom.xml
@@ -180,7 +180,7 @@
                                             <discovery.type>single-node</discovery.type>
                                             <xpack.license.self_generated.type>trial</xpack.license.self_generated.type>
                                             <xpack.security.enabled>true</xpack.security.enabled>
-                                            <ELASTIC_PASSWORD>${integ.security.password}</ELASTIC_PASSWORD>
+                                            <ELASTIC_PASSWORD>${tests.cluster.pass}</ELASTIC_PASSWORD>
                                         </env>
                                     </build>
                                     <run>

--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,12 @@
         <!-- For integration tests using Docker or external cluster -->
         <integ.elasticsearch.image>docker.elastic.co/elasticsearch/elasticsearch</integ.elasticsearch.image>
         <integ.elasticsearch.version>${elasticsearch.version}</integ.elasticsearch.version>
-        <integ.security.username>elastic</integ.security.username>
-        <integ.security.password>changeme</integ.security.password>
         <integ.elasticsearch.port>9200</integ.elasticsearch.port>
+        <tests.cluster.url></tests.cluster.url>
+        <tests.cluster.cloud_id></tests.cluster.cloud_id>
+        <tests.cluster.user>elastic</tests.cluster.user>
+        <tests.cluster.pass>changeme</tests.cluster.pass>
+        <tests.rest.port>8080</tests.rest.port>
 
         <!-- Randomized testing framework -->
         <tests.locale>random</tests.locale>
@@ -192,6 +195,11 @@
                             <tests.timezone>${tests.timezone}</tests.timezone>
                             <java.util.logging.manager>org.apache.logging.log4j.jul.LogManager</java.util.logging.manager>
                             <java.awt.headless>true</java.awt.headless>
+                            <tests.cluster.url>${tests.cluster.url}</tests.cluster.url>
+                            <tests.cluster.cloud_id>${tests.cluster.cloud_id}</tests.cluster.cloud_id>
+                            <tests.cluster.user>${tests.cluster.user}</tests.cluster.user>
+                            <tests.cluster.pass>${tests.cluster.pass}</tests.cluster.pass>
+                            <tests.rest.port>${tests.rest.port}</tests.rest.port>
                         </systemProperties>
                     </configuration>
 


### PR DESCRIPTION
What we documented about our tests using options like `tests.cluster.url`, `tests.cluster.cloud_id`, `tests.cluster.user` and `tests.cluster.pass` was actually working only from the IDE but not when using Maven CLI.
This change makes sure we are passing all those env variables to the randomizedtesting maven plugin.

We are also doing that with `tests.rest.port` which is yet undocumented but will be soon with #728.

Closes #727.