### PR TITLE
Running fscrawler with no argument now lists existing jobs

### DIFF
--- a/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerJobsUtil.java
+++ b/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerJobsUtil.java
@@ -41,12 +41,12 @@ public class FsCrawlerJobsUtil {
                 // This is a directory. Let's see if we have the _settings.json file in it
                 if (Files.isDirectory(path)) {
                     String jobName = path.getFileName().toString();
-                    Path jobSettingsFile = path.resolve(FsSettingsFileHandler.FILENAME_JSON);
-                    if (Files.exists(jobSettingsFile)) {
+                    if (Files.exists(path.resolve(FsSettingsFileHandler.SETTINGS_YAML))
+                            || Files.exists(path.resolve(FsSettingsFileHandler.FILENAME_JSON))) {
                         files.add(jobName);
-                        logger.debug("Adding job [{}]", jobName, FsSettingsFileHandler.FILENAME_JSON);
+                        logger.debug("Adding job [{}]", jobName);
                     } else {
-                        logger.debug("Ignoring [{}] dir as no [{}] has been found", jobName, FsSettingsFileHandler.FILENAME_JSON);
+                        logger.debug("Ignoring [{}] dir as no settings file has been found", jobName);
                     }
                 }
             }

--- a/cli/src/test/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCliJobsUtilTest.java
+++ b/cli/src/test/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCliJobsUtilTest.java
@@ -29,6 +29,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+import static com.carrotsearch.randomizedtesting.RandomizedTest.randomBoolean;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 
@@ -49,7 +50,13 @@ public class FsCrawlerCliJobsUtilTest extends AbstractFSCrawlerMetadataTestCase 
             String jobName = jobNamePrefix + "-" + i;
             Path jobDir = metadataDir.resolve(jobName);
             Files.createDirectories(jobDir);
-            fsSettingsFileHandler.write(FsSettings.builder(jobName).build());
+            if (randomBoolean()) {
+                // Yaml settings file
+                fsSettingsFileHandler.write(FsSettings.builder(jobName).build());
+            } else {
+                // Json settings (empty)
+                Files.createFile(jobDir.resolve(FsSettingsFileHandler.FILENAME_JSON));
+            }
         }
 
         // We test that we can actually see the jobs

--- a/cli/src/test/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCliJobsUtilTest.java
+++ b/cli/src/test/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCliJobsUtilTest.java
@@ -54,7 +54,7 @@ public class FsCrawlerCliJobsUtilTest extends AbstractFSCrawlerMetadataTestCase 
                 // Yaml settings file
                 fsSettingsFileHandler.write(FsSettings.builder(jobName).build());
             } else {
-                // Json settings (empty)
+                // Json settings (empty dummy)
                 Files.createFile(jobDir.resolve(FsSettingsFileHandler.FILENAME_JSON));
             }
         }


### PR DESCRIPTION
This fixes #995 

The code was looking for json settings file, but by default yaml files are created, so jobs were not found