### PR TITLE
Add `path_prefix` option

### DIFF
--- a/docs/source/admin/fs/elasticsearch.rst
+++ b/docs/source/admin/fs/elasticsearch.rst
@@ -22,6 +22,8 @@ Here is a list of Elasticsearch settings (under ``elasticsearch.`` prefix)`:
 +----------------------------------+---------------------------+---------------------------------+
 | ``elasticsearch.nodes``          | ``http://127.0.0.1:9200`` | `Node settings`_                |
 +----------------------------------+---------------------------+---------------------------------+
+| ``elasticsearch.path_prefix``    | ``null``                  | `Path prefix`_                  |
++----------------------------------+---------------------------+---------------------------------+
 | ``elasticsearch.username``       | ``null``                  | :ref:`credentials`              |
 +----------------------------------+---------------------------+---------------------------------+
 | ``elasticsearch.password``       | ``null``                  | :ref:`credentials`              |
@@ -512,6 +514,24 @@ You can define multiple nodes:
          - url: "https://CLUSTERID.eu-west-1.aws.found.io:9243"
 
     For more information, read :ref:`ssl`.
+
+Path prefix
+^^^^^^^^^^^
+
+.. versionadded:: 2.7 If your elasticsearch is running behind a proxy with url rewriting,
+you might have to specify a path prefix. This can be done with ``path_prefix`` setting:
+
+.. code:: yaml
+
+   name: "test"
+   elasticsearch:
+     nodes:
+     - url: "http://mynode1.mycompany.com:9200"
+     path_prefix: "/path/to/elasticsearch"
+
+.. note::
+
+    The same ``path_prefix`` applies to all nodes.
 
 .. _credentials:
 

--- a/elasticsearch-client/elasticsearch-client-v6/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v6/ElasticsearchClientV6.java
+++ b/elasticsearch-client/elasticsearch-client-v6/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v6/ElasticsearchClientV6.java
@@ -408,6 +408,10 @@ public class ElasticsearchClientV6 implements ElasticsearchClient {
 
         RestClientBuilder builder = RestClient.builder(hosts.toArray(new HttpHost[hosts.size()]));
 
+        if (settings.getPathPrefix() != null) {
+            builder.setPathPrefix(settings.getPathPrefix());
+        }
+
         if (settings.getUsername() != null) {
             CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
             credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(settings.getUsername(), settings.getPassword()));

--- a/elasticsearch-client/elasticsearch-client-v7/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v7/ElasticsearchClientV7.java
+++ b/elasticsearch-client/elasticsearch-client-v7/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v7/ElasticsearchClientV7.java
@@ -386,6 +386,10 @@ public class ElasticsearchClientV7 implements ElasticsearchClient {
 
         RestClientBuilder builder = RestClient.builder(hosts.toArray(new HttpHost[hosts.size()]));
 
+        if (settings.getPathPrefix() != null) {
+            builder.setPathPrefix(settings.getPathPrefix());
+        }
+
         if (settings.getUsername() != null) {
             CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
             credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(settings.getUsername(), settings.getPassword()));

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Elasticsearch.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Elasticsearch.java
@@ -46,13 +46,15 @@ public class Elasticsearch {
     @JsonIgnore
     private String password;
     private String pipeline;
+    private String pathPrefix;
 
     public Elasticsearch() {
 
     }
 
     private Elasticsearch(List<ServerUrl> nodes, String index, String indexFolder, int bulkSize,
-                          TimeValue flushInterval, ByteSizeValue byteSize, String username, String password, String pipeline) {
+                          TimeValue flushInterval, ByteSizeValue byteSize, String username, String password, String pipeline,
+                          String pathPrefix) {
         this.nodes = nodes;
         this.index = index;
         this.indexFolder = indexFolder;
@@ -62,6 +64,7 @@ public class Elasticsearch {
         this.username = username;
         this.password = password;
         this.pipeline = pipeline;
+        this.pathPrefix = pathPrefix;
     }
 
     public static Builder builder() {
@@ -134,6 +137,14 @@ public class Elasticsearch {
         this.pipeline = pipeline;
     }
 
+    public String getPathPrefix() {
+        return pathPrefix;
+    }
+
+    public void setPathPrefix(String pathPrefix) {
+        this.pathPrefix = pathPrefix;
+    }
+
     public static class Builder {
         private List<ServerUrl> nodes;
         private String index;
@@ -144,6 +155,7 @@ public class Elasticsearch {
         private String username = null;
         private String password = null;
         private String pipeline = null;
+        private String pathPrefix = null;
 
         public Builder setNodes(List<ServerUrl> nodes) {
             this.nodes = nodes;
@@ -198,8 +210,13 @@ public class Elasticsearch {
             return this;
         }
 
+        public Builder setPathPrefix(String pathPrefix) {
+            this.pathPrefix = pathPrefix;
+            return this;
+        }
+
         public Elasticsearch build() {
-            return new Elasticsearch(nodes, index, indexFolder, bulkSize, flushInterval, byteSize, username, password, pipeline);
+            return new Elasticsearch(nodes, index, indexFolder, bulkSize, flushInterval, byteSize, username, password, pipeline, pathPrefix);
         }
     }
 
@@ -217,6 +234,7 @@ public class Elasticsearch {
         if (!Objects.equals(username, that.username)) return false;
         // We can't really test the password as it may be obfuscated
         if (!Objects.equals(pipeline, that.pipeline)) return false;
+        if (!Objects.equals(pathPrefix, that.pathPrefix)) return false;
         return Objects.equals(flushInterval, that.flushInterval);
 
     }
@@ -228,6 +246,7 @@ public class Elasticsearch {
         result = 31 * result + (indexFolder != null ? indexFolder.hashCode() : 0);
         result = 31 * result + (username != null ? username.hashCode() : 0);
         result = 31 * result + (pipeline != null ? pipeline.hashCode() : 0);
+        result = 31 * result + (pathPrefix != null ? pathPrefix.hashCode() : 0);
         result = 31 * result + bulkSize;
         result = 31 * result + (flushInterval != null ? flushInterval.hashCode() : 0);
         return result;
@@ -243,6 +262,7 @@ public class Elasticsearch {
                 ", byteSize=" + byteSize +
                 ", username='" + username + '\'' +
                 ", pipeline='" + pipeline + '\'' +
+                ", pathPrefix='" + pathPrefix + '\'' +
                 '}';
     }
 }

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsParserTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsParserTest.java
@@ -221,6 +221,17 @@ public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
     }
 
     @Test
+    public void testParseSettingsElasticsearchWithPathPrefix() throws IOException {
+        settingsTester(
+                FsSettings.builder(getCurrentTestName())
+                        .setElasticsearch(Elasticsearch.builder()
+                                .setPathPrefix("/path/to/elasticsearch")
+                                .build())
+                        .build()
+        );
+    }
+
+    @Test
     public void testParseSettingsElasticsearchCloudId() throws IOException {
         String cloudId = "fscrawler:ZXVyb3BlLXdlc3QxLmdjcC5jbG91ZC5lcy5pbyQxZDFlYTk5Njg4Nzc0NWE2YTJiN2NiNzkzMTUzNDhhMyQyOTk1MDI3MzZmZGQ0OTI5OTE5M2UzNjdlOTk3ZmU3Nw==";
         FsSettings fsSettings = FsSettings.builder(getCurrentTestName())


### PR DESCRIPTION
If your elasticsearch is running behind a proxy with url rewriting,
you might have to specify a path prefix. This can be done with `path_prefix` setting:

```yml
name: "test"
elasticsearch:
  nodes:
  - url: "http://mynode1.mycompany.com:9200"
  path_prefix: "/path/to/elasticsearch"
```

**Note:** The same `path_prefix` applies to all nodes.

Closes #816