### PR TITLE
Add an external Log4J2 configuration file

### DIFF
--- a/cli/src/main/resources/log4j2.xml
+++ b/cli/src/main/resources/log4j2.xml
@@ -1,14 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="fatal">
+<Configuration status="fatal" monitorInterval="30">
+   <Properties>
+      <Property name="LOG_PATTERN">%d{ABSOLUTE} %highlight{%-5p} [%c{1.}] %m%n</Property>
+      <Property name="DOCS_PATTERN">%d [%highlight{%-5p}] %m%n</Property>
+      <Property name="LOG_DIR">logs</Property>
+   </Properties>
+
    <Appenders>
-      <Console name="CONSOLE" target="SYSTEM_OUT">
-         <PatternLayout pattern="%d{ABSOLUTE} %highlight{%-5p} [%c{1.}] %m%n"/>
+      <Console name="CONSOLE" target="SYSTEM_OUT" follow="true">
+         <PatternLayout pattern="${LOG_PATTERN}"/>
       </Console>
+
+      <RollingFile name="RollingFile" fileName="${sys:LOG_DIR}/fscrawler.log"
+                   filePattern="${sys:LOG_DIR}/fscrawler-%d{yyyy-MM-dd}-%i.log.gz">
+         <PatternLayout pattern="${LOG_PATTERN}"/>
+         <Policies>
+            <OnStartupTriggeringPolicy />
+            <SizeBasedTriggeringPolicy size="20 MB" />
+            <TimeBasedTriggeringPolicy />
+         </Policies>
+         <DefaultRolloverStrategy max="7"/>
+      </RollingFile>
+
+      <RollingFile name="Documents" fileName="${sys:LOG_DIR}/documents.log"
+                   filePattern="${sys:LOG_DIR}/documents-%d{yyyy-MM-dd}.log.gz">
+         <PatternLayout pattern="${DOCS_PATTERN}"/>
+         <Policies>
+            <TimeBasedTriggeringPolicy />
+         </Policies>
+         <DefaultRolloverStrategy max="7"/>
+      </RollingFile>
    </Appenders>
    <Loggers>
+      <!-- This logger is used to trace all information about documents -->
+      <Logger name="fscrawler.document" level="debug" additivity="false">
+         <AppenderRef ref="Documents" />
+      </Logger>
+
+      <!-- This logger is used to log FSCrawler code execution -->
       <Logger name="fr.pilato.elasticsearch.crawler.fs" level="info" additivity="false">
          <AppenderRef ref="CONSOLE"/>
+         <AppenderRef ref="RollingFile" />
       </Logger>
+
+      <!-- This logger is used to log 3rd party libs execution -->
       <Logger name="org.elasticsearch" level="warn" additivity="false">
          <AppenderRef ref="CONSOLE"/>
       </Logger>
@@ -18,8 +53,9 @@
       <Logger name="org.apache.tika.parser.ocr.TesseractOCRParser" level="error" additivity="false">
          <AppenderRef ref="CONSOLE"/>
       </Logger>
+
       <Root level="info">
-         <AppenderRef ref="CONSOLE"/>
+         <AppenderRef ref="RollingFile" />
       </Root>
    </Loggers>
 </Configuration>

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
@@ -34,6 +34,7 @@ import fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchClient;
 import fr.pilato.elasticsearch.crawler.fs.crawler.FileAbstractModel;
 import fr.pilato.elasticsearch.crawler.fs.crawler.FileAbstractor;
 import fr.pilato.elasticsearch.crawler.fs.framework.ByteSizeValue;
+import fr.pilato.elasticsearch.crawler.fs.framework.FSCrawlerLogger;
 import fr.pilato.elasticsearch.crawler.fs.framework.OsValidator;
 import fr.pilato.elasticsearch.crawler.fs.framework.SignTool;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
@@ -169,7 +170,7 @@ public abstract class FsParserAbstract extends FsParser {
                     try {
                         path.close();
                     } catch (Exception e) {
-                        logger.warn("Error while closing the connection: {}", e, e.getMessage());
+                        logger.warn("Error while closing the connection", e);
                     }
                 }
             }
@@ -486,6 +487,7 @@ public abstract class FsParserAbstract extends FsParser {
 
                 // We index the data structure
                 if (isIndexable(doc.getContent(), fsSettings.getFs().getFilters())) {
+                    FSCrawlerLogger.documentDebug(computeVirtualPathName(stats.getRootPath(), fullFilename), "Indexing content");
                     esIndex(fsSettings.getElasticsearch().getIndex(),
                             generateIdFromFilename(filename, dirname),
                             DocParser.toJson(doc),

--- a/distribution/src/main/assembly/assembly.xml
+++ b/distribution/src/main/assembly/assembly.xml
@@ -29,5 +29,12 @@
                 <include>README.md</include>
             </includes>
         </fileSet>
+        <fileSet>
+            <directory>${project.parent.basedir}/../cli/src/main/resources</directory>
+            <outputDirectory>config</outputDirectory>
+            <includes>
+                <include>log4j2.xml</include>
+            </includes>
+        </fileSet>
     </fileSets>
 </assembly>

--- a/distribution/src/main/scripts/fscrawler
+++ b/distribution/src/main/scripts/fscrawler
@@ -43,6 +43,9 @@ JAVA_OPTS="$JAVA_OPTS -Dsun.jnu.encoding=UTF-8"
 # Use LOG4J2 instead of java.util.logging
 JAVA_OPTS="$JAVA_OPTS -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"
 
+# Define LOG4J2 config file
+JAVA_OPTS="$JAVA_OPTS -Dlog4j.configurationFile=config/log4j2.xml"
+
 # If the user defined FS_JAVA_OPTS, we will use it to start the crawler
 JAVA_OPTS="$JAVA_OPTS $FS_JAVA_OPTS"
 

--- a/distribution/src/main/scripts/fscrawler.bat
+++ b/distribution/src/main/scripts/fscrawler.bat
@@ -26,6 +26,9 @@ set JAVA_OPTS=%JAVA_OPTS% -Dsun.jnu.encoding=UTF-8
 REM Use LOG4J2 instead of java.util.logging
 set JAVA_OPTS=%JAVA_OPTS% -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
 
+REM Define LOG4J2 config file
+set JAVA_OPTS="%JAVA_OPTS% -Dlog4j.configurationFile=config/log4j2.xml
+
 REM If the user defined FS_JAVA_OPTS, we will use it to start the crawler
 set JAVA_OPTS=%JAVA_OPTS% %FS_JAVA_OPTS%
 

--- a/docs/source/admin/logger.rst
+++ b/docs/source/admin/logger.rst
@@ -1,15 +1,25 @@
-Configuring an external logger configuration file
-=================================================
+Configuring the logger
+======================
 
-If you want to define an external ``log4j2.xml`` file, you can use the
-``log4j.configurationFile`` JVM parameter which you can define in
-``FS_JAVA_OPTS`` variable if you wish:
+FSCrawler comes with a default logger configuration which can be found in the
+FSCrawler installation dir as ``config/log4j2.xml`` file.
+
+You can modify it to suit your needs.
+
+You can control where FSCrawler will store the logs by setting the ``LOG_DIR`` Java property.
 
 .. code:: sh
 
-   FS_JAVA_OPTS="-Dlog4j.configurationFile=path/to/log4j2.xml" bin/fscrawler
+   FS_JAVA_OPTS="-DLOG_DIR=path/to/logs_dir" bin/fscrawler
 
-You can use `the default log4j2.xml
-file <https://github.com/dadoonet/fscrawler/blob/master/cli/src/main/resources/log4j2.xml>`__
-as an example to start with.
+By default, it will log everything in the ``logs`` directory inside the installation folder.
 
+Two log files are generated:
+
+* One is used to log FSCrawler code execution, named ``fscrawler.log``. It's automatically
+rotated every day or after 20mb of logs and gzipped. Logs are removed after 7 days.
+* One is used to trace all information about documents, named ``documents.log``. It's automatically
+rotated every day or after 20mb of logs and gzipped. Logs are removed after 7 days.
+
+You can change this strategy by modifying the ``config/log4j2.xml`` file.
+Please read `Log4J2 documentation <https://logging.apache.org/log4j/2.x/manual/index.html>`_ on how to configure Log4J.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -54,6 +54,8 @@ The distribution contains:
    ├── bin
    │   ├── fscrawler
    │   └── fscrawler.bat
+   ├── config
+   │   └── log4j2.xml
    └── lib
        ├── ... All needed jars
 

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/FSCrawlerLogger.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/FSCrawlerLogger.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package fr.pilato.elasticsearch.crawler.fs.framework;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class FSCrawlerLogger {
+
+    /**
+     * This logger is used to log information related to documents
+     */
+    private final static Logger documentLogger = LogManager.getLogger("fscrawler.document");
+
+    public static void documentDebug(String path, String message) {
+        documentLogger.debug("[{}] {}", path, message);
+    }
+
+    public static void documentError(String path, String error) {
+        documentLogger.error("[{}] {}", path, error);
+    }
+}

--- a/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
+++ b/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
@@ -20,6 +20,7 @@
 package fr.pilato.elasticsearch.crawler.fs.tika;
 
 import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
+import fr.pilato.elasticsearch.crawler.fs.framework.FSCrawlerLogger;
 import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
 import org.apache.commons.io.input.TeeInputStream;
@@ -41,6 +42,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.computeVirtualPathName;
 import static fr.pilato.elasticsearch.crawler.fs.framework.StreamsUtil.copy;
 import static fr.pilato.elasticsearch.crawler.fs.tika.TikaInstance.extractText;
 import static fr.pilato.elasticsearch.crawler.fs.tika.TikaInstance.langDetector;
@@ -97,12 +99,15 @@ public class TikaDocParser {
                 Throwable current = e;
                 StringBuilder sb = new StringBuilder();
                 while (current != null) {
-                    sb.append(" -> ");
                     sb.append(current.getMessage());
                     current = current.getCause();
+                    if (current != null) {
+                        sb.append(" -> ");
+                    }
                 }
 
-                logger.warn("Failed to extract [{}] characters of text for [{}] {}", indexedChars, fullFilename, sb.toString());
+                FSCrawlerLogger.documentError(computeVirtualPathName(fsSettings.getFs().getUrl(), fullFilename), sb.toString());
+                logger.warn("Failed to extract [{}] characters of text for [{}]: {}", indexedChars, fullFilename, sb.toString());
                 logger.debug("Failed to extract [" + indexedChars + "] characters of text for [" + fullFilename + "]", e);
             }
 


### PR DESCRIPTION
FSCrawler comes with a default logger configuration which can be found in the FSCrawler installation dir as `config/log4j2.xml` file.

You can modify it to suit your needs.

You can control where FSCrawler will store the logs by setting the `LOG_DIR` Java property.

```sh
FS_JAVA_OPTS="-DLOG_DIR=path/to/logs_dir" bin/fscrawler
```

By default, it will log everything in the `logs` directory inside the installation folder.

Two log files are generated:

* One is used to log FSCrawler code execution, named `fscrawler.log`. It's automatically
rotated every day or after 20mb of logs and gzipped. Logs are removed after 7 days.
* One is used to trace all information about documents, named `documents.log`. It's automatically
rotated every day or after 20mb of logs and gzipped. Logs are removed after 7 days.

You can change this strategy by modifying the `config/log4j2.xml` file.
Please read [Log4J2 documentation](https://logging.apache.org/log4j/2.x/manual/index.html) on how to configure Log4J.

Closes #536.
Closes #1028.