### PR TITLE
Detect when fscrawler runs in foreground and adapt logs

### DIFF
--- a/cli/src/main/resources/log4j2-file.xml
+++ b/cli/src/main/resources/log4j2-file.xml
@@ -5,45 +5,63 @@
       <Property name="LOG_LEVEL">info</Property>
       <!-- If you want to change the log level for documents.log file -->
       <Property name="DOC_LEVEL">info</Property>
+      <!-- If you want to change the output dir for logs -->
+      <Property name="LOG_DIR">$${log4j:configParentLocation}/../logs</Property>
    </Properties>
 
    <Appenders>
-      <Console name="Console" target="SYSTEM_OUT" follow="true">
+      <RollingFile name="RollingFile" fileName="${sys:LOG_DIR}/fscrawler.log"
+                   filePattern="${sys:LOG_DIR}/fscrawler-%d{yyyy-MM-dd}-%i.log.gz">
          <PatternLayout pattern="%d{ABSOLUTE} %highlight{%-5p} [%c{1.}] %m%n"/>
-      </Console>
+         <Policies>
+            <OnStartupTriggeringPolicy />
+            <SizeBasedTriggeringPolicy size="20 MB" />
+            <TimeBasedTriggeringPolicy />
+         </Policies>
+         <DefaultRolloverStrategy max="7"/>
+      </RollingFile>
+
+      <RollingFile name="Documents" fileName="${sys:LOG_DIR}/documents.log"
+                   filePattern="${sys:LOG_DIR}/documents-%d{yyyy-MM-dd}.log.gz">
+         <PatternLayout pattern="%d [%highlight{%-5p}] %m%n"/>
+         <Policies>
+            <TimeBasedTriggeringPolicy />
+         </Policies>
+         <DefaultRolloverStrategy max="7"/>
+      </RollingFile>
    </Appenders>
    <Loggers>
       <!-- This logger is used for the console -->
       <Logger name="fscrawler.console" level="info" additivity="false">
-         <AppenderRef ref="Console" />
+         <AppenderRef ref="RollingFile" />
       </Logger>
 
       <!-- This logger is used to trace all information about documents -->
       <Logger name="fscrawler.document" level="${sys:DOC_LEVEL}" additivity="false">
-         <AppenderRef ref="Console" />
+         <AppenderRef ref="Documents" />
       </Logger>
 
       <!-- This logger is used to log FSCrawler code execution -->
       <Logger name="fr.pilato.elasticsearch.crawler.fs" level="${sys:LOG_LEVEL}" additivity="false">
-         <AppenderRef ref="Console" />
+         <AppenderRef ref="RollingFile" />
       </Logger>
 
       <!-- This logger is used to log 3rd party libs execution -->
       <Logger name="org.elasticsearch" level="warn" additivity="false">
-         <AppenderRef ref="Console" />
+         <AppenderRef ref="RollingFile" />
       </Logger>
       <Logger name="org.glassfish" level="warn" additivity="false">
-         <AppenderRef ref="Console" />
+         <AppenderRef ref="RollingFile" />
       </Logger>
       <Logger name="org.apache.tika.parser.ocr.TesseractOCRParser" level="error" additivity="false">
-         <AppenderRef ref="Console" />
+         <AppenderRef ref="RollingFile" />
       </Logger>
       <Logger name="com.gargoylesoftware" level="error" additivity="false">
-         <AppenderRef ref="Console"/>
+         <AppenderRef ref="RollingFile"/>
       </Logger>
 
       <Root level="warn">
-         <AppenderRef ref="Console" />
+         <AppenderRef ref="RollingFile" />
       </Root>
    </Loggers>
 </Configuration>

--- a/cli/src/main/resources/log4j2.xml
+++ b/cli/src/main/resources/log4j2.xml
@@ -11,7 +11,7 @@
 
    <Appenders>
       <Console name="Console" target="SYSTEM_OUT" follow="true">
-         <PatternLayout pattern="%m%n"/>
+         <PatternLayout pattern="%d{ABSOLUTE} %highlight{%-5p} [%c{1.}] %m%n"/>
       </Console>
 
       <RollingFile name="RollingFile" fileName="${sys:LOG_DIR}/fscrawler.log"
@@ -47,24 +47,30 @@
 
       <!-- This logger is used to log FSCrawler code execution -->
       <Logger name="fr.pilato.elasticsearch.crawler.fs" level="${sys:LOG_LEVEL}" additivity="false">
+         <AppenderRef ref="Console" />
          <AppenderRef ref="RollingFile" />
       </Logger>
 
       <!-- This logger is used to log 3rd party libs execution -->
       <Logger name="org.elasticsearch" level="warn" additivity="false">
+         <AppenderRef ref="Console" />
          <AppenderRef ref="RollingFile" />
       </Logger>
       <Logger name="org.glassfish" level="warn" additivity="false">
+         <AppenderRef ref="Console" />
          <AppenderRef ref="RollingFile" />
       </Logger>
       <Logger name="org.apache.tika.parser.ocr.TesseractOCRParser" level="error" additivity="false">
+         <AppenderRef ref="Console" />
          <AppenderRef ref="RollingFile" />
       </Logger>
       <Logger name="com.gargoylesoftware" level="error" additivity="false">
-         <AppenderRef ref="RollingFile"/>
+         <AppenderRef ref="Console"/>
+         <AppenderRef ref="RollingFile" />
       </Logger>
 
       <Root level="warn">
+         <AppenderRef ref="Console" />
          <AppenderRef ref="RollingFile" />
       </Root>
    </Loggers>

--- a/distribution/src/main/docker/Dockerfile
+++ b/distribution/src/main/docker/Dockerfile
@@ -14,7 +14,4 @@ COPY maven /usr/share/fscrawler
 RUN set -ex \
     && ln -sn /usr/share/fscrawler/bin/fscrawler /usr/bin/
 
-RUN mv /usr/share/fscrawler/config/log4j2.xml /usr/share/fscrawler/config/log4j2-file.xml \
-    && mv /usr/share/fscrawler/config/log4j2-console.xml /usr/share/fscrawler/config/log4j2.xml
-
 WORKDIR /usr/share/fscrawler

--- a/distribution/src/main/scripts/fscrawler
+++ b/distribution/src/main/scripts/fscrawler
@@ -43,8 +43,11 @@ JAVA_OPTS="$JAVA_OPTS -Dsun.jnu.encoding=UTF-8"
 # Use LOG4J2 instead of java.util.logging
 JAVA_OPTS="$JAVA_OPTS -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"
 
-# Define LOG4J2 config file
-JAVA_OPTS="$JAVA_OPTS -Dlog4j.configurationFile=$FS_HOME/config/log4j2.xml"
+# Define LOG4J2 config file (if running in background, we will use log4j2-file)
+case $(ps -o stat= -p $$) in
+  *+*) JAVA_OPTS="$JAVA_OPTS -Dlog4j.configurationFile=$FS_HOME/config/log4j2.xml" ;;
+  *) JAVA_OPTS="$JAVA_OPTS -Dlog4j.configurationFile=$FS_HOME/config/log4j2-file.xml" ;;
+esac
 
 # If the user defined FS_JAVA_OPTS, we will use it to start the crawler
 JAVA_OPTS="$JAVA_OPTS $FS_JAVA_OPTS"

--- a/docs/source/admin/logger.rst
+++ b/docs/source/admin/logger.rst
@@ -36,3 +36,8 @@ rotated every day or after 20mb of logs and gzipped. Logs are removed after 7 da
 
 You can change this strategy by modifying the ``config/log4j2.xml`` file.
 Please read `Log4J2 documentation <https://logging.apache.org/log4j/2.x/manual/index.html>`_ on how to configure Log4J.
+
+.. note::
+
+    FSCrawler detects automatically on Linux machines when it's running in background or foreground.
+    When in background, the logger configuration file used is ``config/log4j2-file.xml``.

--- a/docs/source/dev/build.rst
+++ b/docs/source/dev/build.rst
@@ -218,12 +218,10 @@ If you want to skip the check, you can run with ``-Dossindex.fail=false``::
 Docker build
 ^^^^^^^^^^^^
 
-The docker images build is ran when calling the maven ``deploy`` phase. If you want to generate the images
-without deploying them, you can manually call the docker maven plugin with::
+The docker images build is ran when calling the maven ``package`` phase. If you want to skip the build of the images,
+you can manually use the ``docker.skip`` option::
 
-        cd distribution/es7
-        mvn docker:build
-        cd -
+        mvn package -Ddocker.skip
 
 DockerHub publication
 ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
To ease the debugging, we now detect that fscrawler is launched in foreground or background.

When in background, we use a specific file only logger (`log4j2-file.xml`).

When in foreground, we use the standard logger  (`log4j2.xml`) which prints both to the console and in the logs dir.