### PR TITLE
Add `file.content_type` field on folders

### DIFF
--- a/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/Folder.java
+++ b/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/Folder.java
@@ -24,6 +24,8 @@ package fr.pilato.elasticsearch.crawler.fs.beans;
  */
 public class Folder {
 
+    public static final String CONTENT_TYPE = "text/directory";
+
     /**
      * Generated json field names
      */
@@ -37,6 +39,7 @@ public class Folder {
     public Folder() {
         path = new Path();
         file = new File();
+        file.setContentType(CONTENT_TYPE);
     }
 
     /**
@@ -53,6 +56,7 @@ public class Folder {
         path.setVirtual(virtual);
         file = new File();
         file.setFilename(name);
+        file.setContentType(CONTENT_TYPE);
     }
 
     public Path getPath() {

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestSubDirsIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestSubDirsIT.java
@@ -21,6 +21,7 @@ package fr.pilato.elasticsearch.crawler.fs.test.integration.elasticsearch;
 
 import com.jayway.jsonpath.JsonPath;
 import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
+import fr.pilato.elasticsearch.crawler.fs.beans.Folder;
 import fr.pilato.elasticsearch.crawler.fs.client.ESSearchHit;
 import fr.pilato.elasticsearch.crawler.fs.client.ESSearchRequest;
 import fr.pilato.elasticsearch.crawler.fs.client.ESSearchResponse;
@@ -110,20 +111,13 @@ public class FsCrawlerTestSubDirsIT extends AbstractFsCrawlerITCase {
         document = parseJson(response.getJson());
 
         i = 0;
-        assertThat(JsonPath.read(document, "$.hits.hits[" + i + "]._source.file.filename"), is("test_subdirs_deep_tree"));
-        pathHitTester(document, i++, "/test_subdirs_deep_tree", is("/"));
-        assertThat(JsonPath.read(document, "$.hits.hits[" + i + "]._source.file.filename"), is("subdir1"));
-        pathHitTester(document, i++, "/test_subdirs_deep_tree/subdir1", is("/subdir1"));
-        assertThat(JsonPath.read(document, "$.hits.hits[" + i + "]._source.file.filename"), is("subdir11"));
-        pathHitTester(document, i++, "/test_subdirs_deep_tree/subdir1/subdir11", is("/subdir1/subdir11"));
-        assertThat(JsonPath.read(document, "$.hits.hits[" + i + "]._source.file.filename"), is("subdir12"));
-        pathHitTester(document, i++, "/test_subdirs_deep_tree/subdir1/subdir12", is("/subdir1/subdir12"));
-        assertThat(JsonPath.read(document, "$.hits.hits[" + i + "]._source.file.filename"), is("subdir2"));
-        pathHitTester(document, i++, "/test_subdirs_deep_tree/subdir2", is("/subdir2"));
-        assertThat(JsonPath.read(document, "$.hits.hits[" + i + "]._source.file.filename"), is("subdir21"));
-        pathHitTester(document, i++, "/test_subdirs_deep_tree/subdir2/subdir21", is("/subdir2/subdir21"));
-        assertThat(JsonPath.read(document, "$.hits.hits[" + i + "]._source.file.filename"), is("subdir22"));
-        pathHitTester(document, i, "/test_subdirs_deep_tree/subdir2/subdir22", is("/subdir2/subdir22"));
+        folderHitTester(document, i++, "/test_subdirs_deep_tree", is("/"), "test_subdirs_deep_tree");
+        folderHitTester(document, i++, "/test_subdirs_deep_tree/subdir1", is("/subdir1"), "subdir1");
+        folderHitTester(document, i++, "/test_subdirs_deep_tree/subdir1/subdir11", is("/subdir1/subdir11"), "subdir11");
+        folderHitTester(document, i++, "/test_subdirs_deep_tree/subdir1/subdir12", is("/subdir1/subdir12"), "subdir12");
+        folderHitTester(document, i++, "/test_subdirs_deep_tree/subdir2", is("/subdir2"), "subdir2");
+        folderHitTester(document, i++, "/test_subdirs_deep_tree/subdir2/subdir21", is("/subdir2/subdir21"), "subdir21");
+        folderHitTester(document, i, "/test_subdirs_deep_tree/subdir2/subdir22", is("/subdir2/subdir22"), "subdir22");
     }
 
     @Test
@@ -190,6 +184,13 @@ public class FsCrawlerTestSubDirsIT extends AbstractFsCrawlerITCase {
 
         // We expect to have 1 doc now
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, currentTestResourceDir);
+    }
+
+    private void folderHitTester(Object document, int position, String expectedReal, Matcher<String> expectedVirtual,
+                                 String expectedFilename) {
+        pathHitTester(document, position, expectedReal, expectedVirtual);
+        assertThat(JsonPath.read(document, "$.hits.hits[" + position + "]._source.file.filename"), is(expectedFilename));
+        assertThat(JsonPath.read(document, "$.hits.hits[" + position + "]._source.file.content_type"), is(Folder.CONTENT_TYPE));
     }
 
     private void pathHitTester(Object document, int position, String expectedReal, Matcher<String> expectedVirtual) {

--- a/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/6/_settings_folder.json
+++ b/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/6/_settings_folder.json
@@ -17,6 +17,9 @@
     "properties" : {
       "file": {
         "properties": {
+          "content_type": {
+            "type": "keyword"
+          },
           "filename": {
             "type": "keyword",
             "store": true

--- a/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/7/_settings_folder.json
+++ b/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/7/_settings_folder.json
@@ -17,6 +17,9 @@
     "properties" : {
       "file": {
         "properties": {
+          "content_type": {
+            "type": "keyword"
+          },
           "filename": {
             "type": "keyword",
             "store": true

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsMappingTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsMappingTest.java
@@ -296,6 +296,9 @@ public class FsMappingTest extends AbstractFSCrawlerMetadataTestCase {
                 "    \"properties\" : {\n" +
                 "      \"file\": {\n" +
                 "        \"properties\": {\n" +
+                "          \"content_type\": {\n" +
+                "            \"type\": \"keyword\"\n" +
+                "          },\n" +
                 "          \"filename\": {\n" +
                 "            \"type\": \"keyword\",\n" +
                 "            \"store\": true\n" +
@@ -609,6 +612,9 @@ public class FsMappingTest extends AbstractFSCrawlerMetadataTestCase {
                 "    \"properties\" : {\n" +
                 "      \"file\": {\n" +
                 "        \"properties\": {\n" +
+                "          \"content_type\": {\n" +
+                "            \"type\": \"keyword\"\n" +
+                "          },\n" +
                 "          \"filename\": {\n" +
                 "            \"type\": \"keyword\",\n" +
                 "            \"store\": true\n" +


### PR DESCRIPTION
We are now adding a `file.content_type` field on folders which is always set to `text/directory` as per RFC 2425.

Closes #712.