### PR TITLE
Add a test for the SignTool utility

### DIFF
--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/SignToolTest.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/SignToolTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to David Pilato under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package fr.pilato.elasticsearch.crawler.fs.framework;
+
+import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
+import org.junit.Test;
+
+import java.security.NoSuchAlgorithmException;
+
+import static fr.pilato.elasticsearch.crawler.fs.framework.SignTool.sign;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class SignToolTest extends AbstractFSCrawlerTestCase {
+
+    @Test
+    public void testSign() throws NoSuchAlgorithmException {
+        String signature = sign("ABCD");
+        assertThat(signature, is("cb8ca4a7bb5f9683c19133a84872ca7"));
+    }
+
+}


### PR DESCRIPTION
So we make sure it does not change over time otherwise we would consider it as a breaking change.

Relates to #775.