### PR TITLE
Elasticsearch node settings should not be null by default

### DIFF
--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
@@ -51,6 +51,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collections;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -235,7 +236,7 @@ public abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
         staticLogger.info("Starting a client against [{}]", testClusterUrl);
         // We build the elasticsearch High Level Client based on the parameters
         elasticsearchWithSecurity = Elasticsearch.builder()
-                .addNode(new ServerUrl(testClusterUrl))
+                .setNodes(Collections.singletonList(new ServerUrl(testClusterUrl)))
                 .setUsername(testClusterUser)
                 .setPassword(testClusterPass)
                 .build();
@@ -270,7 +271,7 @@ public abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
     protected static Elasticsearch generateElasticsearchConfig(String indexName, String indexFolderName, int bulkSize,
                                                                TimeValue timeValue, ByteSizeValue byteSize) {
         Elasticsearch.Builder builder = Elasticsearch.builder()
-                .addNode(new ServerUrl(testClusterUrl))
+                .setNodes(Collections.singletonList(new ServerUrl(testClusterUrl)))
                 .setBulkSize(bulkSize);
 
         if (indexName != null) {

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/WPSearchIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/WPSearchIT.java
@@ -36,6 +36,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.Map;
 
 import static fr.pilato.elasticsearch.crawler.fs.client.WorkplaceSearchClientUtil.generateDefaultCustomSourceName;
@@ -73,7 +74,7 @@ public class WPSearchIT extends AbstractWorkplaceSearchITCase {
         FsSettings fsSettings = FsSettings.builder(crawlerName)
                 .setFs(fs)
                 .setElasticsearch(Elasticsearch.builder()
-                        .addNode(new ServerUrl(testClusterUrl))
+                        .setNodes(Collections.singletonList(new ServerUrl(testClusterUrl)))
                         .setUsername(testClusterUser)
                         .setPassword(testClusterPass)
                         .build())
@@ -119,7 +120,7 @@ public class WPSearchIT extends AbstractWorkplaceSearchITCase {
         FsSettings fsSettings = FsSettings.builder(crawlerName)
                 .setFs(fs)
                 .setElasticsearch(Elasticsearch.builder()
-                        .addNode(new ServerUrl(testClusterUrl))
+                        .setNodes(Collections.singletonList(new ServerUrl(testClusterUrl)))
                         .setUsername(testClusterUser)
                         .setPassword(testClusterPass)
                         .build())
@@ -159,7 +160,7 @@ public class WPSearchIT extends AbstractWorkplaceSearchITCase {
         FsSettings fsSettings = FsSettings.builder(getCrawlerName())
                 .setFs(fs)
                 .setElasticsearch(Elasticsearch.builder()
-                        .addNode(new ServerUrl(testClusterUrl))
+                        .setNodes(Collections.singletonList(new ServerUrl(testClusterUrl)))
                         .setUsername(testClusterUser)
                         .setPassword(testClusterPass)
                         .build())

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Elasticsearch.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Elasticsearch.java
@@ -28,6 +28,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -36,7 +38,7 @@ public class Elasticsearch {
     protected static final Logger logger = LogManager.getLogger(Elasticsearch.class);
     public static final ServerUrl NODE_DEFAULT = new ServerUrl("http://127.0.0.1:9200");
 
-    private List<ServerUrl> nodes;
+    private List<ServerUrl> nodes = Collections.singletonList(NODE_DEFAULT);
     private String index;
     private String indexFolder;
     private int bulkSize = 100;
@@ -76,9 +78,7 @@ public class Elasticsearch {
     // Using here a method instead of a constant as sadly FSCrawlerValidator can modify this object
     // TODO fix that: a validator should not modify the original object but return a modified copy
     public static Elasticsearch DEFAULT() {
-        return Elasticsearch.builder()
-                .addNode(NODE_DEFAULT)
-                .build();
+        return Elasticsearch.builder().build();
     }
 
     public List<ServerUrl> getNodes() {
@@ -157,7 +157,7 @@ public class Elasticsearch {
 
     @SuppressWarnings("UnusedReturnValue")
     public static class Builder {
-        private List<ServerUrl> nodes;
+        private List<ServerUrl> nodes = Collections.singletonList(NODE_DEFAULT);
         private String index;
         private String indexFolder;
         private int bulkSize = 100;
@@ -171,14 +171,6 @@ public class Elasticsearch {
 
         public Builder setNodes(List<ServerUrl> nodes) {
             this.nodes = nodes;
-            return this;
-        }
-
-        public Builder addNode(ServerUrl node) {
-            if (this.nodes == null) {
-                this.nodes = new ArrayList<>();
-            }
-            this.nodes.add(node);
             return this;
         }
 

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsParserTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsParserTest.java
@@ -28,6 +28,8 @@ import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCa
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -54,7 +56,7 @@ public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
             .build();
     private static final Elasticsearch ELASTICSEARCH_EMPTY = Elasticsearch.builder().build();
     private static final Elasticsearch ELASTICSEARCH_FULL = Elasticsearch.builder()
-            .addNode(new ServerUrl("http://127.0.0.1"))
+            .setNodes(Collections.singletonList(new ServerUrl("http://127.0.0.1")))
             .setUsername("elastic")
             .setPassword("changeme")
             .setBulkSize(1000)
@@ -196,7 +198,7 @@ public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
         settingsTester(
                 FsSettings.builder(getCurrentTestName())
                         .setElasticsearch(Elasticsearch.builder()
-                                .addNode(new ServerUrl("http://127.0.0.1:9200"))
+                                .setNodes(Collections.singletonList(new ServerUrl("http://127.0.0.1:9200")))
                                 .build())
                         .build()
         );
@@ -207,8 +209,9 @@ public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
         settingsTester(
                 FsSettings.builder(getCurrentTestName())
                         .setElasticsearch(Elasticsearch.builder()
-                                .addNode(new ServerUrl("http://127.0.0.1:9200"))
-                                .addNode(new ServerUrl("http://127.0.0.1:9201"))
+                                .setNodes(Arrays.asList(
+                                        new ServerUrl("http://127.0.0.1:9200"),
+                                        new ServerUrl("http://127.0.0.1:9201")))
                                 .build())
                         .build()
         );
@@ -219,8 +222,9 @@ public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
         settingsTester(
                 FsSettings.builder(getCurrentTestName())
                         .setElasticsearch(Elasticsearch.builder()
-                                .addNode(new ServerUrl("http://127.0.0.1:9200"))
-                                .addNode(new ServerUrl("https://localhost:9243"))
+                                .setNodes(Arrays.asList(
+                                        new ServerUrl("http://127.0.0.1:9200"),
+                                        new ServerUrl("https://localhost:9243")))
                                 .build())
                         .build()
         );
@@ -242,7 +246,7 @@ public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
         String cloudId = "wpsearch:ZXUtd2VzdC0zLmF3cy5lbGFzdGljLWNsb3VkLmNvbTo5MjQzJDg4NTYwNTJmNDBkNjQ4YjE5Mzk1ZDQ5YTViZjgwNTA4JDJhYjJmYTU5N2RiNDQwNjJhMGZmMjY2ZTBkZTEwY2Fm";
         FsSettings fsSettings = FsSettings.builder(getCurrentTestName())
                 .setElasticsearch(Elasticsearch.builder()
-                        .addNode(new ServerUrl(cloudId))
+                        .setNodes(Collections.singletonList(new ServerUrl(cloudId)))
                         .build())
                 .build();
         settingsTester(fsSettings);


### PR DESCRIPTION
[The documentation](https://fscrawler.readthedocs.io/en/latest/admin/fs/elasticsearch.html#node-settings) says that `elasticsearch.nodes` have a default value of `http://127.0.0.1:9200`.

It's not the case when you run a job like:

```yaml
---
name: "rest"
fs:
  url: "/tmp/es"
elasticsearch:
  username: "elastic"
  password: "changeme"
```

This fails with:

```
11:14:38,083 WARN  [f.p.e.c.f.c.v.ElasticsearchClientV7] failed to create elasticsearch client on Elasticsearch{nodes=null, index='rest', indexFolder='rest_folder', bulkSize=100, flushInterval=5s, byteSize=10mb, username='null', pipeline='null', pathPrefix='null', sslVerification='true'}, disabling crawler...
11:14:38,083 FATAL [f.p.e.c.f.c.FsCrawlerCli] We can not start Elasticsearch Client. Exiting.
java.lang.NullPointerException: Cannot invoke "java.util.List.size()" because the return value of "fr.pilato.elasticsearch.crawler.fs.settings.Elasticsearch.getNodes()" is null
        at fr.pilato.elasticsearch.crawler.fs.client.v7.ElasticsearchClientV7.buildRestClient(ElasticsearchClientV7.java:426) ~[fscrawler-elasticsearch-client-v7-2.7-SNAPSHOT.jar:?]
        at fr.pilato.elasticsearch.crawler.fs.client.v7.ElasticsearchClientV7.start(ElasticsearchClientV7.java:151) ~[fscrawler-elasticsearch-client-v7-2.7-SNAPSHOT.jar:?]
        at fr.pilato.elasticsearch.crawler.fs.service.FsCrawlerManagementServiceElasticsearchImpl.start(FsCrawlerManagementServiceElasticsearchImpl.java:60) ~[fscrawler-core-2.7-SNAPSHOT.jar:?]
        at fr.pilato.elasticsearch.crawler.fs.FsCrawlerImpl.start(FsCrawlerImpl.java:116) ~[fscrawler-core-2.7-SNAPSHOT.jar:?]
        at fr.pilato.elasticsearch.crawler.fs.cli.FsCrawlerCli.startEsClient(FsCrawlerCli.java:307) [fscrawler-cli-2.7-SNAPSHOT.jar:?]
        at fr.pilato.elasticsearch.crawler.fs.cli.FsCrawlerCli.main(FsCrawlerCli.java:283) [fscrawler-cli-2.7-SNAPSHOT.jar:?]
```

The only workaround is:

```yaml
---
name: "rest"
fs:
  url: "/tmp/es"
elasticsearch:
  nodes:
  - url: "http://127.0.0.1:9200"
  username: "elastic"
  password: "changeme"
```

Closes #1191.