### PR TITLE
Add logs to the console when running a Docker instance

### DIFF
--- a/cli/src/main/resources/log4j2-console.xml
+++ b/cli/src/main/resources/log4j2-console.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="fatal" monitorInterval="30">
+   <Properties>
+      <!-- If you want to change the log level for fscrawler.log file -->
+      <Property name="LOG_LEVEL">info</Property>
+      <!-- If you want to change the log level for documents.log file -->
+      <Property name="DOC_LEVEL">info</Property>
+   </Properties>
+
+   <Appenders>
+      <Console name="Console" target="SYSTEM_OUT" follow="true">
+         <PatternLayout pattern="%d{ABSOLUTE} %highlight{%-5p} [%c{1.}] %m%n"/>
+      </Console>
+   </Appenders>
+   <Loggers>
+      <!-- This logger is used for the console -->
+      <Logger name="fscrawler.console" level="info" additivity="false">
+         <AppenderRef ref="Console" />
+      </Logger>
+
+      <!-- This logger is used to trace all information about documents -->
+      <Logger name="fscrawler.document" level="${sys:DOC_LEVEL}" additivity="false">
+         <AppenderRef ref="Console" />
+      </Logger>
+
+      <!-- This logger is used to log FSCrawler code execution -->
+      <Logger name="fr.pilato.elasticsearch.crawler.fs" level="${sys:LOG_LEVEL}" additivity="false">
+         <AppenderRef ref="Console" />
+      </Logger>
+
+      <!-- This logger is used to log 3rd party libs execution -->
+      <Logger name="org.elasticsearch" level="warn" additivity="false">
+         <AppenderRef ref="Console" />
+      </Logger>
+      <Logger name="org.glassfish" level="warn" additivity="false">
+         <AppenderRef ref="Console" />
+      </Logger>
+      <Logger name="org.apache.tika.parser.ocr.TesseractOCRParser" level="error" additivity="false">
+         <AppenderRef ref="Console" />
+      </Logger>
+      <Logger name="com.gargoylesoftware" level="error" additivity="false">
+         <AppenderRef ref="Console"/>
+      </Logger>
+
+      <Root level="warn">
+         <AppenderRef ref="Console" />
+      </Root>
+   </Loggers>
+</Configuration>

--- a/distribution/src/main/assembly/assembly.xml
+++ b/distribution/src/main/assembly/assembly.xml
@@ -34,6 +34,7 @@
             <outputDirectory>config</outputDirectory>
             <includes>
                 <include>log4j2.xml</include>
+                <include>log4j2-console.xml</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/distribution/src/main/docker/Dockerfile
+++ b/distribution/src/main/docker/Dockerfile
@@ -14,4 +14,7 @@ COPY maven /usr/share/fscrawler
 RUN set -ex \
     && ln -sn /usr/share/fscrawler/bin/fscrawler /usr/bin/
 
+RUN mv /usr/share/fscrawler/config/log4j2.xml /usr/share/fscrawler/config/log4j2-file.xml \
+    && mv /usr/share/fscrawler/config/log4j2-console.xml /usr/share/fscrawler/config/log4j2.xml
+
 WORKDIR /usr/share/fscrawler


### PR DESCRIPTION
This adds back a way to display logs when running fscrawler from docker.
Otherwise, it's hard to understand what is happening.