### PR TITLE
Check if date is null when formatting it to RFC3339

### DIFF
--- a/crawler/crawler-ssh/src/main/java/fr/pilato/elasticsearch/crawler/fs/crawler/ssh/FileAbstractorSSH.java
+++ b/crawler/crawler-ssh/src/main/java/fr/pilato/elasticsearch/crawler/fs/crawler/ssh/FileAbstractorSSH.java
@@ -22,6 +22,7 @@ package fr.pilato.elasticsearch.crawler.fs.crawler.ssh;
 import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.ChannelSftp;
 import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
 import fr.pilato.elasticsearch.crawler.fs.crawler.FileAbstractModel;
 import fr.pilato.elasticsearch.crawler.fs.crawler.FileAbstractor;
@@ -112,8 +113,10 @@ public class FileAbstractorSSH extends FileAbstractor<ChannelSftp.LsEntry> {
 
     @Override
     public void close() throws Exception {
-        sftp.getSession().disconnect();
-        sftp.disconnect();
+        if (sftp != null) {
+            sftp.getSession().disconnect();
+            sftp.disconnect();
+        }
     }
 
     private ChannelSftp openSSHConnection(Server server) throws Exception {
@@ -130,7 +133,14 @@ public class FileAbstractorSSH extends FileAbstractor<ChannelSftp.LsEntry> {
         if (server.getPassword() != null) {
             session.setPassword(server.getPassword());
         }
-        session.connect();
+
+        try {
+            session.connect();
+        } catch (JSchException e) {
+            logger.warn("Cannot connect with SSH to {}@{}: {}", server.getUsername(),
+                    server.getHostname(), e.getMessage());
+            throw e;
+        }
 
         //Open a new session for SFTP.
         Channel channel = session.openChannel("sftp");

--- a/elasticsearch-client/elasticsearch-client-base/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/WorkplaceSearchClientUtil.java
+++ b/elasticsearch-client/elasticsearch-client-base/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/WorkplaceSearchClientUtil.java
@@ -148,9 +148,8 @@ public abstract class WorkplaceSearchClientUtil {
         return name;
     }
 
-    public static String toRFC3339(Date d)
-    {
-        return RFC_3339.format(d).replaceAll("(\\d\\d)(\\d\\d)$", "$1:$2");
+    public static String toRFC3339(Date d) {
+        return d == null ? null : RFC_3339.format(d).replaceAll("(\\d\\d)(\\d\\d)$", "$1:$2");
     }
 
     /**

--- a/elasticsearch-client/elasticsearch-client-base/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/WorkplaceSearchClientUtilTest.java
+++ b/elasticsearch-client/elasticsearch-client-base/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/WorkplaceSearchClientUtilTest.java
@@ -19,15 +19,23 @@
 
 package fr.pilato.elasticsearch.crawler.fs.client;
 
-import com.carrotsearch.randomizedtesting.RandomizedTest;
+import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil;
 import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
 import org.junit.Test;
 
-import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiAlphanumOfLength;
-import static com.carrotsearch.randomizedtesting.RandomizedTest.randomIntBetween;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import static com.carrotsearch.randomizedtesting.RandomizedTest.*;
 import static fr.pilato.elasticsearch.crawler.fs.client.WorkplaceSearchClientUtil.generateDefaultCustomSourceName;
+import static fr.pilato.elasticsearch.crawler.fs.client.WorkplaceSearchClientUtil.toRFC3339;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 public class WorkplaceSearchClientUtilTest extends AbstractFSCrawlerTestCase {
 
@@ -44,5 +52,12 @@ public class WorkplaceSearchClientUtilTest extends AbstractFSCrawlerTestCase {
         String suffix = max + randomAsciiAlphanumOfLength(randomIntBetween(1, 10));
         String name = generateDefaultCustomSourceName(suffix);
         assertThat(name, is("Local files for " + max));
+    }
+
+    @Test
+    public void testRFC3339() throws ParseException {
+        assertThat(toRFC3339(new Date()), notNullValue());
+        assertThat(toRFC3339(new SimpleDateFormat("dd/MM/yyyy").parse("26/12/1971")), startsWith("1971-12-26T00:00:00"));
+        assertThat(toRFC3339(null), nullValue());
     }
 }

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/WPSearchClientIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/WPSearchClientIT.java
@@ -24,8 +24,6 @@ import com.jayway.jsonpath.JsonPath;
 import fr.pilato.elasticsearch.crawler.fs.client.ESSearchRequest;
 import fr.pilato.elasticsearch.crawler.fs.framework.TimeValue;
 import fr.pilato.elasticsearch.crawler.fs.thirdparty.wpsearch.WPSearchClient;
-import org.hamcrest.Matcher;
-import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -230,14 +228,14 @@ public class WPSearchClientIT extends AbstractWorkplaceSearchITCase {
         assertThat(JsonPath.read(document, "$.meta.page.total_results"), is(results));
         assertThat(JsonPath.read(document, "$.results[*].title.raw"), hasItem(isOneOf(titles.toArray())));
         assertThat(JsonPath.read(document, "$.results[*].body.raw"), hasItems(bodies.toArray()));
-        assertThat(JsonPath.read(document, "$.results[*].size.raw"), notNullValue());
-        assertThat(JsonPath.read(document, "$.results[*].text_size.raw"), notNullValue());
+        assertThat(JsonPath.read(document, "$.results[*].size.raw"), hasItem(notNullValue()));
+        assertThat(JsonPath.read(document, "$.results[*].text_size.raw"), hasItem(notNullValue()));
         assertThat(JsonPath.read(document, "$.results[*].mime_type.raw"), hasItem(startsWith("text/plain")));
         assertThat(JsonPath.read(document, "$.results[*].name.raw"), hasItems(filenames.toArray()));
         assertThat(JsonPath.read(document, "$.results[*].extension.raw"), hasItem("txt"));
         filenames.forEach((filename) -> assertThat(JsonPath.read(document, "$.results[*].path.raw"), hasItem(endsWith(filename))));
         assertThat(JsonPath.read(document, "$.results[*].url.raw"), hasItems(urls.toArray()));
-        assertThat(JsonPath.read(document, "$.results[*].created_at.raw"), notNullValue());
-        assertThat(JsonPath.read(document, "$.results[*].last_modified.raw"), notNullValue());
+        assertThat(JsonPath.read(document, "$.results[*].created_at.raw"), hasItem(notNullValue()));
+        assertThat(JsonPath.read(document, "$.results[*].last_modified.raw"), hasItem(notNullValue()));
     }
 }


### PR DESCRIPTION
When crawling with SSH (it can happen with other sources in the future), we can have a date which is unknown.

Workplace Search integration transforms the date using RFC339. In case the date is `null`, we should not try to transform the date but keep it as `null`.

Closes #1216.