### PR TITLE
Make consistent `path.XYZ` on documents and folders

### DIFF
--- a/3rdparty/workplacesearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/thirdparty/wpsearch/WPSearchClient.java
+++ b/3rdparty/workplacesearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/thirdparty/wpsearch/WPSearchClient.java
@@ -50,6 +50,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.*;
+import static fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil.parseJson;
 
 /**
  * Workplace Search Java client
@@ -321,7 +322,7 @@ public class WPSearchClient implements Closeable {
             String json = listAllCustomSources(currentPage);
 
             // We parse the json
-            Object document = Configuration.defaultConfiguration().jsonProvider().parse(json);
+            Object document = parseJson(json);
             totalPages = JsonPath.read(document, "$.meta.page.total_pages");
 
             // We compare every source
@@ -370,7 +371,7 @@ public class WPSearchClient implements Closeable {
         logger.trace("Source [{}] created. Response: {}", sourceName, response);
 
         // We parse the json
-        Object document = Configuration.defaultConfiguration().jsonProvider().parse(response);
+        Object document = parseJson(response);
         String id = JsonPath.read(document, "$.id");
 
         logger.debug("Source [{}/{}] created.", id, sourceName);
@@ -445,11 +446,9 @@ public class WPSearchClient implements Closeable {
 
     @Override
     public String toString() {
-        final StringBuffer sb = new StringBuffer("WPSearchClient{");
-        sb.append("endpoint='").append(endpoint).append('\'');
-        sb.append(", host='").append(host).append('\'');
-        sb.append(", urlForApi='").append(urlForApi).append('\'');
-        sb.append('}');
-        return sb.toString();
+        return "WPSearchClient{" + "endpoint='" + endpoint + '\'' +
+                ", host='" + host + '\'' +
+                ", urlForApi='" + urlForApi + '\'' +
+                '}';
     }
 }

--- a/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/Folder.java
+++ b/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/Folder.java
@@ -19,22 +19,42 @@
 
 package fr.pilato.elasticsearch.crawler.fs.beans;
 
-import java.io.IOException;
+/**
+ * Represents a folder we have visited
+ */
+public class Folder {
 
-import static fr.pilato.elasticsearch.crawler.fs.framework.MetaParser.prettyMapper;
-
-public class PathParser {
-
-    public static String toJson(Path path) {
-        try {
-            return prettyMapper.writeValueAsString(path);
-        } catch (IOException e) {
-            // TODO Fix that code. We should log here and return null.
-            throw new RuntimeException(e);
-        }
+    /**
+     * Generated json field names
+     */
+    static public final class FIELD_NAMES {
+        public static final String PATH = "path";
     }
 
-    public static Path fromJson(String json) throws IOException {
-        return prettyMapper.readValue(json, Path.class);
+    private Path path;
+
+    public Folder() {
+        path = new Path();
+    }
+
+    /**
+     * Build a folder with a single ctor call
+     * @param root      Root of the folder
+     * @param real      The full path to the folder
+     * @param virtual   The virtual path from the root
+     */
+    public Folder(String root, String real, String virtual) {
+        path = new Path();
+        path.setRoot(root);
+        path.setReal(real);
+        path.setVirtual(virtual);
+    }
+
+    public Path getPath() {
+        return path;
+    }
+
+    public void setPath(Path path) {
+        this.path = path;
     }
 }

--- a/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/FolderParser.java
+++ b/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/FolderParser.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package fr.pilato.elasticsearch.crawler.fs.beans;
+
+import java.io.IOException;
+
+import static fr.pilato.elasticsearch.crawler.fs.framework.MetaParser.prettyMapper;
+
+public class FolderParser {
+
+    public static String toJson(Folder folder) {
+        try {
+            return prettyMapper.writeValueAsString(folder);
+        } catch (IOException e) {
+            // TODO Fix that code. We should log here and return null.
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static Folder fromJson(String json) throws IOException {
+        return prettyMapper.readValue(json, Folder.class);
+    }
+}

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
@@ -22,6 +22,7 @@ package fr.pilato.elasticsearch.crawler.fs;
 import fr.pilato.elasticsearch.crawler.fs.beans.Attributes;
 import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
 import fr.pilato.elasticsearch.crawler.fs.beans.DocParser;
+import fr.pilato.elasticsearch.crawler.fs.beans.Folder;
 import fr.pilato.elasticsearch.crawler.fs.beans.FsJob;
 import fr.pilato.elasticsearch.crawler.fs.beans.FsJobFileHandler;
 import fr.pilato.elasticsearch.crawler.fs.beans.ScanStatistic;
@@ -502,13 +503,13 @@ public abstract class FsParserAbstract extends FsParser {
     }
 
     /**
-     * Index a Path object (AKA a folder) in elasticsearch
-     * @param id    id of the path
-     * @param path  path object
+     * Index a folder object in elasticsearch
+     * @param id        id of the folder
+     * @param folder    path object
      */
-    private void indexDirectory(String id, fr.pilato.elasticsearch.crawler.fs.beans.Path path) throws IOException {
+    private void indexDirectory(String id, Folder folder) throws IOException {
         if (!closed) {
-            managementService.storeVisitedDirectory(fsSettings.getElasticsearch().getIndexFolder(), id, path);
+            managementService.storeVisitedDirectory(fsSettings.getElasticsearch().getIndexFolder(), id, folder);
         } else {
             logger.warn("trying to add new file while closing crawler. Document [{}]/[{}] has been ignored",
                     fsSettings.getElasticsearch().getIndexFolder(), id);
@@ -520,16 +521,10 @@ public abstract class FsParserAbstract extends FsParser {
      * @param path complete path like /path/to/subdir
      */
     private void indexDirectory(String path) throws Exception {
-        fr.pilato.elasticsearch.crawler.fs.beans.Path pathObject = new fr.pilato.elasticsearch.crawler.fs.beans.Path();
-        // The real and complete path
-        pathObject.setReal(path);
         String rootdir = path.substring(0, path.lastIndexOf(pathSeparator));
-        // Encoded version of the parent dir
-        pathObject.setRoot(SignTool.sign(rootdir));
-        // The virtual URL (not including the initial root dir)
-        pathObject.setVirtual(computeVirtualPathName(stats.getRootPath(), path));
+        Folder folder = new Folder(SignTool.sign(rootdir), path, computeVirtualPathName(stats.getRootPath(), path));
 
-        indexDirectory(SignTool.sign(path), pathObject);
+        indexDirectory(SignTool.sign(path), folder);
     }
 
     /**

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerManagementService.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerManagementService.java
@@ -19,6 +19,7 @@
 
 package fr.pilato.elasticsearch.crawler.fs.service;
 
+import fr.pilato.elasticsearch.crawler.fs.beans.Folder;
 import fr.pilato.elasticsearch.crawler.fs.beans.Path;
 
 import java.io.IOException;
@@ -47,7 +48,7 @@ public interface FsCrawlerManagementService extends FsCrawlerService {
      * current directories. So we will be able to remove data if needed.
      * @param indexFolder index name to store this information
      * @param id id of the directory
-     * @param path Path to store
+     * @param folder Folder to store
      */
-    void storeVisitedDirectory(String indexFolder, String id, Path path) throws IOException;
+    void storeVisitedDirectory(String indexFolder, String id, Folder folder) throws IOException;
 }

--- a/docs/source/admin/fs/elasticsearch.rst
+++ b/docs/source/admin/fs/elasticsearch.rst
@@ -98,19 +98,10 @@ Or fall back to the command line:
     elasticsearch version it is connected to.
     The default settings definitions are stored in ``~/.fscrawler/_default/_mappings``:
 
-    -  ``2/_settings.json``: for elasticsearch 2.x series document index settings
-    -  ``2/_settings_folder.json``: for elasticsearch 2.x series folder index settings
-    -  ``5/_settings.json``: for elasticsearch 5.x series document index settings
-    -  ``5/_settings_folder.json``: for elasticsearch 5.x series folder index settings
     -  ``6/_settings.json``: for elasticsearch 6.x series document index settings
     -  ``6/_settings_folder.json``: for elasticsearch 6.x series folder index settings
     -  ``7/_settings.json``: for elasticsearch 7.x series document index settings
     -  ``7/_settings_folder.json``: for elasticsearch 7.x series folder index settings
-
-.. note::
-
-    For versions before 6.x series, the type of the document is ``doc``.
-    From 6.x, the type of the document is ``_doc``.
 
 Creating your own mapping (analyzers)
 """""""""""""""""""""""""""""""""""""
@@ -370,10 +361,6 @@ time instead of the :ref:`default ones <mappings>`:
 .. tip::
     You can do the same for other elasticsearch versions with:
 
-    -  ``~/.fscrawler/{job_name}/_mappings/2/_settings.json`` for 2.x series (deprecated)
-    -  ``~/.fscrawler/{job_name}/_mappings/2/_settings_folder.json`` for 2.x series (deprecated)
-    -  ``~/.fscrawler/{job_name}/_mappings/5/_settings.json`` for 5.x series
-    -  ``~/.fscrawler/{job_name}/_mappings/5/_settings_folder.json`` for 5.x series
     -  ``~/.fscrawler/{job_name}/_mappings/6/_settings.json`` for 6.x series
     -  ``~/.fscrawler/{job_name}/_mappings/6/_settings_folder.json`` for 6.x series
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -487,3 +487,8 @@ Upgrade to 2.7
 - The mapping for elasticsearch 6.x can not contain anymore the type name.
 - We removed the Elasticsearch V5 compatibility as it's not maintained anymore by elastic.
 - You need to use a recent JVM to run FSCrawler (Java 15+ recommended)
+- The mapping for the folders changed and is now consistent with the mapping for documents. If you are already using
+  FSCrawler, you will need to first remove the existing ``*_folder`` indices and remove or edit the default
+  settings files in ``~/_default/7/_settings_folder.json`` and ``~/_default/6/_settings_folder.json`` or any job
+  specific setting file like ``~/.fscrawler/{job_name}/_mappings/7/_settings_folder.json`` or
+  ``~/.fscrawler/{job_name}/_mappings/6/_settings_folder.json``.

--- a/elasticsearch-client/elasticsearch-client-base/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ESSearchResponse.java
+++ b/elasticsearch-client/elasticsearch-client-base/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ESSearchResponse.java
@@ -28,6 +28,11 @@ public class ESSearchResponse {
     private List<ESSearchHit> hits = new ArrayList<>();
     private long totalHits;
     private Map<String, ESTermsAggregation> aggregations = new HashMap<>();
+    private String json;
+
+    public ESSearchResponse(String json) {
+        this.json = json;
+    }
 
     public List<ESSearchHit> getHits() {
         return hits;
@@ -51,5 +56,9 @@ public class ESSearchResponse {
 
     public void addAggregation(String name, ESTermsAggregation aggregation) {
         aggregations.put(name, aggregation);
+    }
+
+    public String getJson() {
+        return json;
     }
 }

--- a/elasticsearch-client/elasticsearch-client-v6/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v6/ElasticsearchClientV6.java
+++ b/elasticsearch-client/elasticsearch-client-v6/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v6/ElasticsearchClientV6.java
@@ -527,7 +527,7 @@ public class ElasticsearchClientV6 implements ElasticsearchClient {
         searchRequest.indicesOptions(LENIENT_EXPAND_OPEN);
 
         SearchResponse response = client.search(searchRequest, RequestOptions.DEFAULT);
-        ESSearchResponse esSearchResponse = new ESSearchResponse();
+        ESSearchResponse esSearchResponse = new ESSearchResponse(response.toString());
         if (response.getHits() != null) {
             for (SearchHit hit : response.getHits()) {
                 ESSearchHit esSearchHit = new ESSearchHit();

--- a/elasticsearch-client/elasticsearch-client-v7/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v7/ElasticsearchClientV7.java
+++ b/elasticsearch-client/elasticsearch-client-v7/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v7/ElasticsearchClientV7.java
@@ -515,7 +515,7 @@ public class ElasticsearchClientV7 implements ElasticsearchClient {
         searchRequest.indicesOptions(LENIENT_EXPAND_OPEN);
 
         SearchResponse response = client.search(searchRequest, RequestOptions.DEFAULT);
-        ESSearchResponse esSearchResponse = new ESSearchResponse();
+        ESSearchResponse esSearchResponse = new ESSearchResponse(response.toString());
         if (response.getHits() != null) {
             for (SearchHit hit : response.getHits()) {
                 ESSearchHit esSearchHit = new ESSearchHit();

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/JsonUtil.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/JsonUtil.java
@@ -21,6 +21,8 @@ package fr.pilato.elasticsearch.crawler.fs.framework;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.Predicate;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -68,5 +70,14 @@ public class JsonUtil {
             currentObject = (Map<String, Object>) jObject;
         }
         return currentObject;
+    }
+
+    /**
+     * Parse a JSON Document using JSON Path
+     * @param json  json to parse
+     * @return an Object which can be used as an input for {@link com.jayway.jsonpath.JsonPath#read(Object, String, Predicate...)}
+     */
+    public static Object parseJson(String json) {
+        return Configuration.defaultConfiguration().jsonProvider().parse(json);
     }
 }

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestSubDirsIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestSubDirsIT.java
@@ -19,6 +19,7 @@
 
 package fr.pilato.elasticsearch.crawler.fs.test.integration.elasticsearch;
 
+import com.jayway.jsonpath.JsonPath;
 import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
 import fr.pilato.elasticsearch.crawler.fs.client.ESSearchHit;
 import fr.pilato.elasticsearch.crawler.fs.client.ESSearchRequest;
@@ -32,19 +33,14 @@ import org.junit.Test;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiLettersOfLengthBetween;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomLongBetween;
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.INDEX_SUFFIX_FOLDER;
 import static fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil.extractFromPath;
+import static fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil.parseJson;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.endsWith;
-import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isOneOf;
-import static org.hamcrest.Matchers.iterableWithSize;
+import static org.hamcrest.Matchers.*;
 
 /**
  * Test crawler with subdirs
@@ -70,7 +66,6 @@ public class FsCrawlerTestSubDirsIT extends AbstractFsCrawlerITCase {
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()).withESQuery(new ESTermQuery("path.real.fulltext", "subdir")), 1L, null);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void test_subdirs_deep_tree() throws Exception {
         startCrawler();
@@ -96,28 +91,32 @@ public class FsCrawlerTestSubDirsIT extends AbstractFsCrawlerITCase {
         response = documentService.getClient().search(new ESSearchRequest().withIndex(getCrawlerName()).withSort("path.virtual"));
         assertThat(response.getTotalHits(), is(7L));
 
+        Object document = parseJson(response.getJson());
+
         int i = 0;
-        pathHitTester(response, i++, hit -> (Map<String, Object>) hit.getSourceAsMap().get("path"), "/test_subdirs_deep_tree/roottxtfile.txt", is("/roottxtfile.txt"));
-        pathHitTester(response, i++, hit -> (Map<String, Object>) hit.getSourceAsMap().get("path"), "/test_subdirs_deep_tree/subdir1/roottxtfile_multi_feed.txt", is("/subdir1/roottxtfile_multi_feed.txt"));
-        pathHitTester(response, i++, hit -> (Map<String, Object>) hit.getSourceAsMap().get("path"), "/test_subdirs_deep_tree/subdir1/subdir11/roottxtfile.txt", is("/subdir1/subdir11/roottxtfile.txt"));
-        pathHitTester(response, i++, hit -> (Map<String, Object>) hit.getSourceAsMap().get("path"), "/test_subdirs_deep_tree/subdir1/subdir12/roottxtfile.txt", is("/subdir1/subdir12/roottxtfile.txt"));
-        pathHitTester(response, i++, hit -> (Map<String, Object>) hit.getSourceAsMap().get("path"), "/test_subdirs_deep_tree/subdir2/roottxtfile_multi_feed.txt", is("/subdir2/roottxtfile_multi_feed.txt"));
-        pathHitTester(response, i++, hit -> (Map<String, Object>) hit.getSourceAsMap().get("path"), "/test_subdirs_deep_tree/subdir2/subdir21/roottxtfile.txt", is("/subdir2/subdir21/roottxtfile.txt"));
-        pathHitTester(response, i, hit -> (Map<String, Object>) hit.getSourceAsMap().get("path"), "/test_subdirs_deep_tree/subdir2/subdir22/roottxtfile.txt", is("/subdir2/subdir22/roottxtfile.txt"));
+        pathHitTester(document, i++, "/test_subdirs_deep_tree/roottxtfile.txt", is("/roottxtfile.txt"));
+        pathHitTester(document, i++, "/test_subdirs_deep_tree/subdir1/roottxtfile_multi_feed.txt", is("/subdir1/roottxtfile_multi_feed.txt"));
+        pathHitTester(document, i++, "/test_subdirs_deep_tree/subdir1/subdir11/roottxtfile.txt", is("/subdir1/subdir11/roottxtfile.txt"));
+        pathHitTester(document, i++, "/test_subdirs_deep_tree/subdir1/subdir12/roottxtfile.txt", is("/subdir1/subdir12/roottxtfile.txt"));
+        pathHitTester(document, i++, "/test_subdirs_deep_tree/subdir2/roottxtfile_multi_feed.txt", is("/subdir2/roottxtfile_multi_feed.txt"));
+        pathHitTester(document, i++, "/test_subdirs_deep_tree/subdir2/subdir21/roottxtfile.txt", is("/subdir2/subdir21/roottxtfile.txt"));
+        pathHitTester(document, i, "/test_subdirs_deep_tree/subdir2/subdir22/roottxtfile.txt", is("/subdir2/subdir22/roottxtfile.txt"));
 
 
         // Check folders
-        response = documentService.getClient().search(new ESSearchRequest().withIndex(getCrawlerName() + INDEX_SUFFIX_FOLDER).withSort("virtual"));
+        response = documentService.getClient().search(new ESSearchRequest().withIndex(getCrawlerName() + INDEX_SUFFIX_FOLDER).withSort("path.virtual"));
         assertThat(response.getTotalHits(), is(7L));
 
+        document = parseJson(response.getJson());
+
         i = 0;
-        pathHitTester(response, i++, ESSearchHit::getSourceAsMap, "/test_subdirs_deep_tree", is("/"));
-        pathHitTester(response, i++, ESSearchHit::getSourceAsMap, "/test_subdirs_deep_tree/subdir1", is("/subdir1"));
-        pathHitTester(response, i++, ESSearchHit::getSourceAsMap, "/test_subdirs_deep_tree/subdir1/subdir11", is("/subdir1/subdir11"));
-        pathHitTester(response, i++, ESSearchHit::getSourceAsMap, "/test_subdirs_deep_tree/subdir1/subdir12", is("/subdir1/subdir12"));
-        pathHitTester(response, i++, ESSearchHit::getSourceAsMap, "/test_subdirs_deep_tree/subdir2", is("/subdir2"));
-        pathHitTester(response, i++, ESSearchHit::getSourceAsMap, "/test_subdirs_deep_tree/subdir2/subdir21", is("/subdir2/subdir21"));
-        pathHitTester(response, i, ESSearchHit::getSourceAsMap, "/test_subdirs_deep_tree/subdir2/subdir22", is("/subdir2/subdir22"));
+        pathHitTester(document, i++, "/test_subdirs_deep_tree", is("/"));
+        pathHitTester(document, i++, "/test_subdirs_deep_tree/subdir1", is("/subdir1"));
+        pathHitTester(document, i++, "/test_subdirs_deep_tree/subdir1/subdir11", is("/subdir1/subdir11"));
+        pathHitTester(document, i++, "/test_subdirs_deep_tree/subdir1/subdir12", is("/subdir1/subdir12"));
+        pathHitTester(document, i++, "/test_subdirs_deep_tree/subdir2", is("/subdir2"));
+        pathHitTester(document, i++, "/test_subdirs_deep_tree/subdir2/subdir21", is("/subdir2/subdir21"));
+        pathHitTester(document, i, "/test_subdirs_deep_tree/subdir2/subdir22", is("/subdir2/subdir22"));
     }
 
     @Test
@@ -165,16 +164,17 @@ public class FsCrawlerTestSubDirsIT extends AbstractFsCrawlerITCase {
                 .withSort("path.virtual"));
         assertThat(response.getTotalHits(), is(subdirs+1));
 
+        Object document = parseJson(response.getJson());
+
         for (int i = 0; i < subdirs; i++) {
-            //noinspection unchecked
-            pathHitTester(response, i, hit -> (Map<String, Object>) hit.getSourceAsMap().get("path"), "sample.txt", endsWith("/" + "sample.txt"));
+            pathHitTester(document, i, "sample.txt", endsWith("/" + "sample.txt"));
         }
 
         // Check folders
         response = documentService.getClient().search(new ESSearchRequest()
                 .withIndex(getCrawlerName() + INDEX_SUFFIX_FOLDER)
                 .withSize(1000)
-                .withSort("virtual"));
+                .withSort("path.virtual"));
         assertThat(response.getTotalHits(), is(subdirs+2));
 
         // Let's remove the main subdir and wait...
@@ -185,15 +185,11 @@ public class FsCrawlerTestSubDirsIT extends AbstractFsCrawlerITCase {
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, currentTestResourceDir);
     }
 
-    private void pathHitTester(ESSearchResponse response, int position, Function<ESSearchHit, Map<String, Object>> extractPath,
-                               String expectedReal, Matcher<String> expectedVirtual) {
-        ESSearchHit hit = response.getHits().get(position);
-        Map<String, Object> path = extractPath.apply(hit);
-        String real = (String) path.get("real");
-        String virtual = (String) path.get("virtual");
+    private void pathHitTester(Object document, int position, String expectedReal, Matcher<String> expectedVirtual) {
+        String real = JsonPath.read(document, "$.hits.hits[" + position + "]._source.path.real");
+        String virtual = JsonPath.read(document, "$.hits.hits[" + position + "]._source.path.virtual");
         logger.debug(" - {}, {}", real, virtual);
         assertThat("path.real[" + position + "]", real, endsWith(expectedReal));
         assertThat("path.virtual[" + position + "]", virtual, expectedVirtual);
     }
-
 }

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/WPSearchClientIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/WPSearchClientIT.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil.parseJson;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -90,8 +91,7 @@ public class WPSearchClientIT extends AbstractWorkplaceSearchITCase {
             countTestHelper(new ESSearchRequest().withIndex(".ent-search-engine-documents-source-" + customSourceId), 1L, null);
             String json = client.search(uniqueId);
 
-            Object response = Configuration.defaultConfiguration().jsonProvider().parse(json);
-            List<String> ids = JsonPath.read(response, "$.results[*].id.raw");
+            List<String> ids = JsonPath.read(json, "$.results[*].id.raw");
 
             assertThat(ids, hasSize(1));
             assertThat(ids.get(0), is("testSearch"));

--- a/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/6/_settings_folder.json
+++ b/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/6/_settings_folder.json
@@ -15,17 +15,38 @@
   },
   "mappings": {
     "properties" : {
-      "real" : {
-        "type" : "keyword",
-        "store" : true
-      },
-      "root" : {
-        "type" : "keyword",
-        "store" : true
-      },
-      "virtual" : {
-        "type" : "keyword",
-        "store" : true
+      "path": {
+        "properties": {
+          "real": {
+            "type": "keyword",
+            "fields": {
+              "tree": {
+                "type": "text",
+                "analyzer": "fscrawler_path",
+                "fielddata": true
+              },
+              "fulltext": {
+                "type": "text"
+              }
+            }
+          },
+          "root": {
+            "type": "keyword"
+          },
+          "virtual": {
+            "type": "keyword",
+            "fields": {
+              "tree": {
+                "type": "text",
+                "analyzer": "fscrawler_path",
+                "fielddata": true
+              },
+              "fulltext": {
+                "type": "text"
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/7/_settings_folder.json
+++ b/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/7/_settings_folder.json
@@ -15,17 +15,38 @@
   },
   "mappings": {
     "properties" : {
-      "real" : {
-        "type" : "keyword",
-        "store" : true
-      },
-      "root" : {
-        "type" : "keyword",
-        "store" : true
-      },
-      "virtual" : {
-        "type" : "keyword",
-        "store" : true
+      "path": {
+        "properties": {
+          "real": {
+            "type": "keyword",
+            "fields": {
+              "tree": {
+                "type": "text",
+                "analyzer": "fscrawler_path",
+                "fielddata": true
+              },
+              "fulltext": {
+                "type": "text"
+              }
+            }
+          },
+          "root": {
+            "type": "keyword"
+          },
+          "virtual": {
+            "type": "keyword",
+            "fields": {
+              "tree": {
+                "type": "text",
+                "analyzer": "fscrawler_path",
+                "fielddata": true
+              },
+              "fulltext": {
+                "type": "text"
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsMappingTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsMappingTest.java
@@ -294,17 +294,38 @@ public class FsMappingTest extends AbstractFSCrawlerMetadataTestCase {
                 "  },\n" +
                 "  \"mappings\": {\n" +
                 "    \"properties\" : {\n" +
-                "      \"real\" : {\n" +
-                "        \"type\" : \"keyword\",\n" +
-                "        \"store\" : true\n" +
-                "      },\n" +
-                "      \"root\" : {\n" +
-                "        \"type\" : \"keyword\",\n" +
-                "        \"store\" : true\n" +
-                "      },\n" +
-                "      \"virtual\" : {\n" +
-                "        \"type\" : \"keyword\",\n" +
-                "        \"store\" : true\n" +
+                "      \"path\": {\n" +
+                "        \"properties\": {\n" +
+                "          \"real\": {\n" +
+                "            \"type\": \"keyword\",\n" +
+                "            \"fields\": {\n" +
+                "              \"tree\": {\n" +
+                "                \"type\": \"text\",\n" +
+                "                \"analyzer\": \"fscrawler_path\",\n" +
+                "                \"fielddata\": true\n" +
+                "              },\n" +
+                "              \"fulltext\": {\n" +
+                "                \"type\": \"text\"\n" +
+                "              }\n" +
+                "            }\n" +
+                "          },\n" +
+                "          \"root\": {\n" +
+                "            \"type\": \"keyword\"\n" +
+                "          },\n" +
+                "          \"virtual\": {\n" +
+                "            \"type\": \"keyword\",\n" +
+                "            \"fields\": {\n" +
+                "              \"tree\": {\n" +
+                "                \"type\": \"text\",\n" +
+                "                \"analyzer\": \"fscrawler_path\",\n" +
+                "                \"fielddata\": true\n" +
+                "              },\n" +
+                "              \"fulltext\": {\n" +
+                "                \"type\": \"text\"\n" +
+                "              }\n" +
+                "            }\n" +
+                "          }\n" +
+                "        }\n" +
                 "      }\n" +
                 "    }\n" +
                 "  }\n" +
@@ -578,17 +599,38 @@ public class FsMappingTest extends AbstractFSCrawlerMetadataTestCase {
                 "  },\n" +
                 "  \"mappings\": {\n" +
                 "    \"properties\" : {\n" +
-                "      \"real\" : {\n" +
-                "        \"type\" : \"keyword\",\n" +
-                "        \"store\" : true\n" +
-                "      },\n" +
-                "      \"root\" : {\n" +
-                "        \"type\" : \"keyword\",\n" +
-                "        \"store\" : true\n" +
-                "      },\n" +
-                "      \"virtual\" : {\n" +
-                "        \"type\" : \"keyword\",\n" +
-                "        \"store\" : true\n" +
+                "      \"path\": {\n" +
+                "        \"properties\": {\n" +
+                "          \"real\": {\n" +
+                "            \"type\": \"keyword\",\n" +
+                "            \"fields\": {\n" +
+                "              \"tree\": {\n" +
+                "                \"type\": \"text\",\n" +
+                "                \"analyzer\": \"fscrawler_path\",\n" +
+                "                \"fielddata\": true\n" +
+                "              },\n" +
+                "              \"fulltext\": {\n" +
+                "                \"type\": \"text\"\n" +
+                "              }\n" +
+                "            }\n" +
+                "          },\n" +
+                "          \"root\": {\n" +
+                "            \"type\": \"keyword\"\n" +
+                "          },\n" +
+                "          \"virtual\": {\n" +
+                "            \"type\": \"keyword\",\n" +
+                "            \"fields\": {\n" +
+                "              \"tree\": {\n" +
+                "                \"type\": \"text\",\n" +
+                "                \"analyzer\": \"fscrawler_path\",\n" +
+                "                \"fielddata\": true\n" +
+                "              },\n" +
+                "              \"fulltext\": {\n" +
+                "                \"type\": \"text\"\n" +
+                "              }\n" +
+                "            }\n" +
+                "          }\n" +
+                "        }\n" +
                 "      }\n" +
                 "    }\n" +
                 "  }\n" +


### PR DESCRIPTION
Initially we were using `path.XYZ` for documents and `XYZ` for folders.

With this change, we are moving the folder mapping to use a similar mapping as for documents.

So:

* `root` is now `path.root`
* `real` is now `path.real`
* `virtual` is now `path.virtual`

We are now also producing the subfields:

* `real.tree` and `real.fulltext`
* `virtual.tree` and `virtual.fulltext`

So it should make the Samba project happy.

Closes #1164.