### PR TITLE
Support ssl verification configurable

### DIFF
--- a/docs/source/admin/fs/elasticsearch.rst
+++ b/docs/source/admin/fs/elasticsearch.rst
@@ -28,6 +28,8 @@ Here is a list of Elasticsearch settings (under ``elasticsearch.`` prefix)`:
 +----------------------------------+---------------------------+---------------------------------+
 | ``elasticsearch.password``       | ``null``                  | :ref:`credentials`              |
 +----------------------------------+---------------------------+---------------------------------+
+| ``elasticsearch.ssl_verification``| ``true``                 | :ref:`credentials`              |
++----------------------------------+---------------------------+---------------------------------+
 
 Index settings
 ^^^^^^^^^^^^^^
@@ -575,7 +577,7 @@ steps:
 .. important::
 
     Prerequisite: you need to have root CA chain certificate or Elasticsearch server certificate
-    in DER format. DER format files have a ``.cer`` extension.
+    in DER format. DER format files have a ``.cer`` extension. Certificate verification can be disabled by option ``ssl_verification = false``
 
 1. Logon to server (or client machine) where FSCrawler is running
 2. Run:

--- a/docs/source/admin/fs/elasticsearch.rst
+++ b/docs/source/admin/fs/elasticsearch.rst
@@ -5,31 +5,31 @@ Elasticsearch settings
 
 Here is a list of Elasticsearch settings (under ``elasticsearch.`` prefix)`:
 
-+----------------------------------+---------------------------+---------------------------------+
-| Name                             | Default value             | Documentation                   |
-+==================================+===========================+=================================+
-| ``elasticsearch.index``          | job name                  | `Index settings for documents`_ |
-+----------------------------------+---------------------------+---------------------------------+
-| ``elasticsearch.index_folder``   | job name + ``_folder``    | `Index settings for folders`_   |
-+----------------------------------+---------------------------+---------------------------------+
-| ``elasticsearch.bulk_size``      | ``100``                   | `Bulk settings`_                |
-+----------------------------------+---------------------------+---------------------------------+
-| ``elasticsearch.flush_interval`` | ``"5s"``                  | `Bulk settings`_                |
-+----------------------------------+---------------------------+---------------------------------+
-| ``elasticsearch.byte_size``      | ``"10mb"``                | `Bulk settings`_                |
-+----------------------------------+---------------------------+---------------------------------+
-| ``elasticsearch.pipeline``       | ``null``                  | :ref:`ingest_node`              |
-+----------------------------------+---------------------------+---------------------------------+
-| ``elasticsearch.nodes``          | ``http://127.0.0.1:9200`` | `Node settings`_                |
-+----------------------------------+---------------------------+---------------------------------+
-| ``elasticsearch.path_prefix``    | ``null``                  | `Path prefix`_                  |
-+----------------------------------+---------------------------+---------------------------------+
-| ``elasticsearch.username``       | ``null``                  | :ref:`credentials`              |
-+----------------------------------+---------------------------+---------------------------------+
-| ``elasticsearch.password``       | ``null``                  | :ref:`credentials`              |
-+----------------------------------+---------------------------+---------------------------------+
-| ``elasticsearch.ssl_verification``| ``true``                 | :ref:`credentials`              |
-+----------------------------------+---------------------------+---------------------------------+
++-----------------------------------+---------------------------+---------------------------------+
+| Name                              | Default value             | Documentation                   |
++===================================+===========================+=================================+
+| ``elasticsearch.index``           | job name                  | `Index settings for documents`_ |
++-----------------------------------+---------------------------+---------------------------------+
+| ``elasticsearch.index_folder``    | job name + ``_folder``    | `Index settings for folders`_   |
++-----------------------------------+---------------------------+---------------------------------+
+| ``elasticsearch.bulk_size``       | ``100``                   | `Bulk settings`_                |
++-----------------------------------+---------------------------+---------------------------------+
+| ``elasticsearch.flush_interval``  | ``"5s"``                  | `Bulk settings`_                |
++-----------------------------------+---------------------------+---------------------------------+
+| ``elasticsearch.byte_size``       | ``"10mb"``                | `Bulk settings`_                |
++-----------------------------------+---------------------------+---------------------------------+
+| ``elasticsearch.pipeline``        | ``null``                  | :ref:`ingest_node`              |
++-----------------------------------+---------------------------+---------------------------------+
+| ``elasticsearch.nodes``           | ``http://127.0.0.1:9200`` | `Node settings`_                |
++-----------------------------------+---------------------------+---------------------------------+
+| ``elasticsearch.path_prefix``     | ``null``                  | `Path prefix`_                  |
++-----------------------------------+---------------------------+---------------------------------+
+| ``elasticsearch.username``        | ``null``                  | :ref:`credentials`              |
++-----------------------------------+---------------------------+---------------------------------+
+| ``elasticsearch.password``        | ``null``                  | :ref:`credentials`              |
++-----------------------------------+---------------------------+---------------------------------+
+| ``elasticsearch.ssl_verification``| ``true``                  | :ref:`credentials`              |
++-----------------------------------+---------------------------+---------------------------------+
 
 Index settings
 ^^^^^^^^^^^^^^
@@ -577,7 +577,7 @@ steps:
 .. important::
 
     Prerequisite: you need to have root CA chain certificate or Elasticsearch server certificate
-    in DER format. DER format files have a ``.cer`` extension. Certificate verification can be disabled by option ``ssl_verification = false``
+    in DER format. DER format files have a ``.cer`` extension. Certificate verification can be disabled by option ``ssl_verification: false``
 
 1. Logon to server (or client machine) where FSCrawler is running
 2. Run:

--- a/elasticsearch-client/elasticsearch-client-v6/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v6/ElasticsearchClientV6.java
+++ b/elasticsearch-client/elasticsearch-client-v6/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v6/ElasticsearchClientV6.java
@@ -42,6 +42,7 @@ import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchStatusException;
@@ -85,8 +86,14 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
 
+import javax.net.ssl.*;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -374,6 +381,25 @@ public class ElasticsearchClientV6 implements ElasticsearchClient {
         return INDEX_TYPE_DOC;
     }
 
+    private static TrustManager[] trustAllCerts = new TrustManager[]{new X509TrustManager() {
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {}
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {}
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() { return null; }
+    }};
+
+    public static class NullHostNameVerifier implements HostnameVerifier {
+
+        @Override
+        public boolean verify(String arg0, SSLSession arg1) { return true; }
+
+    }
+
     @Override
     public void index(String index, String id, String json, String pipeline) {
         bulkProcessor.add(new IndexRequest(index, getDefaultTypeName(), id).setPipeline(pipeline).source(json, XContentType.JSON));
@@ -420,10 +446,24 @@ public class ElasticsearchClientV6 implements ElasticsearchClient {
         if (settings.getUsername() != null) {
             CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
             credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(settings.getUsername(), settings.getPassword()));
-            builder.setHttpClientConfigCallback(httpClientBuilder ->
-                    httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider));
+            if (settings.getSslVerification()) {
+                builder.setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider));
+            } else {
+                builder.setHttpClientConfigCallback(httpClientBuilder -> {
+                    SSLContext sc;
+                    try {
+                        sc = SSLContext.getInstance("SSL");
+                        sc.init(null, trustAllCerts, new SecureRandom());
+                    } catch (KeyManagementException | NoSuchAlgorithmException e) {
+                        logger.warn("Failed to get SSL Context", e);
+                        throw new RuntimeException(e);
+                    }
+                    httpClientBuilder.setSSLStrategy(new SSLIOSessionStrategy(sc, new NullHostNameVerifier()));
+                    httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+                    return httpClientBuilder;
+                });
+            }
         }
-
         return builder;
     }
 

--- a/elasticsearch-client/elasticsearch-client-v7/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v7/ElasticsearchClientV7.java
+++ b/elasticsearch-client/elasticsearch-client-v7/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v7/ElasticsearchClientV7.java
@@ -43,6 +43,7 @@ import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchStatusException;
@@ -86,8 +87,14 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
 
+import javax.net.ssl.*;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -351,6 +358,25 @@ public class ElasticsearchClientV7 implements ElasticsearchClient {
         return INDEX_TYPE_DOC;
     }
 
+    private static TrustManager[] trustAllCerts = new TrustManager[]{new X509TrustManager() {
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {}
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {}
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() { return null; }
+    }};
+
+    public static class NullHostNameVerifier implements HostnameVerifier {
+
+        @Override
+        public boolean verify(String arg0, SSLSession arg1) { return true; }
+
+    }
+
     @Override
     public void index(String index, String id, String json, String pipeline) {
         bulkProcessor.add(new IndexRequest(index).id(id).setPipeline(pipeline).source(json, XContentType.JSON));
@@ -395,8 +421,23 @@ public class ElasticsearchClientV7 implements ElasticsearchClient {
         if (settings.getUsername() != null) {
             CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
             credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(settings.getUsername(), settings.getPassword()));
-            builder.setHttpClientConfigCallback(httpClientBuilder ->
-                    httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider));
+            if (settings.getSslVerification()) {
+                builder.setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider));
+            } else {
+                builder.setHttpClientConfigCallback(httpClientBuilder -> {
+                    SSLContext sc;
+                    try {
+                        sc = SSLContext.getInstance("SSL");
+                        sc.init(null, trustAllCerts, new SecureRandom());
+                    } catch (KeyManagementException | NoSuchAlgorithmException e) {
+                        logger.warn("Failed to get SSL Context", e);
+                        throw new RuntimeException(e);
+                    }
+                    httpClientBuilder.setSSLStrategy(new SSLIOSessionStrategy(sc, new NullHostNameVerifier()));
+                    httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+                    return httpClientBuilder;
+                });
+            }
         }
 
         return builder;

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Elasticsearch.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Elasticsearch.java
@@ -47,6 +47,7 @@ public class Elasticsearch {
     private String password;
     private String pipeline;
     private String pathPrefix;
+    private boolean sslVerification = true;
 
     public Elasticsearch() {
 
@@ -54,7 +55,7 @@ public class Elasticsearch {
 
     private Elasticsearch(List<ServerUrl> nodes, String index, String indexFolder, int bulkSize,
                           TimeValue flushInterval, ByteSizeValue byteSize, String username, String password, String pipeline,
-                          String pathPrefix) {
+                          String pathPrefix, boolean sslVerification) {
         this.nodes = nodes;
         this.index = index;
         this.indexFolder = indexFolder;
@@ -65,6 +66,7 @@ public class Elasticsearch {
         this.password = password;
         this.pipeline = pipeline;
         this.pathPrefix = pathPrefix;
+        this.sslVerification = sslVerification;
     }
 
     public static Builder builder() {
@@ -124,6 +126,10 @@ public class Elasticsearch {
         return password;
     }
 
+    public boolean getSslVerification() {
+        return sslVerification;
+    }
+
     @JsonProperty
     public void setPassword(String password) {
         this.password = password;
@@ -145,6 +151,10 @@ public class Elasticsearch {
         this.pathPrefix = pathPrefix;
     }
 
+    public void setSslVerification(boolean sslVerification) {
+        this.sslVerification = sslVerification;
+    }
+
     public static class Builder {
         private List<ServerUrl> nodes;
         private String index;
@@ -156,6 +166,7 @@ public class Elasticsearch {
         private String password = null;
         private String pipeline = null;
         private String pathPrefix = null;
+        private boolean sslVerification = true;
 
         public Builder setNodes(List<ServerUrl> nodes) {
             this.nodes = nodes;
@@ -215,8 +226,13 @@ public class Elasticsearch {
             return this;
         }
 
+        public Builder setSslVerification(boolean sslVerification) {
+            this.sslVerification = sslVerification;
+            return this;
+        }
+
         public Elasticsearch build() {
-            return new Elasticsearch(nodes, index, indexFolder, bulkSize, flushInterval, byteSize, username, password, pipeline, pathPrefix);
+            return new Elasticsearch(nodes, index, indexFolder, bulkSize, flushInterval, byteSize, username, password, pipeline, pathPrefix, sslVerification);
         }
     }
 
@@ -235,6 +251,7 @@ public class Elasticsearch {
         // We can't really test the password as it may be obfuscated
         if (!Objects.equals(pipeline, that.pipeline)) return false;
         if (!Objects.equals(pathPrefix, that.pathPrefix)) return false;
+        if (!Objects.equals(sslVerification, that.sslVerification)) return false;
         return Objects.equals(flushInterval, that.flushInterval);
 
     }
@@ -249,6 +266,7 @@ public class Elasticsearch {
         result = 31 * result + (pathPrefix != null ? pathPrefix.hashCode() : 0);
         result = 31 * result + bulkSize;
         result = 31 * result + (flushInterval != null ? flushInterval.hashCode() : 0);
+        result = 31 * result + (sslVerification? 1: 0);
         return result;
     }
 
@@ -263,6 +281,7 @@ public class Elasticsearch {
                 ", username='" + username + '\'' +
                 ", pipeline='" + pipeline + '\'' +
                 ", pathPrefix='" + pathPrefix + '\'' +
+                ", sslVerification='" + sslVerification + '\'' +
                 '}';
     }
 }


### PR DESCRIPTION
Add new option `ssl_verification` to elasticseatch group to support skipping ssl verification. This is for #969