### PR TITLE
Fix1092 - Logging depends on where you launch the startup script from

### DIFF
--- a/cli/src/main/resources/log4j2.xml
+++ b/cli/src/main/resources/log4j2.xml
@@ -6,7 +6,7 @@
       <!-- If you want to change the log level for documents.log file -->
       <Property name="DOC_LEVEL">info</Property>
       <!-- If you want to change the output dir for logs -->
-      <Property name="LOG_DIR">logs</Property>
+      <Property name="LOG_DIR">$${log4j:configParentLocation}/../logs</Property>
    </Properties>
 
    <Appenders>

--- a/distribution/src/main/scripts/fscrawler
+++ b/distribution/src/main/scripts/fscrawler
@@ -44,7 +44,7 @@ JAVA_OPTS="$JAVA_OPTS -Dsun.jnu.encoding=UTF-8"
 JAVA_OPTS="$JAVA_OPTS -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"
 
 # Define LOG4J2 config file
-JAVA_OPTS="$JAVA_OPTS -Dlog4j.configurationFile=config/log4j2.xml"
+JAVA_OPTS="$JAVA_OPTS -Dlog4j.configurationFile=$FS_HOME/config/log4j2.xml"
 
 # If the user defined FS_JAVA_OPTS, we will use it to start the crawler
 JAVA_OPTS="$JAVA_OPTS $FS_JAVA_OPTS"

--- a/distribution/src/main/scripts/fscrawler.bat
+++ b/distribution/src/main/scripts/fscrawler.bat
@@ -29,7 +29,7 @@ REM Use LOG4J2 instead of java.util.logging
 set JAVA_OPTS=%JAVA_OPTS% -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
 
 REM Define LOG4J2 config file
-set JAVA_OPTS=%JAVA_OPTS% -Dlog4j.configurationFile=config/log4j2.xml
+set JAVA_OPTS=%JAVA_OPTS% -Dlog4j.configurationFile=%FS_HOME%/config/log4j2.xml
 
 REM If the user defined FS_JAVA_OPTS, we will use it to start the crawler
 set JAVA_OPTS=%JAVA_OPTS% %FS_JAVA_OPTS%


### PR DESCRIPTION
This should take care of the following error when launching fscrawler from outside of the root fscrawler directory for Linux and Windows.
````
ERROR StatusLogger Reconfiguration failed: No configuration found for '5bc2b487' at 'null' in 'null
````

This also changes the default config/log4j2.xml setting to make the log directory always be in the fscrawler root folder.  It previously created a /log directory in whichever path you launched fscrawler from.

This PR makes logging work consistently without regard to the user's PWD. 