### PR TITLE
Tesseract binary path should not contain the executable filename

### DIFF
--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
@@ -24,7 +24,6 @@ import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
 import fr.pilato.elasticsearch.crawler.fs.beans.DocParser;
 import fr.pilato.elasticsearch.crawler.fs.beans.FsJob;
 import fr.pilato.elasticsearch.crawler.fs.beans.FsJobFileHandler;
-import fr.pilato.elasticsearch.crawler.fs.beans.PathParser;
 import fr.pilato.elasticsearch.crawler.fs.beans.ScanStatistic;
 import fr.pilato.elasticsearch.crawler.fs.crawler.FileAbstractModel;
 import fr.pilato.elasticsearch.crawler.fs.crawler.FileAbstractor;
@@ -57,10 +56,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
-import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.computeVirtualPathName;
-import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.isFileSizeUnderLimit;
-import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.isIndexable;
-import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.localDateTimeToDate;
+import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.*;
 
 public abstract class FsParserAbstract extends FsParser {
     private static final Logger logger = LogManager.getLogger(FsParserAbstract.class);

--- a/docs/source/user/ocr.rst
+++ b/docs/source/user/ocr.rst
@@ -93,7 +93,7 @@ your ``~/.fscrawler/test/_settings.yaml`` file:
    fs:
      url: "/path/to/data/dir"
      ocr:
-       path: "/path/to/tesseract/executable"
+       path: "/path/to/tesseract/bin/"
 
 When you set it, it’s highly recommended to set the `OCR Data Path`_.
 
@@ -111,8 +111,8 @@ define the path to use by setting ``fs.ocr.data_path`` property in your
    fs:
      url: "/path/to/data/dir"
      ocr:
-       path: "/path/to/tesseract/executable"
-       data_path: "/path/to/tesseract/tessdata"
+       path: "/path/to/tesseract/bin/"
+       data_path: "/path/to/tesseract/share/tessdata/"
 
 OCR Output Type
 ---------------

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/MetaFileHandler.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/MetaFileHandler.java
@@ -20,6 +20,9 @@
 package fr.pilato.elasticsearch.crawler.fs.framework;
 
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -30,6 +33,7 @@ import java.nio.file.Paths;
  */
 public class MetaFileHandler {
 
+    private static final Logger logger = LogManager.getLogger(MetaFileHandler.class);
     public final static Path DEFAULT_ROOT = Paths.get(System.getProperty("user.home"), ".fscrawler");
 
     private final Path root;
@@ -50,6 +54,7 @@ public class MetaFileHandler {
         if (subdir != null) {
             dir = dir.resolve(subdir);
         }
+        logger.trace("Reading file {} from {}", filename, dir);
         return Files.readString(dir.resolve(filename));
     }
 
@@ -70,6 +75,7 @@ public class MetaFileHandler {
                 Files.createDirectory(dir);
             }
         }
+        logger.trace("Writing file {} to {}", filename, dir);
         Files.writeString(dir.resolve(filename), content);
     }
 
@@ -84,6 +90,7 @@ public class MetaFileHandler {
         if (subdir != null) {
             dir = dir.resolve(subdir);
         }
+        logger.trace("Removing file {} from {} if exists", filename, dir);
         Files.deleteIfExists(dir.resolve(filename));
     }
 }


### PR DESCRIPTION
Instead of using `/path/to/tesseract/bin/tesseract` as the path for tesseract option, we need to use `/path/to/tesseract/bin/` as follows:

```yml
name: "test"
fs:
  url: "/path/to/data/dir"
  ocr:
    path: "/path/to/tesseract/bin/"
    data_path: "/path/to/tesseract/share/tessdata/"
```

Closes #1060.