### PR TITLE
sun.jnu.encoding=UTF-8 needs to be added on boot

### DIFF
--- a/distribution/src/main/scripts/fscrawler
+++ b/distribution/src/main/scripts/fscrawler
@@ -38,6 +38,7 @@ JAVA_OPTS="$JAVA_OPTS -Djava.awt.headless=true"
 
 # Ensure UTF-8 encoding by default (e.g. filenames)
 JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8"
+JAVA_OPTS="$JAVA_OPTS -Dsun.jnu.encoding=UTF-8"
 
 # Use LOG4J2 instead of java.util.logging
 JAVA_OPTS="$JAVA_OPTS -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"


### PR DESCRIPTION
This is a very important property we need to deal with. Specially when we need to work with file system from CLI. `sun.jnu.encoding=UTF-8` is not well documented but it be the last resort to solve file naming issues in CLI.