### PR TITLE
Split build and deploy phases for Docker images

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -158,7 +158,7 @@
                         </execution>
                     </executions>
                 </plugin>
-                <!-- Generate the docker images (run during package step) -->
+                <!-- Generate and push the docker images -->
                 <plugin>
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
@@ -198,11 +198,19 @@
                         </images>
                     </configuration>
                     <executions>
+                        <!-- Generate the docker images during the package phase -->
                         <execution>
-                            <id>docker-build-push</id>
-                            <phase>deploy</phase>
+                            <id>docker-build</id>
+                            <phase>package</phase>
                             <goals>
                                 <goal>build</goal>
+                            </goals>
+                        </execution>
+                        <!-- Push the docker images during the deploy phase -->
+                        <execution>
+                            <id>docker-push</id>
+                            <phase>deploy</phase>
+                            <goals>
                                 <goal>push</goal>
                             </goals>
                         </execution>


### PR DESCRIPTION
If we build the docker image in the deploy phase, something unexpected is happening.

The call to the deploy plugin, changes the name of the artifact when using a SNAPSHOT version.
That artifact is then used by the docker plugin and pulled from Sonatype **without** changing its name.
So we end up with a name like `fscrawler-es7-2.7-20210726.044935-205.jar` instead of the `finalName` which is `fscrawler-es7-2.7-SNAPSHOT.jar`.

The fscrawler job can not start because it calls:

```sh
exec "$JAVA" ${JAVA_OPTS} -cp "$FS_CLASSPATH" -jar "$FS_HOME/lib/${project.build.finalName}.jar" "$@"
```

The jar is then not found.

If we split the docker build and the docker deploy within 2 different phases, the build generates the right artifact name locally and the deploy "just" deploy what has already been generated.

This commit adds this behavior.

Closes #1201.