### PR TITLE
Switch back to Java 11

### DIFF
--- a/docs/source/dev/build.rst
+++ b/docs/source/dev/build.rst
@@ -1,7 +1,7 @@
 Building the project
 --------------------
 
-This project is built with `Maven <https://maven.apache.org/>`_. It needs Java >= 1.14.
+This project is built with `Maven <https://maven.apache.org/>`_. It needs Java >= 1.11.
 Source code is available on `GitHub <https://github.com/dadoonet/fscrawler/>`_.
 Thanks to `JetBrains <https://www.jetbrains.com/?from=FSCrawler>`_ for the IntelliJ IDEA License!
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -486,7 +486,7 @@ Upgrade to 2.7
   to ``true`` if you wish revert to the previous behavior.
 - The mapping for elasticsearch 6.x can not contain anymore the type name.
 - We removed the Elasticsearch V5 compatibility as it's not maintained anymore by elastic.
-- You need to use a recent JVM to run FSCrawler (Java 15+ recommended)
+- You need to use a recent JVM to run FSCrawler (Java 11 as a minimum. Java 15+ recommended)
 - The mapping for the folders changed and is now consistent with the mapping for documents. If you are already using
   FSCrawler, you will need to first remove the existing ``*_folder`` indices and remove or edit the default
   settings files in ``~/_default/7/_settings_folder.json`` and ``~/_default/6/_settings_folder.json`` or any job

--- a/docs/source/user/getting_started.rst
+++ b/docs/source/user/getting_started.rst
@@ -1,7 +1,7 @@
 Getting Started
 ---------------
 
-You need to have at least **Java 14** and have properly configured
+You need to have at least **Java 11** and have properly configured
 ``JAVA_HOME`` to point to your Java installation directory. For example
 on MacOS if you are using sdkman you can define in your ``~/.bash_profile`` file:
 

--- a/docs/source/user/tutorial.rst
+++ b/docs/source/user/tutorial.rst
@@ -9,7 +9,7 @@ using Kibana. For example location worked or the previous company, etc.
 Prerequisites
 ^^^^^^^^^^^^^
 
-* Java 14+ must be installed
+* Java 11+ must be installed
 * ``JAVA_HOME`` must be defined
 
 Install Elastic stack

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/ByteSizeValueTest.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/ByteSizeValueTest.java
@@ -39,14 +39,27 @@ public class ByteSizeValueTest extends AbstractFSCrawlerTestCase {
         // Test 500 random values
         for (int i = 0; i < 500; i++) {
             int unitNumber = randomIntBetween(0, 5);
-            ByteSizeUnit unit = switch (unitNumber) {
-                case 1 -> ByteSizeUnit.KB;
-                case 2 -> ByteSizeUnit.MB;
-                case 3 -> ByteSizeUnit.GB;
-                case 4 -> ByteSizeUnit.TB;
-                case 5 -> ByteSizeUnit.PB;
-                default -> ByteSizeUnit.BYTES;
-            };
+            ByteSizeUnit unit;
+            switch (unitNumber) {
+                case 1:
+                    unit = ByteSizeUnit.KB;
+                    break;
+                case 2:
+                    unit = ByteSizeUnit.MB;
+                    break;
+                case 3:
+                    unit = ByteSizeUnit.GB;
+                    break;
+                case 4:
+                    unit = ByteSizeUnit.TB;
+                    break;
+                case 5:
+                    unit = ByteSizeUnit.PB;
+                    break;
+                default:
+                    unit = ByteSizeUnit.BYTES;
+                    break;
+            }
 
             long value = randomLongBetween(1, 999);
             String randomByteSize = value + unit.getSuffix();

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
@@ -201,6 +201,7 @@ public abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
 
                 staticLogger.info("-> Copying test documents from [{}] to [{}]", source, finalTarget);
                 copyDirs(source, finalTarget);
+                break;
             }
             case "jar" : {
                 if (Files.notExists(target)) {
@@ -214,8 +215,11 @@ public abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
 
                 staticLogger.info("-> Unzipping test documents from [{}] to [{}]", jarFile, target);
                 unzip(jarFile, target);
+                break;
             }
-            default : fail("Unknown protocol for IT document sources: " + resource.getProtocol());
+            default :
+                fail("Unknown protocol for IT document sources: " + resource.getProtocol());
+                break;
         }
     }
 

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
@@ -186,7 +186,7 @@ public abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
         URL resource = AbstractFSCrawlerTestCase.class.getResource(marker);
 
         switch (resource.getProtocol()) {
-            case "file" -> {
+            case "file" : {
                 Path finalTarget = target.resolve(sourceDirName);
                 if (Files.notExists(finalTarget)) {
                     staticLogger.debug("  --> Creating test dir named [{}]", finalTarget);
@@ -202,7 +202,7 @@ public abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
                 staticLogger.info("-> Copying test documents from [{}] to [{}]", source, finalTarget);
                 copyDirs(source, finalTarget);
             }
-            case "jar" -> {
+            case "jar" : {
                 if (Files.notExists(target)) {
                     staticLogger.debug("  --> Creating test dir named [{}]", target);
                     Files.createDirectory(target);
@@ -215,7 +215,7 @@ public abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
                 staticLogger.info("-> Unzipping test documents from [{}] to [{}]", jarFile, target);
                 unzip(jarFile, target);
             }
-            default -> fail("Unknown protocol for IT document sources: " + resource.getProtocol());
+            default : fail("Unknown protocol for IT document sources: " + resource.getProtocol());
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <docker.push.username>${env.DOCKER_USERNAME}</docker.push.username>
         <docker.push.password>${env.DOCKER_PASSWORD}</docker.push.password>
 
-        <java.compiler.version>14</java.compiler.version>
+        <java.compiler.version>11</java.compiler.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>


### PR DESCRIPTION
Some OS don't support Java 14 but Java 11 at most. So let's make more users happy by switching the target to Java 11.