### PR TITLE
Generate only 2 docker images

### DIFF
--- a/distribution/es7/pom.xml
+++ b/distribution/es7/pom.xml
@@ -15,8 +15,12 @@
     <properties>
         <module.name>es7</module.name>
 
-        <docker.eng.tags.0>latest</docker.eng.tags.0>
-        <docker.eng.tags.1>${project.version}</docker.eng.tags.1>
+        <!-- We use this tag to make easy using docker pull dadoonet/fscrawler:noocr -->
+        <docker.noocr.tags.0>noocr</docker.noocr.tags.0>
+
+        <!-- The ocr version will be the default one for anyone trying docker pull dadoonet/fscrawler -->
+        <docker.ocr.tags.0>latest</docker.ocr.tags.0>
+        <docker.ocr.tags.1>${project.version}</docker.ocr.tags.1>
     </properties>
 
     <dependencies>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -19,9 +19,6 @@
     </modules>
 
     <properties>
-        <tesseract.version>4.0.0*</tesseract.version>
-        <tesseract.lang.version>1:4.00*</tesseract.lang.version>
-
         <!-- Global configuration parameters for docker -->
         <!-- By default, build docker images on each modules. -->
         <docker.skip>${env.DOCKER_SKIP}</docker.skip>
@@ -31,40 +28,22 @@
         <module.name>es7</module.name>
 
         <!-- Docker Image Definitions -->
-        <!-- no install tesseract-ocr and data files for any languages -->
-        <docker.nolang.alias>${project.artifactId}-nolang</docker.nolang.alias>
-        <docker.nolang.name>${docker.username}/fscrawler:${project.version}-${module.name}-nolang</docker.nolang.name>
-        <docker.nolang.cacheFrom>${docker.nolang.name}</docker.nolang.cacheFrom>
-        <docker.nolang.dockerFile>${project.basedir}/../src/main/docker/Dockerfile</docker.nolang.dockerFile>
-        <docker.nolang.assembly.descriptor>${project.basedir}/../src/main/assembly/assembly.xml</docker.nolang.assembly.descriptor>
-        <docker.nolang.assembly.mode>tgz</docker.nolang.assembly.mode>
+        <!-- standard install with no ocr -->
+        <docker.noocr.alias>${project.artifactId}-noocr</docker.noocr.alias>
+        <docker.noocr.name>${docker.username}/fscrawler:${project.version}-noocr-${module.name}</docker.noocr.name>
+        <docker.noocr.cacheFrom>${docker.noocr.name}</docker.noocr.cacheFrom>
+        <docker.noocr.dockerFile>${project.basedir}/../src/main/docker/Dockerfile</docker.noocr.dockerFile>
+        <docker.noocr.assembly.descriptor>${project.basedir}/../src/main/assembly/assembly.xml</docker.noocr.assembly.descriptor>
+        <docker.noocr.assembly.mode>tgz</docker.noocr.assembly.mode>
 
-        <!-- install tesseract-ocr and data files for English -->
-        <docker.eng.alias>${project.artifactId}-eng</docker.eng.alias>
-        <docker.eng.name>${docker.username}/fscrawler:${project.version}-${module.name}-eng</docker.eng.name>
-        <docker.eng.cacheFrom>${docker.eng.name}</docker.eng.cacheFrom>
-        <docker.eng.dockerFile>${docker.nolang.dockerFile}</docker.eng.dockerFile>
-        <docker.eng.assembly.descriptor>${docker.nolang.assembly.descriptor}</docker.eng.assembly.descriptor>
-        <docker.eng.assembly.mode>${docker.nolang.assembly.mode}</docker.eng.assembly.mode>
-        <docker.eng.args.langsPkg>tesseract-ocr=${tesseract.version} tesseract-ocr-eng=${tesseract.lang.version}</docker.eng.args.langsPkg>
-
-        <!-- install tesseract-ocr and data files for French -->
-        <docker.fra.alias>${project.artifactId}-fra</docker.fra.alias>
-        <docker.fra.name>${docker.username}/fscrawler:${project.version}-${module.name}-fra</docker.fra.name>
-        <docker.fra.cacheFrom>${docker.fra.name}</docker.fra.cacheFrom>
-        <docker.fra.dockerFile>${docker.nolang.dockerFile}</docker.fra.dockerFile>
-        <docker.fra.assembly.descriptor>${docker.nolang.assembly.descriptor}</docker.fra.assembly.descriptor>
-        <docker.fra.assembly.mode>${docker.nolang.assembly.mode}</docker.fra.assembly.mode>
-        <docker.fra.args.langsPkg>tesseract-ocr=${tesseract.version} tesseract-ocr-fra=${tesseract.lang.version}</docker.fra.args.langsPkg>
-
-        <!-- install tesseract-ocr and  data files for Japanese -->
-        <docker.jpn.alias>${project.artifactId}-jpn</docker.jpn.alias>
-        <docker.jpn.name>${docker.username}/fscrawler:${project.version}-${module.name}-jpn</docker.jpn.name>
-        <docker.jpn.cacheFrom>${docker.jpn.name}</docker.jpn.cacheFrom>
-        <docker.jpn.dockerFile>${docker.nolang.dockerFile}</docker.jpn.dockerFile>
-        <docker.jpn.assembly.descriptor>${docker.nolang.assembly.descriptor}</docker.jpn.assembly.descriptor>
-        <docker.jpn.assembly.mode>${docker.nolang.assembly.mode}</docker.jpn.assembly.mode>
-        <docker.jpn.args.langsPkg>tesseract-ocr=${tesseract.version} tesseract-ocr-jpn=${tesseract.lang.version}</docker.jpn.args.langsPkg>
+        <!-- install tesseract-ocr and all language files -->
+        <docker.ocr.alias>${project.artifactId}-ocr</docker.ocr.alias>
+        <docker.ocr.name>${docker.username}/fscrawler:${project.version}-ocr-${module.name}</docker.ocr.name>
+        <docker.ocr.cacheFrom>${docker.ocr.name}</docker.ocr.cacheFrom>
+        <docker.ocr.dockerFile>${docker.noocr.dockerFile}</docker.ocr.dockerFile>
+        <docker.ocr.assembly.descriptor>${docker.noocr.assembly.descriptor}</docker.ocr.assembly.descriptor>
+        <docker.ocr.assembly.mode>${docker.noocr.assembly.mode}</docker.ocr.assembly.mode>
+        <docker.ocr.args.langsPkg>imagemagick tesseract-ocr tesseract-ocr-all</docker.ocr.args.langsPkg>
     </properties>
 
     <dependencies>
@@ -169,30 +148,18 @@
                                 <password>${docker.push.password}</password>
                             </push>
                         </authConfig>
-                        <!-- Disable configuration for IT -->
+                        <!-- Create multiple images -->
                         <images combine.self="override">
                             <image>
                                 <external>
                                     <type>properties</type>
-                                    <prefix>docker.nolang</prefix>
+                                    <prefix>docker.noocr</prefix>
                                 </external>
                             </image>
                             <image>
                                 <external>
                                     <type>properties</type>
-                                    <prefix>docker.eng</prefix>
-                                </external>
-                            </image>
-                            <image>
-                                <external>
-                                    <type>properties</type>
-                                    <prefix>docker.fra</prefix>
-                                </external>
-                            </image>
-                            <image>
-                                <external>
-                                    <type>properties</type>
-                                    <prefix>docker.jpn</prefix>
+                                    <prefix>docker.ocr</prefix>
                                 </external>
                             </image>
                         </images>

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -59,6 +59,7 @@ The distribution contains:
    └── lib
        ├── ... All needed jars
 
+.. _docker:
 
 Using docker
 ------------
@@ -68,6 +69,18 @@ Pull the Docker image:
 .. code:: sh
 
    docker pull dadoonet/fscrawler
+
+.. note::
+
+    This image is very big (1.2+gb) as it contains `Tesseract <https://tesseract-ocr.github.io/tessdoc/>`__ and
+    all the `trained language data <https://tesseract-ocr.github.io/tessdoc/Data-Files.html>`__.
+    If you don't want to use OCR at all, you can use a smaller image (around 530mb) by pulling instead
+    ``dadoonet/fscrawler:noocr``
+
+    .. code:: sh
+
+       docker pull dadoonet/fscrawler:noocr
+
 
 Let say your documents are located in ``~/tmp`` dir and you want to store your fscrawler jobs in ``~/.fscrawler``.
 You can run FSCrawler with:

--- a/docs/source/user/ocr.rst
+++ b/docs/source/user/ocr.rst
@@ -6,7 +6,7 @@ OCR integration
 .. versionadded:: 2.3
 
 To deal with images containing text, just `install
-Tesseract <https://github.com/tesseract-ocr/tesseract/wiki>`__.
+Tesseract <https://tesseract-ocr.github.io/tessdoc/>`__.
 Tesseract will be auto-detected by Tika or you can explicitly `set the
 path to tesseract binary <OCR Path>`_. Then add an image (png, jpg, …)
 into your Fscrawler :ref:`root-directory`. After the next
@@ -55,9 +55,9 @@ By default, OCR is activated if tesseract can be found on your system.
 OCR Language
 ------------
 
-If you have installed a `Tesseract Language
-pack <https://wiki.apache.org/tika/TikaOCR>`__, you can use it when
-parsing your documents by setting ``fs.ocr.language`` property in your
+If you are using the default Docker image (see :ref:`docker`) or if you have installed any of the
+`Tesseract Languages <https://tesseract-ocr.github.io/tessdoc/Data-Files.html>`__,
+you can use them when parsing your documents by setting ``fs.ocr.language`` property in your
 ``~/.fscrawler/test/_settings.yaml`` file:
 
 .. code:: yaml


### PR DESCRIPTION
Instead of building one docker image per language which limits a bit when you want to run OCR on files containing multiple languages, we are now building 2 docker images per distribution (es6 and es7). Which means today:

* `2.7-SNAPSHOT-ocr-es7`, with alias `latest` and `2.7-SNAPSHOT`
* `2.7-SNAPSHOT-noocr-es7` with alias `noocr`
* `2.7-SNAPSHOT-ocr-es6`
* `2.7-SNAPSHOT-noocr-es6`