### PR TITLE
Fix ENTRYPOINT in Dockerfile to allow variable substitution

### DIFF
--- a/contrib/docker-compose-example/Dockerfile-fscrawler
+++ b/contrib/docker-compose-example/Dockerfile-fscrawler
@@ -24,4 +24,4 @@ RUN unzip $FSCRAWLER_FNAME.zip && rm $FSCRAWLER_FNAME.zip \
 
 VOLUME [ "/usr/app/config", "/usr/app/data" ]
 
-ENTRYPOINT [ "$FSCRAWLER_FNAME/bin/fscrawler", "--config_dir", "/usr/app/config","idx", "--rest" ]
+ENTRYPOINT $FSCRAWLER_FNAME/bin/fscrawler --config_dir /usr/app/config idx --rest


### PR DESCRIPTION
Without that fix, the docker fail with the following error:

```
es02 is up-to-date
kib01 is up-to-date
es01 is up-to-date
Starting fscrawler ... error

ERROR: for fscrawler  Cannot start service fscrawler: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"$FSCRAWLER_FNAME/bin/fscrawler\": stat $FSCRAWLER_FNAME/bin/fscrawler: no such file or directory": unknown

ERROR: for fscrawler  Cannot start service fscrawler: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"$FSCRAWLER_FNAME/bin/fscrawler\": stat $FSCRAWLER_FNAME/bin/fscrawler: no such file or directory": unknown
ERROR: Encountered errors while bringing up the project.

```