### PR TITLE
Log index errors in documents.log

### DIFF
--- a/cli/src/main/resources/log4j2.xml
+++ b/cli/src/main/resources/log4j2.xml
@@ -33,7 +33,7 @@
    </Appenders>
    <Loggers>
       <!-- This logger is used to trace all information about documents -->
-      <Logger name="fscrawler.document" level="debug" additivity="false">
+      <Logger name="fscrawler.document" level="info" additivity="false">
          <AppenderRef ref="Documents" />
       </Logger>
 

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
@@ -431,12 +431,12 @@ public abstract class FsParserAbstract extends FsParser {
         final long size = fileAbstractModel.getSize();
 
         logger.debug("fetching content from [{}],[{}]", dirname, filename);
+        String fullFilename = new File(dirname, filename).toString();
 
         try {
             // Create the Doc object (only needed when we have add_as_inner_object: true (default) or when we don't index json or xml)
             if (fsSettings.getFs().isAddAsInnerObject() || (!fsSettings.getFs().isJsonSupport() && !fsSettings.getFs().isXmlSupport())) {
 
-                String fullFilename = new File(dirname, filename).toString();
 
                 Doc doc = new Doc();
 
@@ -487,7 +487,9 @@ public abstract class FsParserAbstract extends FsParser {
 
                 // We index the data structure
                 if (isIndexable(doc.getContent(), fsSettings.getFs().getFilters())) {
-                    FSCrawlerLogger.documentDebug(computeVirtualPathName(stats.getRootPath(), fullFilename), "Indexing content");
+                    FSCrawlerLogger.documentDebug(generateIdFromFilename(filename, dirname),
+                            computeVirtualPathName(stats.getRootPath(), fullFilename),
+                            "Indexing content");
                     esIndex(fsSettings.getElasticsearch().getIndex(),
                             generateIdFromFilename(filename, dirname),
                             DocParser.toJson(doc),
@@ -498,12 +500,18 @@ public abstract class FsParserAbstract extends FsParser {
                 }
             } else {
                 if (fsSettings.getFs().isJsonSupport()) {
+                    FSCrawlerLogger.documentDebug(generateIdFromFilename(filename, dirname),
+                            computeVirtualPathName(stats.getRootPath(), fullFilename),
+                            "Indexing json content");
                     // We index the json content directly
                     esIndex(fsSettings.getElasticsearch().getIndex(),
                             generateIdFromFilename(filename, dirname),
                             read(inputStream),
                             fsSettings.getElasticsearch().getPipeline());
                 } else if (fsSettings.getFs().isXmlSupport()) {
+                    FSCrawlerLogger.documentDebug(generateIdFromFilename(filename, dirname),
+                            computeVirtualPathName(stats.getRootPath(), fullFilename),
+                            "Indexing xml content");
                     // We index the xml content directly
                     esIndex(fsSettings.getElasticsearch().getIndex(),
                             generateIdFromFilename(filename, dirname),

--- a/elasticsearch-client/elasticsearch-client-v6/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v6/ElasticsearchClientV6.java
+++ b/elasticsearch-client/elasticsearch-client-v6/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v6/ElasticsearchClientV6.java
@@ -33,6 +33,7 @@ import fr.pilato.elasticsearch.crawler.fs.client.ESSearchResponse;
 import fr.pilato.elasticsearch.crawler.fs.client.ESTermQuery;
 import fr.pilato.elasticsearch.crawler.fs.client.ESTermsAggregation;
 import fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchClient;
+import fr.pilato.elasticsearch.crawler.fs.framework.FSCrawlerLogger;
 import fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil;
 import fr.pilato.elasticsearch.crawler.fs.settings.Elasticsearch;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
@@ -208,6 +209,10 @@ public class ElasticsearchClientV6 implements ElasticsearchClient {
                 response.iterator().forEachRemaining(bir -> {
                     if (bir.isFailed()) {
                         failures[0]++;
+                        FSCrawlerLogger.documentError(
+                                bir.getId(),
+                                null,
+                                bir.getFailureMessage());
                         logger.debug("Error caught for [{}]/[{}]/[{}]: {}", bir.getIndex(),
                                 bir.getType(), bir.getId(), bir.getFailureMessage());
                     }

--- a/elasticsearch-client/elasticsearch-client-v7/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v7/ElasticsearchClientV7.java
+++ b/elasticsearch-client/elasticsearch-client-v7/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v7/ElasticsearchClientV7.java
@@ -33,7 +33,9 @@ import fr.pilato.elasticsearch.crawler.fs.client.ESSearchResponse;
 import fr.pilato.elasticsearch.crawler.fs.client.ESTermQuery;
 import fr.pilato.elasticsearch.crawler.fs.client.ESTermsAggregation;
 import fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchClient;
+import fr.pilato.elasticsearch.crawler.fs.framework.FSCrawlerLogger;
 import fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil;
+import fr.pilato.elasticsearch.crawler.fs.framework.SignTool;
 import fr.pilato.elasticsearch.crawler.fs.settings.Elasticsearch;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
 import org.apache.http.HttpHost;
@@ -93,11 +95,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 
-import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.INDEX_SETTINGS_FILE;
-import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.INDEX_SETTINGS_FOLDER_FILE;
-import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.extractMajorVersion;
-import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.isNullOrEmpty;
-import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.readJsonFile;
+import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.*;
 import static org.elasticsearch.action.support.IndicesOptions.LENIENT_EXPAND_OPEN;
 
 /**
@@ -188,6 +186,10 @@ public class ElasticsearchClientV7 implements ElasticsearchClient {
                 response.iterator().forEachRemaining(bir -> {
                     if (bir.isFailed()) {
                         failures[0]++;
+                        FSCrawlerLogger.documentError(
+                                bir.getId(),
+                                null,
+                                bir.getFailureMessage());
                         logger.debug("Error caught for [{}]/[{}]/[{}]: {}", bir.getIndex(),
                                 bir.getType(), bir.getId(), bir.getFailureMessage());
                     }

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/FSCrawlerLogger.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/FSCrawlerLogger.java
@@ -29,11 +29,11 @@ public class FSCrawlerLogger {
      */
     private final static Logger documentLogger = LogManager.getLogger("fscrawler.document");
 
-    public static void documentDebug(String path, String message) {
-        documentLogger.debug("[{}] {}", path, message);
+    public static void documentDebug(String id, String path, String message) {
+        documentLogger.debug("[{}][{}] {}", id, path, message);
     }
 
-    public static void documentError(String path, String error) {
-        documentLogger.error("[{}] {}", path, error);
+    public static void documentError(String id, String path, String error) {
+        documentLogger.error("[{}][{}] {}", id, path, error);
     }
 }

--- a/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
+++ b/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
@@ -22,6 +22,7 @@ package fr.pilato.elasticsearch.crawler.fs.tika;
 import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
 import fr.pilato.elasticsearch.crawler.fs.framework.FSCrawlerLogger;
 import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil;
+import fr.pilato.elasticsearch.crawler.fs.framework.SignTool;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
 import org.apache.commons.io.input.TeeInputStream;
 import org.apache.logging.log4j.LogManager;
@@ -32,10 +33,12 @@ import org.apache.tika.metadata.Property;
 import org.apache.tika.metadata.TikaCoreProperties;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
@@ -106,7 +109,12 @@ public class TikaDocParser {
                     }
                 }
 
-                FSCrawlerLogger.documentError(computeVirtualPathName(fsSettings.getFs().getUrl(), fullFilename), sb.toString());
+                try {
+                    FSCrawlerLogger.documentError(
+                            fsSettings.getFs().isFilenameAsId() ? filename : SignTool.sign(fullFilename),
+                            computeVirtualPathName(fsSettings.getFs().getUrl(), fullFilename),
+                            sb.toString());
+                } catch (NoSuchAlgorithmException ignored) { }
                 logger.warn("Failed to extract [{}] characters of text for [{}]: {}", indexedChars, fullFilename, sb.toString());
                 logger.debug("Failed to extract [" + indexedChars + "] characters of text for [" + fullFilename + "]", e);
             }


### PR DESCRIPTION
We change the way we are logging in `documents.log`:

* `INFO` level by default instead of `DEBUG`.
* Add the document `_id` to the log
* Add the documentLogger to the BulkListeners so we at least trace which `_id` has failed

Follow up for #1031