### PR TITLE
fscrawler.bat added a CD to move to the appropriate directory

### DIFF
--- a/distribution/src/main/scripts/fscrawler.bat
+++ b/distribution/src/main/scripts/fscrawler.bat
@@ -4,6 +4,7 @@ SETLOCAL enabledelayedexpansion
 TITLE FSCrawler ${project.version}
 
 set SCRIPT_DIR=%~dp0
+cd "%SCRIPT_DIR%\.."
 for %%I in ("%SCRIPT_DIR%..") do set FS_HOME=%%~dpfI
 
 IF DEFINED JAVA_HOME (

--- a/distribution/src/main/scripts/fscrawler.bat
+++ b/distribution/src/main/scripts/fscrawler.bat
@@ -4,7 +4,8 @@ SETLOCAL enabledelayedexpansion
 TITLE FSCrawler ${project.version}
 
 set SCRIPT_DIR=%~dp0
-cd "%SCRIPT_DIR%\.."
+REM change into script directory
+PUSHD "%SCRIPT_DIR%\.."
 for %%I in ("%SCRIPT_DIR%..") do set FS_HOME=%%~dpfI
 
 IF DEFINED JAVA_HOME (
@@ -66,5 +67,6 @@ FOR /F "usebackq tokens=1* delims= " %%A IN (!params!) DO (
 )
 
 %JAVA% %JAVA_OPTS% -cp "%FS_CLASSPATH%" -jar "%FS_HOME%/lib/${project.build.finalName}.jar" !newparams!
-
+REM Return to original directory
+POPD
 ENDLOCAL


### PR DESCRIPTION
Issue #1080 uncovered that fscrawler.bat is sensitive to the pwd
  when the batch file is called. Removed that dependency by CDing
  to the expected start directory at the beginning of the bat call