### PR TITLE
Fix flaky tests

### DIFF
--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
@@ -377,7 +377,7 @@ public abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
             // Let's search for entries
             try {
                 response[0] = esClient.search(request);
-            } catch (IOException e) {
+            } catch (RuntimeException|IOException e) {
                 staticLogger.warn("error caught", e);
                 return -1;
             }


### PR DESCRIPTION
Sometimes the shards do not seem to be ready for querying just after the index creation and we are failing the suite.
It sounds like Elasticsearch can throw an `ElasticsearchException` which is a `RuntimeException` and not an `IOException`.

This change tries to catch it so we can retry before failing.