### PR TITLE
Fix flaky tests

### DIFF
--- a/test-framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/framework/AbstractFSCrawlerTestCase.java
+++ b/test-framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/framework/AbstractFSCrawlerTestCase.java
@@ -147,9 +147,6 @@ public abstract class AbstractFSCrawlerTestCase {
 
         while (sum + timeInMillis < maxTimeInMillis) {
             long current = breakSupplier.getAsLong();
-            if (current < 0) {
-                return current;
-            }
             if (expected == null && current >= 1) {
                 return current;
             } else if (expected != null && current == expected) {

--- a/test-framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/framework/AbstractFSCrawlerTestCaseTest.java
+++ b/test-framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/framework/AbstractFSCrawlerTestCaseTest.java
@@ -18,7 +18,12 @@
  */
 package fr.pilato.elasticsearch.crawler.fs.test.framework;
 
+import org.hamcrest.Matchers;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -36,6 +41,23 @@ public class AbstractFSCrawlerTestCaseTest extends AbstractFSCrawlerTestCase {
             throw new RuntimeException("RTE");
         }));
         assertThat(assertionError.getMessage(), containsString("Expected: an instance of " + NullPointerException.class.getName()));
+    }
+
+    @Test
+    public void testSimulateElasticsearchException() throws InterruptedException {
+        AtomicLong l = new AtomicLong(-1);
+
+        long hits = awaitBusy(() -> {
+            // Let's search for entries
+            try {
+                throw new RuntimeException("foo bar");
+            } catch (RuntimeException e) {
+                staticLogger.warn("error caught", e);
+                return l.getAndIncrement();
+            }
+        }, null, 1, TimeUnit.SECONDS);
+
+        assertThat(hits, Matchers.greaterThan(-1L));
     }
 
 }


### PR DESCRIPTION
When we are returning a negative value in the tests, we considered this as the final result instead of waiting for another value.

That was wrong.

This commit fixes it and adds a test to make sure we don't have a regression in the future.

This should definitely closes issues like #679.

Was the last part missing in #971.