### PR TITLE
Cache Docker Layers in Github Actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,6 +22,8 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
+      - name: Docker Layer Caching
+        uses: satackey/action-docker-layer-caching@v0.0.11
       - name: Build the project
         run: mvn --batch-mode verify -DskipTests
 
@@ -45,6 +47,8 @@ jobs:
           server-id: sonatype-nexus-snapshots
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
+      - name: Docker Layer Caching
+        uses: satackey/action-docker-layer-caching@v0.0.11
       - name: Deploy with Maven
         run: mvn deploy -DskipTests
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,5 +23,7 @@ jobs:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
+    - name: Docker Layer Caching
+      uses: satackey/action-docker-layer-caching@v0.0.11
     - name: Build with Maven
       run: mvn --batch-mode --update-snapshots verify


### PR DESCRIPTION
We want to have faster builds so let's cache our docker layers instead of rebuilding everything again and again.