### PR TITLE
Remove the explicit PDFBox 2.0.24 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -770,15 +770,6 @@
                 <artifactId>asm</artifactId>
                 <version>9.2</version>
             </dependency>
-            <!--
-                Temporary fix for https://github.com/dadoonet/fscrawler/pull/1030
-                This is fixed in PDFBox 2.0.22 which is not yet added to Tika
-             -->
-            <dependency>
-                <groupId>org.apache.pdfbox</groupId>
-                <artifactId>pdfbox</artifactId>
-                <version>2.0.24</version>
-            </dependency>
 
             <!-- For Language detection -->
             <dependency>


### PR DESCRIPTION
Tika 1.27 contains already this dependency so we don't need to add it manually.

Related to:

* #1193
* #1030
* https://issues.apache.org/jira/browse/TIKA-3224
* https://issues.apache.org/jira/browse/PDFBOX-5009