### PR TITLE
Force some dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -555,6 +555,24 @@
                 <version>4.2.1</version>
             </dependency>
 
+            <!-- This is needed to compile on my machine :( -->
+            <dependency>
+                <groupId>com.sun.activation</groupId>
+                <artifactId>jakarta.activation</artifactId>
+                <version>1.2.2</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.activation</groupId>
+                <artifactId>jakarta.activation-api</artifactId>
+                <version>1.2.2</version>
+            </dependency>
+            <!-- This is needed to compile on my machine :( -->
+            <dependency>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>2.3.3</version>
+            </dependency>
+
             <!-- We manually update until we have a Tika 1.23 version available -->
             <dependency>
                 <groupId>org.apache.poi</groupId>


### PR DESCRIPTION
This seems to be needed when compiling the project locally:

```
[INFO] --- maven-enforcer-plugin:3.0.0-M3:enforce (enforce) @ fscrawler-core ---
[WARNING]
Dependency convergence error for com.sun.activation:jakarta.activation:1.2.1 paths to dependency are:
+-fr.pilato.elasticsearch.crawler:fscrawler-core:2.7-SNAPSHOT
  +-org.apache.tika:tika-parsers:1.24.1
    +-com.sun.activation:jakarta.activation:1.2.1
and
+-fr.pilato.elasticsearch.crawler:fscrawler-core:2.7-SNAPSHOT
  +-org.apache.tika:tika-langdetect:1.24.1
    +-com.sun.activation:jakarta.activation:1.2.1
and
+-fr.pilato.elasticsearch.crawler:fscrawler-core:2.7-SNAPSHOT
  +-org.glassfish.jersey.containers:jersey-container-grizzly2-http:2.31
    +-org.glassfish.jersey.core:jersey-common:2.31
      +-com.sun.activation:jakarta.activation:1.2.2

[WARNING]
Dependency convergence error for jakarta.xml.bind:jakarta.xml.bind-api:2.3.2 paths to dependency are:
+-fr.pilato.elasticsearch.crawler:fscrawler-core:2.7-SNAPSHOT
  +-fr.pilato.elasticsearch.crawler:fscrawler-framework:2.7-SNAPSHOT
    +-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.11.1
      +-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.11.1
        +-jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
and
+-fr.pilato.elasticsearch.crawler:fscrawler-core:2.7-SNAPSHOT
  +-org.apache.tika:tika-parsers:1.24.1
    +-org.glassfish.jaxb:jaxb-runtime:2.3.2
      +-jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
and
+-fr.pilato.elasticsearch.crawler:fscrawler-core:2.7-SNAPSHOT
  +-org.apache.tika:tika-parsers:1.24.1
    +-org.glassfish.jaxb:jaxb-runtime:2.3.2
      +-org.jvnet.staxex:stax-ex:1.8.1
        +-jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
and
+-fr.pilato.elasticsearch.crawler:fscrawler-core:2.7-SNAPSHOT
  +-org.glassfish.jersey.containers:jersey-container-grizzly2-http:2.31
    +-org.glassfish.jersey.core:jersey-server:2.31
      +-jakarta.xml.bind:jakarta.xml.bind-api:2.3.3

[WARNING] Rule 1: org.apache.maven.plugins.enforcer.DependencyConvergence failed with message:
Failed while enforcing releasability. See above detailed error message.
```