### PR TITLE
Processing pipeline support

### DIFF
--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/DefaultProcessingPipeline.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/DefaultProcessingPipeline.java
@@ -22,7 +22,9 @@ import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.util.Collections;
 
 /**
  * The processing pipeline that will be used if not overridden.
@@ -67,9 +69,9 @@ public class DefaultProcessingPipeline implements ProcessingPipeline {
     }
 
     @Override
-    public void init(Config config) {
+    public void init(Config config) throws IOException {
         this.config = config;
-        tika = new TikaProcessor(config.getFsSettings(), config.getMessageDigest());
+        tika = new TikaProcessor(config.getFsSettings(), config.getMessageDigest(), Collections.emptyMap());
         es = new EsIndexProcessor(config.getFsSettings(), config.getEsClient());
     }
 }

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/DefaultProcessingPipeline.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/DefaultProcessingPipeline.java
@@ -35,10 +35,10 @@ public class DefaultProcessingPipeline implements ProcessingPipeline {
     protected EsIndexProcessor es;
     protected Config config;
 
-    public DefaultProcessingPipeline() { }
-
     @Override
     public void processFile(FsCrawlerContext ctx) {
+        logger.debug("Starting processing of file {}", ctx.getFullFilename());
+
         // Extracting content with Tika
         tika.process(ctx);
 

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/DefaultProcessingPipeline.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/DefaultProcessingPipeline.java
@@ -21,6 +21,8 @@ package fr.pilato.elasticsearch.crawler.fs;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.lang.invoke.MethodHandles;
+
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.isIndexable;
 
 /**
@@ -28,7 +30,7 @@ import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.isIndex
  *
  */
 public class DefaultProcessingPipeline implements ProcessingPipeline {
-    private static final Logger logger = LogManager.getLogger(DefaultProcessingPipeline.class);
+    private static final Logger logger = LogManager.getLogger(MethodHandles.lookup().lookupClass());
     private final TikaProcessor tika;
     private final EsIndexProcessor es;
 

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/DefaultProcessingPipeline.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/DefaultProcessingPipeline.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package fr.pilato.elasticsearch.crawler.fs;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.isIndexable;
+
+/**
+ * The processing pipeline that will be used if not overridden.
+ *
+ */
+public class DefaultProcessingPipeline implements ProcessingPipeline {
+    private static final Logger logger = LogManager.getLogger(DefaultProcessingPipeline.class);
+    private final TikaProcessor tika;
+    private final EsIndexProcessor es;
+
+    public DefaultProcessingPipeline() {
+        tika = new TikaProcessor();
+        es = new EsIndexProcessor();
+    }
+
+    @Override
+    public void processFile(FsCrawlerContext ctx) {
+        // Extracting content with Tika
+        tika.process(ctx);
+
+        // Index to es
+        if (isIndexable(ctx.getDoc().getContent(), ctx.getFsSettings().getFs().getFilters())) {
+            es.process(ctx);
+        } else {
+            logger.debug("We ignore file [{}] because it does not match all the patterns {}", ctx.getFile().getName(),
+                    ctx.getFsSettings().getFs().getFilters());
+        }
+    }
+}

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/EsIndexProcessor.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/EsIndexProcessor.java
@@ -33,7 +33,8 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 
 /**
- * Pulls {@link fr.pilato.elasticsearch.crawler.fs.beans.Doc} from context and indexes it to Elasticsearch
+ * Pulls {@link fr.pilato.elasticsearch.crawler.fs.beans.Doc} from context,
+ * merges it with 'extraDoc' if it exists and then indexes it to Elasticsearch
  */
 public class EsIndexProcessor implements Processor {
     private static final Logger logger = LogManager.getLogger(MethodHandles.lookup().lookupClass());
@@ -65,13 +66,13 @@ public class EsIndexProcessor implements Processor {
         return new Gson().toJson(doc);
     }
 
-    String generateId(FsCrawlerContext ctx) {
+    protected String generateId(FsCrawlerContext ctx) {
         try {
             return ctx.getFsSettings().getFs().isFilenameAsId() ?
                     ctx.getFile().getName() :
                     SignTool.sign((new File(ctx.getFile().getName(), ctx.getFilepath())).toString());
         } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
+            throw new ProcessingException(e);
         }
     }
 }

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/EsIndexProcessor.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/EsIndexProcessor.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package fr.pilato.elasticsearch.crawler.fs;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import fr.pilato.elasticsearch.crawler.fs.beans.DocParser;
+import fr.pilato.elasticsearch.crawler.fs.framework.SignTool;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.File;
+import java.lang.invoke.MethodHandles;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * Pulls {@link fr.pilato.elasticsearch.crawler.fs.beans.Doc} from context and indexes it to Elasticsearch
+ */
+public class EsIndexProcessor implements Processor {
+    private static final Logger logger = LogManager.getLogger(MethodHandles.lookup().lookupClass());
+
+    @Override
+    public void process(FsCrawlerContext ctx) throws ProcessingException {
+        try {
+            long startTime = System.currentTimeMillis();
+            String index = ctx.getFsSettings().getElasticsearch().getIndex();
+            String id = generateId(ctx);
+            String pipeline = ctx.getFsSettings().getElasticsearch().getPipeline();
+            String json = DocParser.toJson(ctx.getDoc());
+            ctx.getEsClient().index(index, id, json, pipeline);
+            logger.debug("Indexed {}/{}?pipeline={} in {}ms", index, id, pipeline,
+                    System.currentTimeMillis() - startTime);
+            logger.trace("JSon indexed : {}", json);
+        } catch (JsonProcessingException e) {
+            throw new ProcessingException(e);
+        }
+    }
+
+    String generateId(FsCrawlerContext ctx) {
+        try {
+            return ctx.getFsSettings().getFs().isFilenameAsId() ?
+                    ctx.getFile().getName() :
+                    SignTool.sign((new File(ctx.getFile().getName(), ctx.getFilepath())).toString());
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsCrawlerContext.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsCrawlerContext.java
@@ -19,12 +19,9 @@
 package fr.pilato.elasticsearch.crawler.fs;
 
 import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
-import fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchClient;
 import fr.pilato.elasticsearch.crawler.fs.crawler.FileAbstractModel;
-import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
 
 import java.io.InputStream;
-import java.security.MessageDigest;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -34,22 +31,15 @@ import java.util.Map;
  */
 public class FsCrawlerContext {
     private final FileAbstractModel file;
-    private final FsSettings fsSettings;
     private final String filepath;
-    private final ElasticsearchClient esClient;
     private final InputStream inputStream;
     private final String fullFilename;
     private final Map<String, Object> extraDoc;
     private Doc doc;
 
-    private final MessageDigest messageDigest;
-
     public FsCrawlerContext(Builder builder) {
         this.file = builder.file;
-        this.fsSettings = builder.fsSettings;
         this.filepath = builder.filepath;
-        this.messageDigest = builder.messageDigest;
-        this.esClient = builder.esClient;
         this.inputStream = builder.inputStream;
         this.fullFilename = builder.fullFilename;
         this.doc = builder.doc;
@@ -58,10 +48,6 @@ public class FsCrawlerContext {
 
     public FileAbstractModel getFile() {
         return file;
-    }
-
-    public FsSettings getFsSettings() {
-        return fsSettings;
     }
 
     public String getFilepath() {
@@ -74,14 +60,6 @@ public class FsCrawlerContext {
 
     public Doc getDoc() {
         return doc;
-    }
-
-    public MessageDigest getMessageDigest() {
-        return messageDigest;
-    }
-
-    public ElasticsearchClient getEsClient() {
-        return esClient;
     }
 
     public InputStream getInputStream() {
@@ -99,10 +77,7 @@ public class FsCrawlerContext {
 
     public static class Builder {
         private FileAbstractModel file;
-        private FsSettings fsSettings;
         private String filepath;
-        private MessageDigest messageDigest;
-        private ElasticsearchClient esClient;
         private InputStream inputStream;
         private String fullFilename;
         private Doc doc = new Doc();
@@ -113,23 +88,8 @@ public class FsCrawlerContext {
             return this;
         }
 
-        public Builder withFsSettings(FsSettings fsSettings) {
-            this.fsSettings = fsSettings;
-            return this;
-        }
-
         public Builder withFilePath(String filepath) {
             this.filepath = filepath;
-            return this;
-        }
-
-        public Builder withMessageDigest(MessageDigest messageDigest) {
-            this.messageDigest = messageDigest;
-            return this;
-        }
-
-        public Builder withEsClient(ElasticsearchClient esClient) {
-            this.esClient = esClient;
             return this;
         }
 

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsCrawlerContext.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsCrawlerContext.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package fr.pilato.elasticsearch.crawler.fs;
+
+import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
+import fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchClient;
+import fr.pilato.elasticsearch.crawler.fs.crawler.FileAbstractModel;
+import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
+
+import java.io.InputStream;
+import java.security.MessageDigest;
+
+/**
+ * A class that keeps necessary context for the processing pipeline.
+ * Each processor will typically update the 'doc' as needed.
+ */
+public class FsCrawlerContext {
+    private final FileAbstractModel file;
+    private final FsSettings fsSettings;
+    private final String filepath;
+    private final ElasticsearchClient esClient;
+    private final InputStream inputStream;
+    private final String fullFilename;
+    private Doc doc;
+    private final MessageDigest messageDigest;
+
+    public FsCrawlerContext(Builder builder) {
+        this.file = builder.file;
+        this.fsSettings = builder.fsSettings;
+        this.filepath = builder.filepath;
+        this.messageDigest = builder.messageDigest;
+        this.esClient = builder.esClient;
+        this.inputStream = builder.inputStream;
+        this.fullFilename = builder.fullFilename;
+        this.doc = builder.doc;
+    }
+
+    public FileAbstractModel getFile() {
+        return file;
+    }
+
+    public FsSettings getFsSettings() {
+        return fsSettings;
+    }
+
+    public String getFilepath() {
+        return filepath;
+    }
+
+    public void setDoc() {
+        this.doc = new Doc();
+    }
+
+    public Doc getDoc() {
+        return doc;
+    }
+
+    public MessageDigest getMessageDigest() {
+        return messageDigest;
+    }
+
+    public ElasticsearchClient getEsClient() {
+        return esClient;
+    }
+
+    public InputStream getInputStream() {
+        return inputStream;
+    }
+
+    public String getFullFilename() {
+        return fullFilename;
+    }
+
+
+    public static class Builder {
+        private FileAbstractModel file;
+        private FsSettings fsSettings;
+        private String filepath;
+        private MessageDigest messageDigest;
+        private ElasticsearchClient esClient;
+        private InputStream inputStream;
+        private String fullFilename;
+        private Doc doc = new Doc();
+
+        public Builder withFileModel(FileAbstractModel file) {
+            this.file = file;
+            return this;
+        }
+
+        public Builder withFsSettings(FsSettings fsSettings) {
+            this.fsSettings = fsSettings;
+            return this;
+        }
+
+        public Builder withFilePath(String filepath) {
+            this.filepath = filepath;
+            return this;
+        }
+
+        public Builder withMessageDigest(MessageDigest messageDigest) {
+            this.messageDigest = messageDigest;
+            return this;
+        }
+
+        public Builder withEsClient(ElasticsearchClient esClient) {
+            this.esClient = esClient;
+            return this;
+        }
+
+        public Builder withInputStream(InputStream inputStream) {
+            this.inputStream = inputStream;
+            return this;
+        }
+
+        public Builder withFullFilename(String fullFilename) {
+            this.fullFilename = fullFilename;
+            return this;
+        }
+
+        public Builder withDoc(Doc doc) {
+            this.doc = doc;
+            return this;
+        }
+
+        public FsCrawlerContext build() {
+            return new FsCrawlerContext(this);
+        }
+
+    }
+}

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsCrawlerContext.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsCrawlerContext.java
@@ -25,6 +25,8 @@ import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
 
 import java.io.InputStream;
 import java.security.MessageDigest;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A class that keeps necessary context for the processing pipeline.
@@ -37,7 +39,9 @@ public class FsCrawlerContext {
     private final ElasticsearchClient esClient;
     private final InputStream inputStream;
     private final String fullFilename;
+    private final Map<String, Object> extraDoc;
     private Doc doc;
+
     private final MessageDigest messageDigest;
 
     public FsCrawlerContext(Builder builder) {
@@ -49,6 +53,7 @@ public class FsCrawlerContext {
         this.inputStream = builder.inputStream;
         this.fullFilename = builder.fullFilename;
         this.doc = builder.doc;
+        this.extraDoc = builder.extraDoc;
     }
 
     public FileAbstractModel getFile() {
@@ -87,6 +92,10 @@ public class FsCrawlerContext {
         return fullFilename;
     }
 
+    public Map<String, Object> getExtraDoc() {
+        return extraDoc;
+    }
+
 
     public static class Builder {
         private FileAbstractModel file;
@@ -97,6 +106,7 @@ public class FsCrawlerContext {
         private InputStream inputStream;
         private String fullFilename;
         private Doc doc = new Doc();
+        private Map<String,Object> extraDoc = new HashMap<>();
 
         public Builder withFileModel(FileAbstractModel file) {
             this.file = file;
@@ -135,6 +145,11 @@ public class FsCrawlerContext {
 
         public Builder withDoc(Doc doc) {
             this.doc = doc;
+            return this;
+        }
+
+        public Builder withExtraDoc(Map<String,Object> extraDoc) {
+            this.extraDoc = extraDoc;
             return this;
         }
 

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
@@ -104,14 +104,14 @@ public abstract class FsParserAbstract extends FsParser {
             messageDigest = null;
         }
 
+        // Look for a custom processing pipeline
         try {
             Class<?> clazz = FsParserAbstract.class.getClassLoader().loadClass(fsSettings.getFs().getPipeline().getClassName());
             pipeline = (ProcessingPipeline) clazz.getDeclaredConstructor().newInstance();
             pipeline.init(new ProcessingPipeline.Config(fsSettings, esClient, messageDigest, Collections.emptyMap()));
             logger.info("Created processing pipeline {}", this.pipeline.getClass().getName());
         } catch (Exception e) {
-            logger.error("Could not create processing pipeline");
-            e.printStackTrace();
+            throw new RuntimeException("Could not create processing pipeline " + fsSettings.getFs().getPipeline().getClassName() + ". giving up");
         }
 
         // On Windows, when using SSH server, we need to force the "Linux" separator

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
@@ -109,7 +109,7 @@ public abstract class FsParserAbstract extends FsParser {
             pipeline = (ProcessingPipeline) clazz.getDeclaredConstructor().newInstance();
             pipeline.init(new ProcessingPipeline.Config(fsSettings, esClient, messageDigest, Collections.emptyMap()));
             logger.info("Created processing pipeline {}", this.pipeline.getClass().getName());
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+        } catch (Exception e) {
             logger.error("Could not create processing pipeline");
             e.printStackTrace();
         }
@@ -452,7 +452,7 @@ public abstract class FsParserAbstract extends FsParser {
             // Create the Doc object (only needed when we have add_as_inner_object: true (default) or when we don't index json or xml)
             if (fsSettings.getFs().isAddAsInnerObject() || (!fsSettings.getFs().isJsonSupport() && !fsSettings.getFs().isXmlSupport())) {
 
-                String fullFilename = new File(dirname, filename).toString();
+                String fullFilename = new File(dirname, filename).getAbsolutePath();
 
                 Doc doc = new Doc();
 

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
@@ -19,15 +19,24 @@
 
 package fr.pilato.elasticsearch.crawler.fs;
 
-import fr.pilato.elasticsearch.crawler.fs.beans.*;
-import fr.pilato.elasticsearch.crawler.fs.client.*;
+import fr.pilato.elasticsearch.crawler.fs.beans.Attributes;
+import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
+import fr.pilato.elasticsearch.crawler.fs.beans.DocParser;
+import fr.pilato.elasticsearch.crawler.fs.beans.FsJob;
+import fr.pilato.elasticsearch.crawler.fs.beans.FsJobFileHandler;
+import fr.pilato.elasticsearch.crawler.fs.beans.PathParser;
+import fr.pilato.elasticsearch.crawler.fs.beans.ScanStatistic;
+import fr.pilato.elasticsearch.crawler.fs.client.ESSearchHit;
+import fr.pilato.elasticsearch.crawler.fs.client.ESSearchRequest;
+import fr.pilato.elasticsearch.crawler.fs.client.ESSearchResponse;
+import fr.pilato.elasticsearch.crawler.fs.client.ESTermQuery;
+import fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchClient;
 import fr.pilato.elasticsearch.crawler.fs.crawler.FileAbstractModel;
 import fr.pilato.elasticsearch.crawler.fs.crawler.FileAbstractor;
 import fr.pilato.elasticsearch.crawler.fs.framework.ByteSizeValue;
 import fr.pilato.elasticsearch.crawler.fs.framework.OsValidator;
 import fr.pilato.elasticsearch.crawler.fs.framework.SignTool;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
-import fr.pilato.elasticsearch.crawler.fs.settings.Pipeline;
 import fr.pilato.elasticsearch.crawler.fs.tika.XmlDocParser;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
@@ -76,7 +76,7 @@ public abstract class FsParserAbstract extends FsParser {
         this.esClient = esClient;
         this.loop = loop;
         try {
-            Class<?> clazz = FsParserAbstract.class.getClassLoader().loadClass(Pipeline.DEFAULT().getClassName());
+            Class<?> clazz = FsParserAbstract.class.getClassLoader().loadClass(fsSettings.getFs().getPipeline().getClassName());
             this.pipeline = (ProcessingPipeline) clazz.getDeclaredConstructor().newInstance();
             logger.info("Created processing pipeline {}", this.pipeline.getClass().getName());
         } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
@@ -41,8 +41,11 @@ import fr.pilato.elasticsearch.crawler.fs.tika.XmlDocParser;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.BufferedReader;
 import java.io.File;
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.NoSuchFileException;
@@ -57,7 +60,10 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.stream.Collectors;
 
-import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.*;
+import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.computeVirtualPathName;
+import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.isFileSizeUnderLimit;
+import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.isIndexable;
+import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.localDateTimeToDate;
 
 public abstract class FsParserAbstract extends FsParser {
     private static final Logger logger = LogManager.getLogger(FsParserAbstract.class);

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
@@ -57,7 +57,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.stream.Collectors;
 
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.computeVirtualPathName;

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
@@ -241,7 +241,7 @@ public abstract class FsParserAbstract extends FsParser {
         fsJobFileHandler.write(jobName, fsJob);
     }
 
-    private void addFilesRecursively(FileAbstractor<?> abstractor, String filepath, LocalDateTime lastScanDate)
+    private void addFilesRecursively(FileAbstractor<?> path, String filepath, LocalDateTime lastScanDate)
             throws Exception {
 
         logger.debug("indexing [{}] content", filepath);
@@ -251,9 +251,9 @@ public abstract class FsParserAbstract extends FsParser {
             return;
         }
 
-        final Collection<FileAbstractModel> children = abstractor.getFiles(filepath);
-        final Collection<String> fsFolders = new HashSet<>();
-        final Collection<String> fsFiles = new HashSet<>();
+        final Collection<FileAbstractModel> children = path.getFiles(filepath);
+        Collection<String> fsFiles = new ArrayList<>();
+        Collection<String> fsFolders = new ArrayList<>();
 
         if (children != null) {
             boolean ignoreFolder = false;
@@ -287,7 +287,7 @@ public abstract class FsParserAbstract extends FsParser {
                                 if (isFileSizeUnderLimit(fsSettings.getFs().getIgnoreAbove(), child.getSize())) {
                                     try {
                                         indexFile(child, stats, filepath,
-                                                fsSettings.getFs().isIndexContent() || fsSettings.getFs().isStoreSource() ? abstractor.getInputStream(child) : null, child.getSize());
+                                                fsSettings.getFs().isIndexContent() || fsSettings.getFs().isStoreSource() ? path.getInputStream(child) : null, child.getSize());
                                         stats.addFile();
                                     } catch (java.io.FileNotFoundException e) {
                                         if (fsSettings.getFs().isContinueOnError()) {
@@ -316,7 +316,7 @@ public abstract class FsParserAbstract extends FsParser {
                                 fsFolders.add(child.getFullpath());
                                 indexDirectory(child.getFullpath());
                             }
-                            addFilesRecursively(abstractor, child.getFullpath(), lastScanDate);
+                            addFilesRecursively(path, child.getFullpath(), lastScanDate);
                         } else {
                             logger.debug("  - other: {}", filename);
                             logger.debug("Not a file nor a dir. Skipping {}", child.getFullpath());

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/ProcessingException.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/ProcessingException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package fr.pilato.elasticsearch.crawler.fs;
+
+import java.io.IOException;
+
+/**
+ * Thrown by processor plugins
+ */
+public class ProcessingException extends RuntimeException {
+    public ProcessingException(IOException e) {
+        super(e);
+    }
+}

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/ProcessingException.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/ProcessingException.java
@@ -25,4 +25,12 @@ public class ProcessingException extends RuntimeException {
     public ProcessingException(Throwable e) {
         super(e);
     }
+
+    public ProcessingException(String reason) {
+        super(reason);
+    }
+
+    public ProcessingException(String reason, Throwable e) {
+        super(reason, e);
+    }
 }

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/ProcessingException.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/ProcessingException.java
@@ -18,13 +18,11 @@
  */
 package fr.pilato.elasticsearch.crawler.fs;
 
-import java.io.IOException;
-
 /**
  * Thrown by processor plugins
  */
 public class ProcessingException extends RuntimeException {
-    public ProcessingException(IOException e) {
+    public ProcessingException(Throwable e) {
         super(e);
     }
 }

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/ProcessingPipeline.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/ProcessingPipeline.java
@@ -21,6 +21,7 @@ package fr.pilato.elasticsearch.crawler.fs;
 import fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchClient;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
 
+import java.io.IOException;
 import java.security.MessageDigest;
 import java.util.Map;
 
@@ -41,7 +42,7 @@ public interface ProcessingPipeline {
     /**
      * Initialize the pipeline with settings and ES client objects
      */
-    void init(Config config);
+    void init(Config config) throws IOException;
 
     /**
      * This class holds configurations and the ES client for a processing pipeline.

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/ProcessingPipeline.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/ProcessingPipeline.java
@@ -32,7 +32,7 @@ import java.util.Map;
  */
 public interface ProcessingPipeline {
     /**
-     * Process one file
+     * Process one file.
      * @param ctx the context in which to find the file inputstream as well as
      *            other details about the file
      */
@@ -43,7 +43,11 @@ public interface ProcessingPipeline {
      */
     void init(Config config);
 
-    public static class Config {
+    /**
+     * This class holds configurations and the ES client for a processing pipeline.
+     * The configMap supports sending arbitrary configuration to a pipeline.
+     */
+    class Config {
         private final FsSettings fsSettings;
         private final ElasticsearchClient esClient;
         private MessageDigest messageDigest;

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/ProcessingPipeline.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/ProcessingPipeline.java
@@ -18,6 +18,12 @@
  */
 package fr.pilato.elasticsearch.crawler.fs;
 
+import fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchClient;
+import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
+
+import java.security.MessageDigest;
+import java.util.Map;
+
 /**
  * Custom pipeline implementations will implement this interface.
  * A pipeline will find the document with basic metadata in the context,
@@ -25,5 +31,48 @@ package fr.pilato.elasticsearch.crawler.fs;
  * to Elasticsearch through the {@link EsIndexProcessor}
  */
 public interface ProcessingPipeline {
+    /**
+     * Process one file
+     * @param ctx the context in which to find the file inputstream as well as
+     *            other details about the file
+     */
     void processFile(FsCrawlerContext ctx);
+
+    /**
+     * Initialize the pipeline with settings and ES client objects
+     */
+    void init(Config config);
+
+    public static class Config {
+        private final FsSettings fsSettings;
+        private final ElasticsearchClient esClient;
+        private MessageDigest messageDigest;
+        private Map<String, Object> configMap;
+
+        public Config(FsSettings fsSettings,
+                      ElasticsearchClient esClient,
+                      MessageDigest messageDigest,
+                      Map<String,Object> configMap) {
+            this.fsSettings = fsSettings;
+            this.esClient = esClient;
+            this.messageDigest = messageDigest;
+            this.configMap = configMap;
+        }
+
+        public FsSettings getFsSettings() {
+            return fsSettings;
+        }
+
+        public ElasticsearchClient getEsClient() {
+            return esClient;
+        }
+
+        public Map<String, Object> getConfigMap() {
+            return configMap;
+        }
+
+        public MessageDigest getMessageDigest() {
+            return messageDigest;
+        }
+    }
 }

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/ProcessingPipeline.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/ProcessingPipeline.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package fr.pilato.elasticsearch.crawler.fs;
+
+/**
+ * Custom pipeline implementations will implement this interface.
+ * A pipeline will find the document with basic metadata in the context,
+ * and can do various processing, and should end with indexing the document
+ * to Elasticsearch through the {@link EsIndexProcessor}
+ */
+public interface ProcessingPipeline {
+    void processFile(FsCrawlerContext ctx);
+}

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/Processor.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/Processor.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package fr.pilato.elasticsearch.crawler.fs;
+
+/**
+ * A processor reads the context, and will typically update the
+ * 'doc'. It as access to various context and also ES.
+ */
+public interface Processor {
+    public void process(FsCrawlerContext ctx) throws ProcessingException;
+}

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/TikaProcessor.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/TikaProcessor.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package fr.pilato.elasticsearch.crawler.fs;
+
+import fr.pilato.elasticsearch.crawler.fs.beans.DocParser;
+import fr.pilato.elasticsearch.crawler.fs.tika.TikaDocParser;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+
+/**
+ * Tikaprocessor will parse full text and update the Doc instance on context
+ */
+public class TikaProcessor implements Processor {
+    private static final Logger logger = LogManager.getLogger(MethodHandles.lookup().lookupClass());
+
+    @Override
+    public void process(FsCrawlerContext ctx) throws ProcessingException {
+        try {
+            long startTime = System.currentTimeMillis();
+            TikaDocParser.generate(
+                    ctx.getFsSettings(),
+                    ctx.getInputStream(),
+                    ctx.getFile().getName(),
+                    ctx.getFullFilename(),
+                    ctx.getDoc(),
+                    ctx.getMessageDigest(),
+                    ctx.getFile().getSize());
+            logger.debug("Parsing document {} with Tika in {}ms", ctx.getFile().getName(),
+                    System.currentTimeMillis() - startTime);
+            logger.trace("Parsed doc={}", DocParser.toJson(ctx.getDoc()));
+        } catch (IOException e) {
+            throw new ProcessingException(e);
+        }
+    }
+}

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/TikaProcessor.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/TikaProcessor.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.security.MessageDigest;
+import java.util.Map;
 
 /**
  * Tikaprocessor will parse full text and update the Doc instance on context.
@@ -39,10 +40,12 @@ public class TikaProcessor implements Processor {
     private static final Logger logger = LogManager.getLogger(MethodHandles.lookup().lookupClass());
     private FsSettings fsSettings;
     private MessageDigest messageDigest;
+    private Map<String, String> metadataMapping;
 
-    public TikaProcessor(FsSettings fsSettings, MessageDigest messageDigest) {
+    public TikaProcessor(FsSettings fsSettings, MessageDigest messageDigest, Map<String,String> metadataMapping) {
         this.fsSettings = fsSettings;
         this.messageDigest = messageDigest;
+        this.metadataMapping = metadataMapping;
     }
 
     @Override
@@ -56,7 +59,8 @@ public class TikaProcessor implements Processor {
                     ctx.getFullFilename(),
                     ctx.getDoc(),
                     messageDigest,
-                    ctx.getFile().getSize());
+                    ctx.getFile().getSize(),
+                    metadataMapping);
             logger.debug("Parsing document {} with Tika in {}ms", ctx.getFile().getName(),
                     System.currentTimeMillis() - startTime);
             logger.trace("Parsed doc={}", DocParser.toJson(ctx.getDoc()));

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/TikaProcessor.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/TikaProcessor.java
@@ -24,21 +24,26 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
 
 /**
- * Tikaprocessor will parse full text and update the Doc instance on context
+ * Tikaprocessor will parse full text and update the Doc instance on context.
+ * <ul>
+ *     <li>Input: raw file input stream</li>
+ *     <li>Output: Doc with the parsed text and metadata</li>
+ * </ul>
  */
 public class TikaProcessor implements Processor {
     private static final Logger logger = LogManager.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public void process(FsCrawlerContext ctx) throws ProcessingException {
-        try {
+        try(InputStream stream = ctx.getInputStream()) {
             long startTime = System.currentTimeMillis();
             TikaDocParser.generate(
                     ctx.getFsSettings(),
-                    ctx.getInputStream(),
+                    stream,
                     ctx.getFile().getName(),
                     ctx.getFullFilename(),
                     ctx.getDoc(),

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/TikaProcessor.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/TikaProcessor.java
@@ -48,11 +48,11 @@ public class TikaProcessor implements Processor {
 
     @Override
     public void process(FsCrawlerContext ctx) throws ProcessingException {
-        try(InputStream stream = ctx.getInputStream()) {
+        try {
             long startTime = System.currentTimeMillis();
             TikaDocParser.generate(
                     fsSettings,
-                    stream,
+                    ctx.getInputStream(),
                     ctx.getFile().getName(),
                     ctx.getFullFilename(),
                     ctx.getDoc(),

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/TikaProcessor.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/TikaProcessor.java
@@ -25,7 +25,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
 import java.security.MessageDigest;
 

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/TikaProcessor.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/TikaProcessor.java
@@ -19,6 +19,7 @@
 package fr.pilato.elasticsearch.crawler.fs;
 
 import fr.pilato.elasticsearch.crawler.fs.beans.DocParser;
+import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
 import fr.pilato.elasticsearch.crawler.fs.tika.TikaDocParser;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -26,6 +27,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
+import java.security.MessageDigest;
 
 /**
  * Tikaprocessor will parse full text and update the Doc instance on context.
@@ -36,18 +38,25 @@ import java.lang.invoke.MethodHandles;
  */
 public class TikaProcessor implements Processor {
     private static final Logger logger = LogManager.getLogger(MethodHandles.lookup().lookupClass());
+    private FsSettings fsSettings;
+    private MessageDigest messageDigest;
+
+    public TikaProcessor(FsSettings fsSettings, MessageDigest messageDigest) {
+        this.fsSettings = fsSettings;
+        this.messageDigest = messageDigest;
+    }
 
     @Override
     public void process(FsCrawlerContext ctx) throws ProcessingException {
         try(InputStream stream = ctx.getInputStream()) {
             long startTime = System.currentTimeMillis();
             TikaDocParser.generate(
-                    ctx.getFsSettings(),
+                    fsSettings,
                     stream,
                     ctx.getFile().getName(),
                     ctx.getFullFilename(),
                     ctx.getDoc(),
-                    ctx.getMessageDigest(),
+                    messageDigest,
                     ctx.getFile().getSize());
             logger.debug("Parsing document {} with Tika in {}ms", ctx.getFile().getName(),
                     System.currentTimeMillis() - startTime);

--- a/core/src/test/java/fr/pilato/elasticsearch/crawler/fs/EsIndexProcessorTest.java
+++ b/core/src/test/java/fr/pilato/elasticsearch/crawler/fs/EsIndexProcessorTest.java
@@ -1,0 +1,22 @@
+package fr.pilato.elasticsearch.crawler.fs;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class EsIndexProcessorTest {
+
+    @Test
+    public void mergeExtraDoc() {
+        Map<String,Object> extra = new HashMap<>();
+        Map<String,Object> geo = new HashMap<>();
+        geo.put("hello", "world");
+        extra.put("geo", geo);
+        String json = "{\"file\" : {\"extension\" : \"pdf\"} }";
+        String modifiedJson = new EsIndexProcessor().mergeExtraDoc(json, extra);
+        assertEquals("{\"file\":{\"extension\":\"pdf\"},\"geo\":{\"hello\":\"world\"}}", modifiedJson);
+    }
+}

--- a/core/src/test/java/fr/pilato/elasticsearch/crawler/fs/EsIndexProcessorTest.java
+++ b/core/src/test/java/fr/pilato/elasticsearch/crawler/fs/EsIndexProcessorTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class EsIndexProcessorTest {
 

--- a/core/src/test/java/fr/pilato/elasticsearch/crawler/fs/EsIndexProcessorTest.java
+++ b/core/src/test/java/fr/pilato/elasticsearch/crawler/fs/EsIndexProcessorTest.java
@@ -16,7 +16,7 @@ public class EsIndexProcessorTest {
         geo.put("hello", "world");
         extra.put("geo", geo);
         String json = "{\"file\" : {\"extension\" : \"pdf\"} }";
-        String modifiedJson = new EsIndexProcessor().mergeExtraDoc(json, extra);
+        String modifiedJson = EsIndexProcessor.mergeExtraDoc(json, extra);
         assertEquals("{\"file\":{\"extension\":\"pdf\"},\"geo\":{\"hello\":\"world\"}}", modifiedJson);
     }
 }

--- a/docs/source/admin/fs/index.rst
+++ b/docs/source/admin/fs/index.rst
@@ -33,6 +33,8 @@ The job file must comply to the following ``yaml`` specifications:
        language: "eng"
        path: "/path/to/tesseract/if/not/available/in/PATH"
        data_path: "/path/to/tesseract/tessdata/if/needed"
+     pipeline:
+       class_name: "com.example.MyCustomProcessingPipeline"
    server:
      hostname: "localhost"
      port: 22

--- a/docs/source/admin/fs/local-fs.rst
+++ b/docs/source/admin/fs/local-fs.rst
@@ -54,6 +54,8 @@ Here is a list of Local FS settings (under ``fs.`` prefix)`:
 +----------------------------+-----------------------+---------------------------------+
 | ``fs.follow_symlinks``     | ``false``             | `Follow Symlinks`_              |
 +----------------------------+-----------------------+---------------------------------+
+| ``fs.pipeline.class_name`` | ``DefaultProcessingPipeline`` | :ref:`pipeline_class    |
++----------------------------+-----------------------+---------------------------------+
 
 .. _root-directory:
 
@@ -575,6 +577,28 @@ continue with the rest of the directory tree you can set
    name: "test"
    fs:
      continue_on_error: true
+
+.. _pipeline_class:
+
+Pipeline Class
+^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 2.8
+
+By default FSCrawler will parse binary documents with Apache Tika,
+and then index to Elasticsearch. If you require custom processing,
+implement the `ProcessingPipeline` interface, place the jar file in
+FSCrawler's classpath, and configure the class name of your custom
+pipeline class in the job config file. Your custom pipeline class
+could extend the `DefaultProcessingPipeline` class to reuse the tika
+and indexing processors:
+
+.. code:: yaml
+
+   name: "test"
+   fs:
+     pipeline:
+       class_name: com.example.CustomProcessingPipeline
 
 Language detection
 ^^^^^^^^^^^^^^^^^^

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Fs.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Fs.java
@@ -58,7 +58,7 @@ public class Fs {
     private Ocr ocr = new Ocr();
     private ByteSizeValue ignoreAbove = null;
     private boolean followSymlinks = false;
-    private Pipeline pipeline;
+    private Pipeline pipeline = Pipeline.DEFAULT;
 
     public static Builder builder() {
         return new Builder();
@@ -92,7 +92,7 @@ public class Fs {
         private Ocr ocr = new Ocr();
         private ByteSizeValue ignoreAbove = null;
         private boolean followSymlinks = false;
-        private Pipeline pipeline = Pipeline.DEFAULT;
+        private Pipeline pipeline;
 
         public Builder setUrl(String url) {
             this.url = url;

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Fs.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Fs.java
@@ -92,7 +92,7 @@ public class Fs {
         private Ocr ocr = new Ocr();
         private ByteSizeValue ignoreAbove = null;
         private boolean followSymlinks = false;
-        private Pipeline pipeline = Pipeline.DEFAULT();
+        private Pipeline pipeline = Pipeline.DEFAULT;
 
         public Builder setUrl(String url) {
             this.url = url;

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Fs.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Fs.java
@@ -58,6 +58,7 @@ public class Fs {
     private Ocr ocr = new Ocr();
     private ByteSizeValue ignoreAbove = null;
     private boolean followSymlinks = false;
+    private Pipeline pipeline;
 
     public static Builder builder() {
         return new Builder();
@@ -91,6 +92,7 @@ public class Fs {
         private Ocr ocr = new Ocr();
         private ByteSizeValue ignoreAbove = null;
         private boolean followSymlinks = false;
+        private Pipeline pipeline = Pipeline.DEFAULT();
 
         public Builder setUrl(String url) {
             this.url = url;
@@ -246,10 +248,15 @@ public class Fs {
             return this;
         }
 
+        public Builder setPipeline(Pipeline pipeline) {
+            this.pipeline = pipeline;
+            return this;
+        }
+
         public Fs build() {
             return new Fs(url, updateRate, includes, excludes, filters, jsonSupport, filenameAsId, addFilesize,
                     removeDeleted, addAsInnerObject, storeSource, indexedChars, indexContent, attributesSupport, rawMetadata,
-                    checksum, xmlSupport, indexFolders, langDetect, continueOnError, ocr, ignoreAbove, followSymlinks);
+                    checksum, xmlSupport, indexFolders, langDetect, continueOnError, ocr, ignoreAbove, followSymlinks, pipeline);
         }
     }
 
@@ -260,7 +267,8 @@ public class Fs {
     private Fs(String url, TimeValue updateRate, List<String> includes, List<String> excludes, List<String> filters, boolean jsonSupport,
                boolean filenameAsId, boolean addFilesize, boolean removeDeleted, boolean addAsInnerObject, boolean storeSource,
                Percentage indexedChars, boolean indexContent, boolean attributesSupport, boolean rawMetadata, String checksum, boolean xmlSupport,
-               boolean indexFolders, boolean langDetect, boolean continueOnError, Ocr ocr, ByteSizeValue ignoreAbove, boolean followSymlinks) {
+               boolean indexFolders, boolean langDetect, boolean continueOnError, Ocr ocr, ByteSizeValue ignoreAbove, boolean followSymlinks,
+               Pipeline pipeline) {
         this.url = url;
         this.updateRate = updateRate;
         this.includes = includes;
@@ -284,6 +292,7 @@ public class Fs {
         this.ocr = ocr;
         this.ignoreAbove = ignoreAbove;
         this.followSymlinks = followSymlinks;
+        this.pipeline = pipeline;
     }
 
     public String getUrl() {
@@ -445,6 +454,15 @@ public class Fs {
     public void setContinueOnError(boolean continueOnError) {
         this.continueOnError = continueOnError;
     }
+
+    public Pipeline getPipeline() {
+        return pipeline;
+    }
+
+    public void setPipeline(Pipeline pipeline) {
+        this.pipeline = pipeline;
+    }
+
 
     @Deprecated
     public void setPdfOcr(boolean pdfOcr) {

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettings.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettings.java
@@ -29,7 +29,6 @@ public class FsSettings {
     private Server server;
     private Elasticsearch elasticsearch;
     private Rest rest;
-    private Pipeline pipeline;
 
     public FsSettings() {
 
@@ -47,17 +46,12 @@ public class FsSettings {
         return new Builder().setName(name);
     }
 
-    public Pipeline getPipeline() {
-        return pipeline;
-    }
-
     public static class Builder {
         private String name;
         private Fs fs = Fs.DEFAULT;
         private Server server = null;
         private Elasticsearch elasticsearch = Elasticsearch.DEFAULT();
         private Rest rest = null;
-        private Pipeline pipeline = Pipeline.DEFAULT();
 
         private Builder setName(String name) {
             this.name = name;
@@ -86,10 +80,6 @@ public class FsSettings {
 
         public FsSettings build() {
             return new FsSettings(name, fs, server, elasticsearch, rest);
-        }
-
-        public Pipeline getPipeline() {
-            return pipeline;
         }
     }
 
@@ -144,7 +134,6 @@ public class FsSettings {
         if (!Objects.equals(fs, that.fs)) return false;
         if (!Objects.equals(server, that.server)) return false;
         if (!Objects.equals(rest, that.rest)) return false;
-        if (!Objects.equals(pipeline, that.pipeline)) return false;
         return Objects.equals(elasticsearch, that.elasticsearch);
 
     }
@@ -156,7 +145,6 @@ public class FsSettings {
         result = 31 * result + (server != null ? server.hashCode() : 0);
         result = 31 * result + (rest != null ? rest.hashCode() : 0);
         result = 31 * result + (elasticsearch != null ? elasticsearch.hashCode() : 0);
-        result = 31 * result + (pipeline != null ? pipeline.hashCode() : 0);
         return result;
     }
 
@@ -167,7 +155,6 @@ public class FsSettings {
                 ", server=" + server +
                 ", elasticsearch=" + elasticsearch +
                 ", rest=" + rest +
-                ", pipeline=" + pipeline +
                 '}';
     }
 }

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettings.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettings.java
@@ -29,6 +29,7 @@ public class FsSettings {
     private Server server;
     private Elasticsearch elasticsearch;
     private Rest rest;
+    private Pipeline pipeline;
 
     public FsSettings() {
 
@@ -46,12 +47,17 @@ public class FsSettings {
         return new Builder().setName(name);
     }
 
+    public Pipeline getPipeline() {
+        return pipeline;
+    }
+
     public static class Builder {
         private String name;
         private Fs fs = Fs.DEFAULT;
         private Server server = null;
         private Elasticsearch elasticsearch = Elasticsearch.DEFAULT();
         private Rest rest = null;
+        private Pipeline pipeline = Pipeline.DEFAULT();
 
         private Builder setName(String name) {
             this.name = name;
@@ -80,6 +86,10 @@ public class FsSettings {
 
         public FsSettings build() {
             return new FsSettings(name, fs, server, elasticsearch, rest);
+        }
+
+        public Pipeline getPipeline() {
+            return pipeline;
         }
     }
 
@@ -134,6 +144,7 @@ public class FsSettings {
         if (!Objects.equals(fs, that.fs)) return false;
         if (!Objects.equals(server, that.server)) return false;
         if (!Objects.equals(rest, that.rest)) return false;
+        if (!Objects.equals(pipeline, that.pipeline)) return false;
         return Objects.equals(elasticsearch, that.elasticsearch);
 
     }
@@ -145,6 +156,7 @@ public class FsSettings {
         result = 31 * result + (server != null ? server.hashCode() : 0);
         result = 31 * result + (rest != null ? rest.hashCode() : 0);
         result = 31 * result + (elasticsearch != null ? elasticsearch.hashCode() : 0);
+        result = 31 * result + (pipeline != null ? pipeline.hashCode() : 0);
         return result;
     }
 
@@ -155,6 +167,7 @@ public class FsSettings {
                 ", server=" + server +
                 ", elasticsearch=" + elasticsearch +
                 ", rest=" + rest +
+                ", pipeline=" + pipeline +
                 '}';
     }
 }

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Pipeline.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Pipeline.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package fr.pilato.elasticsearch.crawler.fs.settings;
+
+/**
+ * Makes it possible to provide your own pipeline
+ */
+public class Pipeline {
+    private final String className;
+
+    private Pipeline(Builder builder) {
+        this.className = builder.className;
+    }
+
+    public static Pipeline DEFAULT() {
+        return Pipeline.builder()
+                .addClass("fr.pilato.elasticsearch.crawler.fs.DefaultProcessingPipeline")
+                .build();
+    }
+
+    private static Builder builder() {
+        return new Builder();
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Pipeline pipeline = (Pipeline) o;
+
+        return className != null ? className.equals(pipeline.className) : pipeline.className == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return className != null ? className.hashCode() : 0;
+    }
+
+    public static class Builder {
+        private String className;
+
+        public Builder addClass(String className) {
+            this.className = className;
+            return this;
+        }
+
+        public Pipeline build() {
+            return new Pipeline(this);
+        }
+    }
+}

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Pipeline.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Pipeline.java
@@ -30,11 +30,9 @@ public class Pipeline {
         this.className = className;
     }
 
-    public static Pipeline DEFAULT() {
-        return Pipeline.builder()
-                .addClass("fr.pilato.elasticsearch.crawler.fs.DefaultProcessingPipeline")
-                .build();
-    }
+    public static final Pipeline DEFAULT = Pipeline.builder()
+            .addClass("fr.pilato.elasticsearch.crawler.fs.DefaultProcessingPipeline")
+            .build();
 
     private static Builder builder() {
         return new Builder();

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Pipeline.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Pipeline.java
@@ -22,6 +22,10 @@ package fr.pilato.elasticsearch.crawler.fs.settings;
  * Makes it possible to provide your own pipeline
  */
 public class Pipeline {
+    public static final Pipeline DEFAULT = Pipeline.builder()
+            .addClass("fr.pilato.elasticsearch.crawler.fs.DefaultProcessingPipeline")
+            .build();
+
     private String className = "fr.pilato.elasticsearch.crawler.fs.DefaultProcessingPipeline";
 
     public Pipeline() { }
@@ -29,10 +33,6 @@ public class Pipeline {
     private Pipeline(String className) {
         this.className = className;
     }
-
-    public static final Pipeline DEFAULT = Pipeline.builder()
-            .addClass("fr.pilato.elasticsearch.crawler.fs.DefaultProcessingPipeline")
-            .build();
 
     private static Builder builder() {
         return new Builder();

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Pipeline.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Pipeline.java
@@ -22,10 +22,12 @@ package fr.pilato.elasticsearch.crawler.fs.settings;
  * Makes it possible to provide your own pipeline
  */
 public class Pipeline {
-    private final String className;
+    private String className = "fr.pilato.elasticsearch.crawler.fs.DefaultProcessingPipeline";
 
-    private Pipeline(Builder builder) {
-        this.className = builder.className;
+    public Pipeline() { }
+
+    private Pipeline(String className) {
+        this.className = className;
     }
 
     public static Pipeline DEFAULT() {
@@ -66,7 +68,7 @@ public class Pipeline {
         }
 
         public Pipeline build() {
-            return new Pipeline(this);
+            return new Pipeline(className);
         }
     }
 }


### PR DESCRIPTION
This PR fixes #1003 by letting users bring their own complex document processing.
Instead of trying to make a fancy configurable pipeline, it is much simpler to just let users provide a jar file with their custom `ProcessingPipeline` implementation. By default the `DefaultProcessingPipeline` is used, which simply parses by Tika and indexes.

A custom pipeline may e.g. do
* Parse with TIka, but with custom configuration, metadata mapping, custom parsers etc
* Clean and sanitize the resulting `Doc`
* Enrich the ES document with further content, e.g. from external source, by adding an `extraDoc` on the context, that will get merged into the primary document right before indexing.
