### PR TITLE
Ignore errors when parsing a 0 byte file

### DIFF
--- a/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaInstance.java
+++ b/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaInstance.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tika.config.ServiceLoader;
 import org.apache.tika.exception.TikaException;
+import org.apache.tika.exception.ZeroByteFileException;
 import org.apache.tika.language.detect.LanguageDetector;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.mime.MediaTypeRegistry;
@@ -141,6 +142,9 @@ public class TikaInstance {
                 // This should never happen with BodyContentHandler...
                 throw new TikaException("Unexpected SAX processing failure", e);
             }
+        } catch (ZeroByteFileException e) {
+            String resourceName = metadata.get("resourceName");
+            logger.debug("Got an empty file for {}, so we are just skipping it.", resourceName);
         }
         return handler.toString();
     }

--- a/tika/src/test/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParserTest.java
+++ b/tika/src/test/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParserTest.java
@@ -829,6 +829,25 @@ public class TikaDocParserTest extends DocParserTestCase {
     }
 
     /**
+     * Test case for https://github.com/dadoonet/fscrawler/issues/834.
+     * @throws IOException In case something goes wrong
+     */
+    @Test
+    public void testEmptyFileIssue834() throws IOException {
+        FsSettings fsSettings = FsSettings.builder(getCurrentTestName())
+                .setFs(Fs.builder().setRawMetadata(true).build())
+                .build();
+        Doc doc = extractFromFile("issue-834.txt", fsSettings);
+        assertThat(doc.getContent(), isEmptyString());
+
+        // Meta data
+        Map<String, String> raw = doc.getMeta().getRaw();
+        assertThat(raw.entrySet(), iterableWithSize(2));
+        assertThat(raw, hasEntry("Content-Type", "text/plain"));
+        assertThat(raw, hasEntry("resourceName", "issue-834.txt"));
+    }
+
+    /**
      * Test protected document
      */
     @Test

--- a/tika/src/test/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParserTest.java
+++ b/tika/src/test/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParserTest.java
@@ -36,18 +36,7 @@ import java.util.Map;
 
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.localDateTimeToDate;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.emptyIterable;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
-import static org.hamcrest.Matchers.isEmptyString;
-import static org.hamcrest.Matchers.iterableWithSize;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.stringContainsInOrder;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeNoException;
 import static org.junit.Assume.assumeTrue;
@@ -782,7 +771,10 @@ public class TikaDocParserTest extends DocParserTestCase {
         Doc doc = extractFromFile("issue-1097.pdf", fsSettings);
         // TODO This test is now passing but should be failing when
         // https://issues.apache.org/jira/browse/TIKA-3364 is solved
-        assertThat(doc.getContent(), is("\nDummy PDF file\n\nDummy PDF file\n\n\n\tDummy PDF file\n\n"));
+        assertThat(doc.getContent(), isOneOf(
+                "\nDummy PDF file\n\nDummy PDF file\n\n\n\tDummy PDF file\n\n", // When OCR
+                "\nDummy PDF file\n\n\n\tDummy PDF file\n\n") // When NO OCR
+        );
 
         // Meta data
         assertThat(doc.getMeta().getAuthor(), not(nullValue()));


### PR DESCRIPTION
FSCrawler is freezing when crawling a 0 byte TXT file or it complains with a `InputStream must have > 0 bytes` message.
This fix will ignore such a case so the crawling can continue.

Closes #834
Closes #1084