### PR TITLE
Fix CVE reports until Tika 1.23

### DIFF
--- a/docs/source/fscrawler.ini
+++ b/docs/source/fscrawler.ini
@@ -4,7 +4,7 @@ Version=2.7-SNAPSHOT
 [3rdParty]
 TikaVersion=1.22
 ElasticsearchVersion5=5.6.15
-ElasticsearchVersion6=6.8.2
+ElasticsearchVersion6=6.8.5
 ElasticsearchVersion7=7.4.1
 LevigoVersion=2.0
 TiffVersion=1.4.0

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <properties>
         <elasticsearch.version>7.4.1</elasticsearch.version>
         <elasticsearch7.version>${elasticsearch.version}</elasticsearch7.version>
-        <elasticsearch6.version>6.8.2</elasticsearch6.version>
+        <elasticsearch6.version>6.8.5</elasticsearch6.version>
         <elasticsearch5.version>5.6.15</elasticsearch5.version>
 
         <tika.version>1.22</tika.version>
@@ -559,6 +559,28 @@
                 <version>4.2</version>
             </dependency>
 
+            <!-- We manually update until we have a Tika 1.23 version available -->
+            <dependency>
+                <groupId>org.apache.poi</groupId>
+                <artifactId>poi</artifactId>
+                <version>4.1.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.poi</groupId>
+                <artifactId>poi-scratchpad</artifactId>
+                <version>4.1.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.poi</groupId>
+                <artifactId>poi-ooxml</artifactId>
+                <version>4.1.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>1.19</version>
+            </dependency>
+            
             <dependency>
                 <groupId>org.apache.tika</groupId>
                 <artifactId>tika-parsers</artifactId>


### PR DESCRIPTION
* Update Elasticsearch 6.x to 6.8.5
* Force Apache poi to 4.1.1
* Force Apache commons-compress to 1.19