### PR TITLE
Isolate WorkplaceSearchClient and ElasticsearchClient

### DIFF
--- a/3rdparty/workplacesearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/thirdparty/wpsearch/WPSearchClient.java
+++ b/3rdparty/workplacesearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/thirdparty/wpsearch/WPSearchClient.java
@@ -259,18 +259,16 @@ public class WPSearchClient implements Closeable {
     /**
      * Get one single document
      * @param id the document id
-     * @return the Json document as an object readable with JsonPath
+     * @return the Json document as an object readable with JsonPath or null if not found
      */
-    public Object getDocument(String id) {
+    public String getDocument(String id) {
         checkStarted();
         logger.debug("Getting document {} to custom source {}", id, sourceId);
-
-        String json = get("/sources/" + sourceId + "/documents/" + id, String.class);
-        logger.fatal("{}", json);
-
-        Object document = parseJson(json);
-
-        return JsonPath.read(document, "$.results[0]");
+        try {
+            return get("/sources/" + sourceId + "/documents/" + id, String.class);
+        } catch (NotFoundException e) {
+            return null;
+        }
     }
 
     /**

--- a/3rdparty/workplacesearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/thirdparty/wpsearch/WPSearchClient.java
+++ b/3rdparty/workplacesearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/thirdparty/wpsearch/WPSearchClient.java
@@ -254,6 +254,18 @@ public class WPSearchClient implements Closeable {
         bulkProcessor.add(new WPSearchOperation(sourceId, document));
     }
 
+
+    /**
+     * Get one single document
+     * @param id the document id
+     */
+    public String getDocument(String id) {
+        checkStarted();
+        logger.debug("Getting document {} to custom source {}", id, sourceId);
+        String json = search(null, Collections.singletonMap("id", Collections.singletonList(id)));
+        return JsonPath.read(json, "$.results[0]");
+    }
+
     /**
      * Delete existing documents
      * @param sourceId  The custom source Id
@@ -275,7 +287,7 @@ public class WPSearchClient implements Closeable {
      * Delete one document
      * @param id Document id to delete
      */
-    public void destroyDocument(String sourceId, String id) {
+    public void destroyDocument(String id) {
         destroyDocuments(sourceId, Collections.singletonList(id));
     }
 
@@ -395,6 +407,10 @@ public class WPSearchClient implements Closeable {
         // Delete the source
         String response = delete("sources/" + id, null, String.class);
         logger.debug("removeCustomSource({}): {}", id, response);
+    }
+
+    public void flush() {
+        bulkProcessor.flush();
     }
 
     @Override

--- a/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
+++ b/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
@@ -283,7 +283,7 @@ public class FsCrawlerCli {
                 if (!startEsClient(fsCrawler)) {
                     return;
                 }
-                String elasticsearchVersion = fsCrawler.getManagementService().getClient().getVersion();
+                String elasticsearchVersion = fsCrawler.getManagementService().getVersion();
                 checkForDeprecatedResources(configDir, elasticsearchVersion);
 
                 // Start the REST Server if needed

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
@@ -34,7 +34,6 @@ import fr.pilato.elasticsearch.crawler.fs.framework.OsValidator;
 import fr.pilato.elasticsearch.crawler.fs.framework.SignTool;
 import fr.pilato.elasticsearch.crawler.fs.service.FsCrawlerDocumentService;
 import fr.pilato.elasticsearch.crawler.fs.service.FsCrawlerManagementService;
-import fr.pilato.elasticsearch.crawler.fs.service.FsCrawlerService;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
 import fr.pilato.elasticsearch.crawler.fs.tika.TikaDocParser;
 import fr.pilato.elasticsearch.crawler.fs.tika.XmlDocParser;
@@ -548,12 +547,24 @@ public abstract class FsParserAbstract extends FsParser {
     }
 
     /**
-     * Add to bulk a DeleteRequest
+     * Remove a document with the document service
      */
-    private void esDelete(FsCrawlerService service, String index, String id) {
+    private void esDelete(FsCrawlerDocumentService service, String index, String id) {
         logger.debug("Deleting {}/{}", index, id);
         if (!closed) {
-            service.getClient().delete(index, id);
+            service.delete(index, id);
+        } else {
+            logger.warn("trying to remove a file while closing crawler. Document [{}]/[{}] has been ignored", index, id);
+        }
+    }
+
+    /**
+     * Remove a document with the management service
+     */
+    private void esDelete(FsCrawlerManagementService service, String index, String id) {
+        logger.debug("Deleting {}/{}", index, id);
+        if (!closed) {
+            service.delete(index, id);
         } else {
             logger.warn("trying to remove a file while closing crawler. Document [{}]/[{}] has been ignored", index, id);
         }

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentService.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentService.java
@@ -20,6 +20,11 @@
 package fr.pilato.elasticsearch.crawler.fs.service;
 
 import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
+import fr.pilato.elasticsearch.crawler.fs.client.ESSearchHit;
+import fr.pilato.elasticsearch.crawler.fs.client.ESSearchRequest;
+import fr.pilato.elasticsearch.crawler.fs.client.ESSearchResponse;
+
+import java.io.IOException;
 
 public interface FsCrawlerDocumentService extends FsCrawlerService {
     /**
@@ -45,4 +50,45 @@ public interface FsCrawlerDocumentService extends FsCrawlerService {
      * @param pipeline  Pipeline (can be null)
      */
     void indexRawJson(String index, String id, String json, String pipeline);
+
+    /**
+     * Remove a document from the target service
+     * @param index     Index name
+     * @param id        Document ID
+     */
+    void delete(String index, String id);
+
+    /**
+     * Refresh the document database to make changes visible
+     * @param index     Optional index name
+     */
+    void refresh(String index) throws IOException;
+
+    /**
+     * Search for information
+     * @param request   The request
+     * @return a response from the document service
+     */
+    ESSearchResponse search(ESSearchRequest request) throws IOException;
+
+    /**
+     * Remove a document from the target service
+     * @param index     Index name
+     * @param id        Document ID
+     * @return true if the document exists
+     */
+    boolean exists(String index, String id) throws IOException;
+
+    /**
+     * Get a document from the target service
+     * @param index     Index name
+     * @param id        Document ID
+     * @return the document or null
+     */
+    ESSearchHit get(String index, String id) throws IOException;
+
+    /**
+     * Flush any pending operation
+     */
+    void flush();
 }

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentServiceElasticsearchImpl.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentServiceElasticsearchImpl.java
@@ -21,6 +21,9 @@ package fr.pilato.elasticsearch.crawler.fs.service;
 
 import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
 import fr.pilato.elasticsearch.crawler.fs.beans.DocParser;
+import fr.pilato.elasticsearch.crawler.fs.client.ESSearchHit;
+import fr.pilato.elasticsearch.crawler.fs.client.ESSearchRequest;
+import fr.pilato.elasticsearch.crawler.fs.client.ESSearchResponse;
 import fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchClient;
 import fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchClientUtil;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
@@ -40,6 +43,10 @@ public class FsCrawlerDocumentServiceElasticsearchImpl implements FsCrawlerDocum
         this.client = ElasticsearchClientUtil.getInstance(config, settings);
     }
 
+    public ElasticsearchClient getClient() {
+        return client;
+    }
+
     @Override
     public void start() throws IOException {
         client.start();
@@ -47,14 +54,14 @@ public class FsCrawlerDocumentServiceElasticsearchImpl implements FsCrawlerDocum
     }
 
     @Override
-    public ElasticsearchClient getClient() {
-        return client;
-    }
-
-    @Override
     public void close() throws IOException {
         client.close();
         logger.debug("Elasticsearch Document Service stopped");
+    }
+
+    @Override
+    public String getVersion() throws IOException {
+        return client.getVersion();
     }
 
     @Override
@@ -73,4 +80,39 @@ public class FsCrawlerDocumentServiceElasticsearchImpl implements FsCrawlerDocum
         client.indexRawJson(index, id, json, pipeline);
     }
 
+    @Override
+    public void delete(String index, String id) {
+        logger.debug("Deleting {}/{}", index, id);
+        client.delete(index, id);
+    }
+
+    @Override
+    public void refresh(String index) throws IOException {
+        logger.debug("Refreshing {}", index);
+        client.refresh(index);
+    }
+
+    @Override
+    public ESSearchResponse search(ESSearchRequest request) throws IOException {
+        logger.debug("Searching {}", request);
+        return client.search(request);
+    }
+
+    @Override
+    public boolean exists(String index, String id) throws IOException {
+        logger.debug("Search if document {}/{} exists", index, id);
+        return client.exists(index, id);
+    }
+
+    @Override
+    public ESSearchHit get(String index, String id) throws IOException {
+        logger.debug("Getting {}/{}", index, id);
+        return client.get(index, id);
+    }
+
+    @Override
+    public void flush() {
+        logger.debug("Flushing");
+        client.flush();
+    }
 }

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentServiceWorkplaceSearchImpl.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentServiceWorkplaceSearchImpl.java
@@ -19,7 +19,11 @@
 
 package fr.pilato.elasticsearch.crawler.fs.service;
 
+import com.google.gson.JsonObject;
+import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.spi.json.GsonJsonProvider;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
 import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
 import fr.pilato.elasticsearch.crawler.fs.client.ESBoolQuery;
 import fr.pilato.elasticsearch.crawler.fs.client.ESMatchQuery;
@@ -50,9 +54,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static fr.pilato.elasticsearch.crawler.fs.framework.MetaParser.mapper;
+
 public class FsCrawlerDocumentServiceWorkplaceSearchImpl implements FsCrawlerDocumentService {
 
     private static final Logger logger = LogManager.getLogger(FsCrawlerDocumentServiceWorkplaceSearchImpl.class);
+    private final Configuration conf = Configuration.builder().jsonProvider(new JacksonJsonProvider(mapper)).build();
 
     private final WorkplaceSearchClient client;
 
@@ -124,7 +131,8 @@ public class FsCrawlerDocumentServiceWorkplaceSearchImpl implements FsCrawlerDoc
         response.setTotalHits(totalHits);
         for (int i = 0; i < totalHits; i++) {
             ESSearchHit hit = new ESSearchHit();
-            hit.setSourceAsObject(JsonPath.read(document, "$.results[" + i + "]"));
+            // We read the hit and transform it again as a json document using Jackson
+            hit.setSourceAsString(mapper.writeValueAsString(JsonPath.read(document, "$.results[" + i + "]")));
             response.addHit(hit);
         }
 

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentServiceWorkplaceSearchImpl.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentServiceWorkplaceSearchImpl.java
@@ -140,12 +140,12 @@ public class FsCrawlerDocumentServiceWorkplaceSearchImpl implements FsCrawlerDoc
     @Override
     public ESSearchHit get(String index, String id) throws IOException {
         logger.debug("Getting {}/{}", index, id);
-        Object json = client.get(id);
+        String json = client.get(id);
 
         ESSearchHit hit = new ESSearchHit();
         hit.setIndex(index);
         hit.setId(id);
-        hit.setSourceAsObject(json);
+        hit.setSourceAsString(json);
 
         return hit;
     }

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentServiceWorkplaceSearchImpl.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentServiceWorkplaceSearchImpl.java
@@ -20,7 +20,15 @@
 package fr.pilato.elasticsearch.crawler.fs.service;
 
 import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
-import fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchClient;
+import fr.pilato.elasticsearch.crawler.fs.client.ESBoolQuery;
+import fr.pilato.elasticsearch.crawler.fs.client.ESMatchQuery;
+import fr.pilato.elasticsearch.crawler.fs.client.ESPrefixQuery;
+import fr.pilato.elasticsearch.crawler.fs.client.ESQuery;
+import fr.pilato.elasticsearch.crawler.fs.client.ESRangeQuery;
+import fr.pilato.elasticsearch.crawler.fs.client.ESSearchHit;
+import fr.pilato.elasticsearch.crawler.fs.client.ESSearchRequest;
+import fr.pilato.elasticsearch.crawler.fs.client.ESSearchResponse;
+import fr.pilato.elasticsearch.crawler.fs.client.ESTermQuery;
 import fr.pilato.elasticsearch.crawler.fs.client.WorkplaceSearchClient;
 import fr.pilato.elasticsearch.crawler.fs.client.WorkplaceSearchClientUtil;
 import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerIllegalConfigurationException;
@@ -53,29 +61,99 @@ public class FsCrawlerDocumentServiceWorkplaceSearchImpl implements FsCrawlerDoc
     }
 
     @Override
-    public ElasticsearchClient getClient() {
-        return client;
-    }
-
-    @Override
     public void close() throws IOException {
         client.close();
         logger.debug("Workplace Search Document Service stopped");
     }
 
     @Override
+    public String getVersion() throws IOException {
+        throw new RuntimeException("Not implemented yet");
+    }
+
+    @Override
     public void createSchema() {
+        // TODO implement this as this is not true anymore
         // There is no way yet to create a schema in workplace before hand.
     }
 
     @Override
     public void index(String index, String id, Doc doc, String pipeline) {
         logger.debug("Indexing {}/{}?pipeline={}", index, id, pipeline);
-        client.index(index, id, doc, pipeline);
+        client.index(id, doc);
     }
 
     @Override
     public void indexRawJson(String index, String id, String json, String pipeline) {
         throw new RuntimeException("We can't send Raw Json Documents to Workplace Search");
     }
+
+    @Override
+    public void delete(String index, String id) {
+        logger.debug("Deleting {}/{}", index, id);
+        client.delete(id);
+    }
+
+    @Override
+    public void refresh(String index) throws IOException {
+        logger.debug("Refreshing {}", index);
+    }
+
+    @Override
+    public ESSearchResponse search(ESSearchRequest request) throws IOException {
+        logger.debug("Searching {}", request);
+
+        // Convert the ESSearchRequest to a WPSearch request
+        client.search(toWorkplaceSearchQuery(request.getESQuery()), null);
+        return null;
+    }
+
+    @Override
+    public boolean exists(String index, String id) throws IOException {
+        logger.debug("Search if document {} exists", id);
+        return client.exists(id);
+    }
+
+    @Override
+    public ESSearchHit get(String index, String id) throws IOException {
+        logger.debug("Getting {}/{}", index, id);
+        String json = client.get(id);
+
+        // TODO parse the json and return it as an ESSearchHit
+        return null;
+    }
+
+    @Override
+    public void flush() {
+        logger.debug("Flushing");
+        client.flush();
+    }
+
+    private String toWorkplaceSearchQuery(ESQuery query) {
+        if (query instanceof ESTermQuery) {
+            ESTermQuery esQuery = (ESTermQuery) query;
+            return esQuery.getValue();
+        }
+        if (query instanceof ESMatchQuery) {
+            ESMatchQuery esQuery = (ESMatchQuery) query;
+            return esQuery.getValue();
+        }
+        if (query instanceof ESPrefixQuery) {
+            ESPrefixQuery esQuery = (ESPrefixQuery) query;
+        }
+        if (query instanceof ESRangeQuery) {
+            ESRangeQuery esQuery = (ESRangeQuery) query;
+            if (esQuery.getFrom() != null) {
+            }
+            if (esQuery.getTo() != null) {
+            }
+        }
+        if (query instanceof ESBoolQuery) {
+            ESBoolQuery esQuery = (ESBoolQuery) query;
+            for (ESQuery clause : esQuery.getMustClauses()) {
+            }
+        }
+        throw new IllegalArgumentException("Query " + query.getClass().getSimpleName() + " not implemented yet");
+    }
+
 }

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerManagementService.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerManagementService.java
@@ -51,4 +51,12 @@ public interface FsCrawlerManagementService extends FsCrawlerService {
      * @param folder Folder to store
      */
     void storeVisitedDirectory(String indexFolder, String id, Folder folder) throws IOException;
+
+
+    /**
+     * Remove a document from the target service
+     * @param index     Index name
+     * @param id        Document ID
+     */
+    void delete(String index, String id);
 }

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerManagementServiceElasticsearchImpl.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerManagementServiceElasticsearchImpl.java
@@ -54,6 +54,10 @@ public class FsCrawlerManagementServiceElasticsearchImpl implements FsCrawlerMan
         this.client = ElasticsearchClientUtil.getInstance(config, settings);
     }
 
+    public ElasticsearchClient getClient() {
+        return client;
+    }
+
     @Override
     public void start() throws IOException {
         client.start();
@@ -61,14 +65,14 @@ public class FsCrawlerManagementServiceElasticsearchImpl implements FsCrawlerMan
     }
 
     @Override
-    public ElasticsearchClient getClient() {
-        return client;
-    }
-
-    @Override
     public void close() throws IOException {
         client.close();
         logger.debug("Elasticsearch Management Service stopped");
+    }
+
+    @Override
+    public String getVersion() throws IOException {
+        return client.getVersion();
     }
 
     @Override
@@ -131,5 +135,10 @@ public class FsCrawlerManagementServiceElasticsearchImpl implements FsCrawlerMan
     @Override
     public void storeVisitedDirectory(String indexFolder, String id, Folder folder) {
         client.indexRawJson(indexFolder, id, FolderParser.toJson(folder), null);
+    }
+
+    @Override
+    public void delete(String index, String id) {
+        client.delete(index, id);
     }
 }

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerService.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerService.java
@@ -1,7 +1,5 @@
 package fr.pilato.elasticsearch.crawler.fs.service;
 
-import fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchClient;
-
 import java.io.Closeable;
 import java.io.IOException;
 
@@ -13,8 +11,8 @@ public interface FsCrawlerService extends Closeable {
     void start() throws IOException;
 
     /**
-     * Get the elasticsearch client
-     * @return elasticsearch client
+     * Get the version of the service
+     * @return a version
      */
-    ElasticsearchClient getClient();
+    String getVersion() throws IOException;
 }

--- a/elasticsearch-client/elasticsearch-client-base/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ESSearchHit.java
+++ b/elasticsearch-client/elasticsearch-client-base/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ESSearchHit.java
@@ -28,6 +28,7 @@ public class ESSearchHit {
     private Long version;
     private Map<String, Object> source;
     private String sourceAsString;
+    private Object sourceAsObject;
     private Map<String, ESDocumentField> fields;
     private Map<String, ESHighlightField> highlightFields = new HashMap<>();
 
@@ -85,5 +86,13 @@ public class ESSearchHit {
 
     public void setVersion(Long version) {
         this.version = version;
+    }
+
+    public Object getSourceAsObject() {
+        return sourceAsObject;
+    }
+
+    public void setSourceAsObject(Object json) {
+        this.sourceAsObject = json;
     }
 }

--- a/elasticsearch-client/elasticsearch-client-base/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ESSearchHit.java
+++ b/elasticsearch-client/elasticsearch-client-base/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ESSearchHit.java
@@ -28,7 +28,6 @@ public class ESSearchHit {
     private Long version;
     private Map<String, Object> source;
     private String sourceAsString;
-    private Object sourceAsObject;
     private Map<String, ESDocumentField> fields;
     private Map<String, ESHighlightField> highlightFields = new HashMap<>();
 
@@ -88,11 +87,4 @@ public class ESSearchHit {
         this.version = version;
     }
 
-    public Object getSourceAsObject() {
-        return sourceAsObject;
-    }
-
-    public void setSourceAsObject(Object json) {
-        this.sourceAsObject = json;
-    }
 }

--- a/elasticsearch-client/elasticsearch-client-base/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ESSearchResponse.java
+++ b/elasticsearch-client/elasticsearch-client-base/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ESSearchResponse.java
@@ -50,6 +50,10 @@ public class ESSearchResponse {
         this.totalHits = totalHits;
     }
 
+    public void setTotalHits(int totalHits) {
+        this.totalHits = totalHits;
+    }
+
     public Map<String, ESTermsAggregation> getAggregations() {
         return aggregations;
     }

--- a/elasticsearch-client/elasticsearch-client-base/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/WorkplaceSearchClient.java
+++ b/elasticsearch-client/elasticsearch-client-base/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/WorkplaceSearchClient.java
@@ -14,7 +14,7 @@ public interface WorkplaceSearchClient extends Closeable {
 
     void delete(String id);
 
-    String search(String query, Map<String, List<String>> filters);
+    String search(String query, Map<String, Object> filters);
 
     /**
      * Check that a document exists
@@ -28,7 +28,7 @@ public interface WorkplaceSearchClient extends Closeable {
      * @param id    Document id
      * @return the document or null
      */
-    String get(String id);
+    Object get(String id);
 
     /**
      * Flush any pending operation

--- a/elasticsearch-client/elasticsearch-client-base/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/WorkplaceSearchClient.java
+++ b/elasticsearch-client/elasticsearch-client-base/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/WorkplaceSearchClient.java
@@ -28,7 +28,7 @@ public interface WorkplaceSearchClient extends Closeable {
      * @param id    Document id
      * @return the document or null
      */
-    Object get(String id);
+    String get(String id);
 
     /**
      * Flush any pending operation

--- a/elasticsearch-client/elasticsearch-client-base/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/WorkplaceSearchClient.java
+++ b/elasticsearch-client/elasticsearch-client-base/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/WorkplaceSearchClient.java
@@ -1,4 +1,37 @@
 package fr.pilato.elasticsearch.crawler.fs.client;
 
-public interface WorkplaceSearchClient extends ElasticsearchClient {
+import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public interface WorkplaceSearchClient extends Closeable {
+    void start() throws IOException;
+
+    void index(String id, Doc doc);
+
+    void delete(String id);
+
+    String search(String query, Map<String, List<String>> filters);
+
+    /**
+     * Check that a document exists
+     * @param id    Document id
+     * @return true if it exists, false otherwise
+     */
+    boolean exists(String id);
+
+    /**
+     * Get a document
+     * @param id    Document id
+     * @return the document or null
+     */
+    String get(String id);
+
+    /**
+     * Flush any pending operation
+     */
+    void flush();
 }

--- a/elasticsearch-client/elasticsearch-client-v7/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v7/WorkplaceSearchClientV7.java
+++ b/elasticsearch-client/elasticsearch-client-v7/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v7/WorkplaceSearchClientV7.java
@@ -21,11 +21,6 @@ package fr.pilato.elasticsearch.crawler.fs.client.v7;
 
 
 import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
-import fr.pilato.elasticsearch.crawler.fs.client.ESSearchHit;
-import fr.pilato.elasticsearch.crawler.fs.client.ESSearchRequest;
-import fr.pilato.elasticsearch.crawler.fs.client.ESSearchResponse;
-import fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchClient;
-import fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchClientUtil;
 import fr.pilato.elasticsearch.crawler.fs.client.WorkplaceSearchClient;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
 import fr.pilato.elasticsearch.crawler.fs.thirdparty.wpsearch.WPSearchClient;
@@ -34,6 +29,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 
 import static fr.pilato.elasticsearch.crawler.fs.client.WorkplaceSearchClientUtil.docToJson;
@@ -49,17 +45,11 @@ public class WorkplaceSearchClientV7 implements WorkplaceSearchClient {
     private final Path config;
     private final FsSettings settings;
 
-    private ElasticsearchClient esClient = null;
     private WPSearchClient wpSearchClient = null;
 
     public WorkplaceSearchClientV7(Path config, FsSettings settings) {
         this.config = config;
         this.settings = settings;
-    }
-
-    @Override
-    public String compatibleVersion() {
-        return "7";
     }
 
     @Override
@@ -83,140 +73,48 @@ public class WorkplaceSearchClientV7 implements WorkplaceSearchClient {
 
         wpSearchClient.configureCustomSource(settings.getWorkplaceSearch().getId(), sourceName);
 
-        esClient = ElasticsearchClientUtil.getInstance(config, settings);
-        esClient.start();
         logger.debug("Workplace Search V7 client started");
     }
 
     @Override
-    public String getVersion() throws IOException {
-        return esClient.getVersion();
-    }
-
-    /**
-     * Create an index
-     * @param index index name
-     * @param ignoreErrors don't fail if the index already exists
-     * @param indexSettings index settings if any
-     * @throws IOException In case of error
-     */
-    public void createIndex(String index, boolean ignoreErrors, String indexSettings) throws IOException {
-        esClient.createIndex(index, ignoreErrors, indexSettings);
-    }
-
-    /**
-     * Check if an index exists
-     * @param index index name
-     * @return true if the index exists, false otherwise
-     * @throws IOException In case of error
-     */
-    public boolean isExistingIndex(String index) throws IOException {
-        return esClient.isExistingIndex(index);
-    }
-
-    /**
-     * Check if a pipeline exists
-     * @param pipelineName pipeline name
-     * @return true if the pipeline exists, false otherwise
-     * @throws IOException In case of error
-     */
-    public boolean isExistingPipeline(String pipelineName) throws IOException {
-        return esClient.isExistingPipeline(pipelineName);
-    }
-
-    /**
-     * Refresh an index
-     * @param index index name
-     * @throws IOException In case of error
-     */
-    public void refresh(String index) throws IOException {
-        esClient.refresh(index);
-    }
-
-    /**
-     * Wait for an index to become at least yellow (all primaries assigned)
-     * @param index index name
-     * @throws IOException In case of error
-     */
-    public void waitForHealthyIndex(String index) throws IOException {
-        esClient.waitForHealthyIndex(index);
-    }
-
-    // Utility methods
-
-    public boolean isIngestSupported() {
-        return true;
-    }
-
-    public String getDefaultTypeName() {
-        return esClient.getDefaultTypeName();
-    }
-
-    @Override
-    public void index(String index, String id, Doc doc, String pipeline) {
-        wpSearchClient.indexDocument(docToJson(id, doc, settings.getWorkplaceSearch().getUrlPrefix()));
-    }
-
-    @Override
-    public void indexRawJson(String index, String id, String json, String pipeline) {
-        throw new RuntimeException("Not supported by the workplace search client. Should not be called.");
-    }
-
-    @Override
-    public void indexSingle(String index, String id, String json) {
-        throw new RuntimeException("Not supported by the workplace search client. Should not be called.");
-    }
-
-    @Override
-    public void delete(String index, String id) {
-        wpSearchClient.destroyDocument(index, id);
-    }
-
-    @Override
-    public void close() throws IOException {
+    public void close() {
         logger.debug("Closing Workplace Search V7 client");
-        if (esClient != null) {
-            esClient.close();
-        }
         if (wpSearchClient != null) {
             wpSearchClient.close();
         }
         logger.debug("Workplace Search V7 client closed");
     }
 
-    public void createIndices() throws Exception {
-        esClient.createIndices();
+    @Override
+    public void index(String id, Doc doc) {
+        wpSearchClient.indexDocument(docToJson(id, doc, settings.getWorkplaceSearch().getUrlPrefix()));
     }
 
     @Override
-    public ESSearchResponse search(ESSearchRequest request) throws IOException {
-        // TODO use the wpSearchClient instead
-        return esClient.search(request);
+    public void delete(String id) {
+        wpSearchClient.destroyDocument(id);
     }
 
     @Override
-    public void deleteIndex(String index) throws IOException {
-        esClient.deleteIndex(index);
+    public String search(String query, Map<String, List<String>> filters) {
+        return wpSearchClient.search(query, filters);
+    }
+
+    @Override
+    public boolean exists(String id) {
+        String document = wpSearchClient.getDocument(id);
+
+        // TODO Implement this and test it
+        return document == null;
+    }
+
+    @Override
+    public String get(String id) {
+        return wpSearchClient.getDocument(id);
     }
 
     @Override
     public void flush() {
-        esClient.flush();
-    }
-
-    @Override
-    public void performLowLevelRequest(String method, String endpoint, String jsonEntity) throws IOException {
-        esClient.performLowLevelRequest(method, endpoint, jsonEntity);
-    }
-
-    @Override
-    public ESSearchHit get(String index, String id) {
-        throw new RuntimeException("Not implemented yet");
-    }
-
-    @Override
-    public boolean exists(String index, String id) {
-        throw new RuntimeException("Not implemented yet");
-        // return esClient.exists(index, id);
+        wpSearchClient.flush();
     }
 }

--- a/elasticsearch-client/elasticsearch-client-v7/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v7/WorkplaceSearchClientV7.java
+++ b/elasticsearch-client/elasticsearch-client-v7/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v7/WorkplaceSearchClientV7.java
@@ -96,20 +96,17 @@ public class WorkplaceSearchClientV7 implements WorkplaceSearchClient {
     }
 
     @Override
-    public String search(String query, Map<String, List<String>> filters) {
+    public String search(String query, Map<String, Object> filters) {
         return wpSearchClient.search(query, filters);
     }
 
     @Override
     public boolean exists(String id) {
-        String document = wpSearchClient.getDocument(id);
-
-        // TODO Implement this and test it
-        return document == null;
+        return wpSearchClient.getDocument(id) != null;
     }
 
     @Override
-    public String get(String id) {
+    public Object get(String id) {
         return wpSearchClient.getDocument(id);
     }
 

--- a/elasticsearch-client/elasticsearch-client-v7/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v7/WorkplaceSearchClientV7.java
+++ b/elasticsearch-client/elasticsearch-client-v7/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/v7/WorkplaceSearchClientV7.java
@@ -106,7 +106,7 @@ public class WorkplaceSearchClientV7 implements WorkplaceSearchClient {
     }
 
     @Override
-    public Object get(String id) {
+    public String get(String id) {
         return wpSearchClient.getDocument(id);
     }
 

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerBulkProcessor.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerBulkProcessor.java
@@ -158,6 +158,10 @@ public class FsCrawlerBulkProcessor<
         return listener;
     }
 
+    public void flush() {
+        execute();
+    }
+
     public static class Builder<O extends FsCrawlerOperation<O>,
             Req extends FsCrawlerBulkRequest<O>,
             Res extends FsCrawlerBulkResponse<O>> {

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractFsCrawlerITCase.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractFsCrawlerITCase.java
@@ -44,7 +44,7 @@ public abstract class AbstractFsCrawlerITCase extends AbstractRestITCase {
     @Before
     public void cleanExistingIndex() throws IOException {
         logger.info(" -> Removing existing index [{}*]", getCrawlerName());
-        documentService.getClient().deleteIndex(getCrawlerName() + "*");
+        managementService.getClient().deleteIndex(getCrawlerName() + "*");
     }
 
     @After

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
@@ -418,7 +418,7 @@ public abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
     }
 
     protected String getRandomCrawlerName() {
-        return testCrawlerPrefix.concat(randomAsciiAlphanumOfLength(randomIntBetween(1, 30))).toLowerCase(Locale.ROOT);
+        return testCrawlerPrefix.concat(randomAsciiAlphanumOfLength(randomIntBetween(10, 15))).toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/ElasticsearchClientIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/ElasticsearchClientIT.java
@@ -42,7 +42,7 @@ import static org.junit.Assume.assumeThat;
  */
 public class ElasticsearchClientIT extends AbstractITCase {
 
-    private ElasticsearchClient esClient = documentService.getClient();
+    private final ElasticsearchClient esClient = managementService.getClient();
 
     @Before
     public void cleanExistingIndex() throws IOException {

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerImplAllDocumentsIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerImplAllDocumentsIT.java
@@ -75,7 +75,7 @@ public class FsCrawlerImplAllDocumentsIT extends AbstractFsCrawlerITCase {
         }
 
         staticLogger.info(" -> Removing existing index [fscrawler_test_all_documents*]");
-        documentService.getClient().deleteIndex("fscrawler_test_all_documents*");
+        managementService.getClient().deleteIndex("fscrawler_test_all_documents*");
 
         staticLogger.info("  --> starting crawler in [{}] which contains [{}] files", testResourceTarget, numFiles);
 
@@ -242,7 +242,7 @@ public class FsCrawlerImplAllDocumentsIT extends AbstractFsCrawlerITCase {
         if (content != null) {
             query.addMust(new ESMatchQuery("content", content));
         }
-        ESSearchResponse response = documentService.getClient().search(new ESSearchRequest()
+        ESSearchResponse response = documentService.search(new ESSearchRequest()
                         .withIndex("fscrawler_test_all_documents")
                         .withESQuery(query));
         assertThat(response.getTotalHits(), is(1L));

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerRestIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerRestIT.java
@@ -31,7 +31,6 @@ import fr.pilato.elasticsearch.crawler.fs.rest.UploadResponse;
 import fr.pilato.elasticsearch.crawler.fs.service.FsCrawlerDocumentService;
 import fr.pilato.elasticsearch.crawler.fs.service.FsCrawlerDocumentServiceElasticsearchImpl;
 import fr.pilato.elasticsearch.crawler.fs.service.FsCrawlerDocumentServiceWorkplaceSearchImpl;
-import fr.pilato.elasticsearch.crawler.fs.service.FsCrawlerManagementService;
 import fr.pilato.elasticsearch.crawler.fs.service.FsCrawlerManagementServiceElasticsearchImpl;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsCrawlerValidator;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
@@ -58,16 +57,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.copyDirs;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.*;
 
 @SuppressWarnings("ALL")
 public class FsCrawlerRestIT extends AbstractRestITCase {
 
     private Path currentTestTagDir;
-    private FsCrawlerManagementService managementService;
+    private FsCrawlerManagementServiceElasticsearchImpl managementService;
     private FsCrawlerDocumentService documentService;
 
     @Before
@@ -312,7 +308,7 @@ public class FsCrawlerRestIT extends AbstractRestITCase {
     }
 
     private void checkDocument(String filename, HitChecker checker) throws IOException {
-        ESSearchResponse response = documentService.getClient().search(new ESSearchRequest()
+        ESSearchResponse response = documentService.search(new ESSearchRequest()
                 .withIndex(getCrawlerName())
                 .withESQuery(new ESTermQuery("file.filename", filename)));
 

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestDefaultsIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestDefaultsIT.java
@@ -94,7 +94,7 @@ public class FsCrawlerTestDefaultsIT extends AbstractFsCrawlerITCase {
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
 
         // Let's test highlighting
-        ESSearchResponse response = documentService.getClient().search(new ESSearchRequest()
+        ESSearchResponse response = documentService.search(new ESSearchRequest()
                 .withIndex(getCrawlerName())
                 .withESQuery(new ESMatchQuery("content", "exemplo"))
                 .addHighlighter("content"));

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestFilenameAsIdIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestFilenameAsIdIT.java
@@ -47,7 +47,7 @@ public class FsCrawlerTestFilenameAsIdIT extends AbstractFsCrawlerITCase {
 
         assertThat("Document should exists with [roottxtfile.txt] id...", awaitBusy(() -> {
             try {
-                return documentService.getClient().exists(getCrawlerName(), "roottxtfile.txt");
+                return documentService.exists(getCrawlerName(), "roottxtfile.txt");
             } catch (IOException e) {
                 return false;
             }
@@ -70,14 +70,14 @@ public class FsCrawlerTestFilenameAsIdIT extends AbstractFsCrawlerITCase {
 
         assertThat("Document should exists with [id1.txt] id...", awaitBusy(() -> {
             try {
-                return documentService.getClient().exists(getCrawlerName(), "id1.txt");
+                return documentService.exists(getCrawlerName(), "id1.txt");
             } catch (IOException e) {
                 return false;
             }
         }), equalTo(true));
         assertThat("Document should exists with [id2.txt] id...", awaitBusy(() -> {
             try {
-                return documentService.getClient().exists(getCrawlerName(), "id2.txt");
+                return documentService.exists(getCrawlerName(), "id2.txt");
             } catch (IOException e) {
                 return false;
             }

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestIgnoreFoldersIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestIgnoreFoldersIT.java
@@ -48,7 +48,7 @@ public class FsCrawlerTestIgnoreFoldersIT extends AbstractFsCrawlerITCase {
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 2L, null);
 
         // We expect having no folders
-        ESSearchResponse response = documentService.getClient().search(new ESSearchRequest().withIndex(getCrawlerName() + INDEX_SUFFIX_FOLDER));
+        ESSearchResponse response = documentService.search(new ESSearchRequest().withIndex(getCrawlerName() + INDEX_SUFFIX_FOLDER));
         assertThat(response.getTotalHits(), is(0L));
     }
 }

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestIngestPipelineIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestIngestPipelineIT.java
@@ -47,7 +47,7 @@ public class FsCrawlerTestIngestPipelineIT extends AbstractFsCrawlerITCase {
         String crawlerName = getCrawlerName();
 
         // We can only run this test against a 5.0 cluster or >
-        assumeThat("We skip the test as we are not running it with a 5.0 cluster or >", documentService.getClient().isIngestSupported(), is(true));
+        assumeThat("We skip the test as we are not running it with a 5.0 cluster or >", managementService.getClient().isIngestSupported(), is(true));
 
         // Create an empty ingest pipeline
         String pipeline = "{\n" +
@@ -61,7 +61,7 @@ public class FsCrawlerTestIngestPipelineIT extends AbstractFsCrawlerITCase {
                 "    }\n" +
                 "  ]\n" +
                 "}";
-        documentService.getClient().performLowLevelRequest("PUT", "/_ingest/pipeline/" + crawlerName, pipeline);
+        managementService.getClient().performLowLevelRequest("PUT", "/_ingest/pipeline/" + crawlerName, pipeline);
 
         Elasticsearch elasticsearch = endCrawlerDefinition(crawlerName);
         elasticsearch.setPipeline(crawlerName);
@@ -74,7 +74,7 @@ public class FsCrawlerTestIngestPipelineIT extends AbstractFsCrawlerITCase {
                 .withESQuery(new ESMatchQuery("my_content_field", "perniciosoque")), 1L, currentTestResourceDir);
 
         // We expect to have one folder
-        ESSearchResponse response = documentService.getClient().search(new ESSearchRequest().withIndex(getCrawlerName() + INDEX_SUFFIX_FOLDER));
+        ESSearchResponse response = documentService.search(new ESSearchRequest().withIndex(getCrawlerName() + INDEX_SUFFIX_FOLDER));
         assertThat(response.getTotalHits(), is(1L));
     }
 
@@ -86,7 +86,7 @@ public class FsCrawlerTestIngestPipelineIT extends AbstractFsCrawlerITCase {
         String crawlerName = getCrawlerName();
 
         // We can only run this test against a 5.0 cluster or >
-        assumeThat("We skip the test as we are not running it with a 5.0 cluster or >", documentService.getClient().isIngestSupported(), is(true));
+        assumeThat("We skip the test as we are not running it with a 5.0 cluster or >", managementService.getClient().isIngestSupported(), is(true));
 
         // Create an empty ingest pipeline
         String pipeline = "{\n" +
@@ -109,7 +109,7 @@ public class FsCrawlerTestIngestPipelineIT extends AbstractFsCrawlerITCase {
                 "    }\n" +
                 "  ]\n" +
                 "}";
-        documentService.getClient().performLowLevelRequest("PUT", "/_ingest/pipeline/" + crawlerName, pipeline);
+        managementService.getClient().performLowLevelRequest("PUT", "/_ingest/pipeline/" + crawlerName, pipeline);
 
         Elasticsearch elasticsearch = endCrawlerDefinition(crawlerName);
         elasticsearch.setPipeline(crawlerName);
@@ -130,7 +130,7 @@ public class FsCrawlerTestIngestPipelineIT extends AbstractFsCrawlerITCase {
 
         // We can only run this test against a 5.0 cluster or >
         assumeThat("We skip the test as we are not running it with a 5.0 cluster or >",
-                documentService.getClient().isIngestSupported(), is(true));
+                managementService.getClient().isIngestSupported(), is(true));
 
         Elasticsearch elasticsearch = endCrawlerDefinition(crawlerName);
         elasticsearch.setPipeline(crawlerName);

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestJsonSupportIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestJsonSupportIT.java
@@ -48,7 +48,7 @@ public class FsCrawlerTestJsonSupportIT extends AbstractFsCrawlerITCase {
 
         assertThat("We should have 2 doc for tweet in text field...", awaitBusy(() -> {
             try {
-                ESSearchResponse response = documentService.getClient().search(new ESSearchRequest()
+                ESSearchResponse response = documentService.search(new ESSearchRequest()
                         .withIndex(getCrawlerName())
                         .withESQuery(new ESMatchQuery("text", "tweet")));
                 return response.getTotalHits() == 2;
@@ -71,7 +71,7 @@ public class FsCrawlerTestJsonSupportIT extends AbstractFsCrawlerITCase {
 
         assertThat("We should have 0 doc for tweet in text field...", awaitBusy(() -> {
             try {
-                ESSearchResponse response = documentService.getClient().search(new ESSearchRequest()
+                ESSearchResponse response = documentService.search(new ESSearchRequest()
                         .withIndex(getCrawlerName())
                         .withESQuery(new ESMatchQuery("text", "tweet")));
                 return response.getTotalHits() == 0;
@@ -83,7 +83,7 @@ public class FsCrawlerTestJsonSupportIT extends AbstractFsCrawlerITCase {
 
         assertThat("We should have 2 docs for tweet in content field...", awaitBusy(() -> {
             try {
-                ESSearchResponse response = documentService.getClient().search(new ESSearchRequest()
+                ESSearchResponse response = documentService.search(new ESSearchRequest()
                         .withIndex(getCrawlerName())
                         .withESQuery(new ESMatchQuery("content", "tweet")));
                 return response.getTotalHits() == 2;
@@ -107,7 +107,7 @@ public class FsCrawlerTestJsonSupportIT extends AbstractFsCrawlerITCase {
 
         assertThat("We should have 2 doc for tweet in object.text field...", awaitBusy(() -> {
             try {
-                ESSearchResponse response = documentService.getClient().search(new ESSearchRequest()
+                ESSearchResponse response = documentService.search(new ESSearchRequest()
                         .withIndex(getCrawlerName())
                         .withESQuery(new ESMatchQuery("object.text", "tweet")));
                 return response.getTotalHits() == 2;
@@ -130,7 +130,7 @@ public class FsCrawlerTestJsonSupportIT extends AbstractFsCrawlerITCase {
 
         assertThat("We should have 2 docs only...", awaitBusy(() -> {
             try {
-                ESSearchResponse response = documentService.getClient().search(new ESSearchRequest().withIndex(getCrawlerName()));
+                ESSearchResponse response = documentService.search(new ESSearchRequest().withIndex(getCrawlerName()));
                 return response.getTotalHits() == 2;
             } catch (IOException e) {
                 logger.warn("Caught exception while running the test", e);

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRawIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRawIT.java
@@ -67,9 +67,9 @@ public class FsCrawlerTestRawIT extends AbstractFsCrawlerITCase {
 
         // This will cause an Elasticsearch Exception as the String is not a Date
         // If the mapping is incorrect
-        documentService.getClient().indexRawJson(getCrawlerName(), "1", json1, null);
-        documentService.getClient().indexRawJson(getCrawlerName(), "2", json2, null);
-        documentService.getClient().flush();
+        documentService.indexRawJson(getCrawlerName(), "1", json1, null);
+        documentService.indexRawJson(getCrawlerName(), "2", json2, null);
+        documentService.flush();
     }
 
     @Test

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRemoveDeletedIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRemoveDeletedIT.java
@@ -233,7 +233,7 @@ public class FsCrawlerTestRemoveDeletedIT extends AbstractFsCrawlerITCase {
         for (ESSearchHit hit : response.getHits()) {
             // Read the document. This is needed since 5.0 as search does not return the _version field
             try {
-                ESSearchHit getHit = documentService.getClient().get(hit.getIndex(), hit.getId());
+                ESSearchHit getHit = documentService.get(hit.getIndex(), hit.getId());
                 assertThat(getHit.getVersion(), lessThanOrEqualTo(maxVersion));
             } catch (IOException e) {
                 fail("We got an IOException: " + e.getMessage());

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestStoreSourceIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestStoreSourceIT.java
@@ -56,7 +56,7 @@ public class FsCrawlerTestStoreSourceIT extends AbstractFsCrawlerITCase {
 
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
 
-        ESSearchResponse searchResponse = documentService.getClient().search(new ESSearchRequest().withIndex(getCrawlerName()));
+        ESSearchResponse searchResponse = documentService.search(new ESSearchRequest().withIndex(getCrawlerName()));
         for (ESSearchHit hit : searchResponse.getHits()) {
             // We check that the field is not part of _source
             expectThrows(PathNotFoundException.class, () -> JsonPath.read(hit.getSourceAsString(), "$.attachment"));

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestSubDirsIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestSubDirsIT.java
@@ -72,7 +72,7 @@ public class FsCrawlerTestSubDirsIT extends AbstractFsCrawlerITCase {
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 7L, null);
 
         // Run aggs
-        ESSearchResponse response = documentService.getClient().search(new ESSearchRequest()
+        ESSearchResponse response = documentService.search(new ESSearchRequest()
                         .withIndex(getCrawlerName())
                         .withSize(0)
                         .withAggregation(new ESTermsAggregation("folders", "path.virtual.tree")));
@@ -86,7 +86,7 @@ public class FsCrawlerTestSubDirsIT extends AbstractFsCrawlerITCase {
         assertThat(buckets, iterableWithSize(10));
 
         // Check files
-        response = documentService.getClient().search(new ESSearchRequest().withIndex(getCrawlerName()).withSort("path.virtual"));
+        response = documentService.search(new ESSearchRequest().withIndex(getCrawlerName()).withSort("path.virtual"));
         assertThat(response.getTotalHits(), is(7L));
 
         Object document = parseJson(response.getJson());
@@ -102,7 +102,7 @@ public class FsCrawlerTestSubDirsIT extends AbstractFsCrawlerITCase {
 
 
         // Check folders
-        response = documentService.getClient().search(new ESSearchRequest().withIndex(getCrawlerName() + INDEX_SUFFIX_FOLDER).withSort("path.virtual"));
+        response = documentService.search(new ESSearchRequest().withIndex(getCrawlerName() + INDEX_SUFFIX_FOLDER).withSort("path.virtual"));
         assertThat(response.getTotalHits(), is(7L));
 
         document = parseJson(response.getJson());
@@ -142,7 +142,7 @@ public class FsCrawlerTestSubDirsIT extends AbstractFsCrawlerITCase {
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), subdirs+1, null);
 
         // Run aggs
-        ESSearchResponse response = documentService.getClient().search(new ESSearchRequest()
+        ESSearchResponse response = documentService.search(new ESSearchRequest()
                 .withIndex(getCrawlerName())
                 .withSize(0)
                 .withAggregation(new ESTermsAggregation("folders", "path.virtual.tree")));
@@ -156,7 +156,7 @@ public class FsCrawlerTestSubDirsIT extends AbstractFsCrawlerITCase {
         assertThat(buckets, iterableWithSize(10));
 
         // Check files
-        response = documentService.getClient().search(new ESSearchRequest()
+        response = documentService.search(new ESSearchRequest()
                 .withIndex(getCrawlerName())
                 .withSize(1000)
                 .withSort("path.virtual"));
@@ -169,7 +169,7 @@ public class FsCrawlerTestSubDirsIT extends AbstractFsCrawlerITCase {
         }
 
         // Check folders
-        response = documentService.getClient().search(new ESSearchRequest()
+        response = documentService.search(new ESSearchRequest()
                 .withIndex(getCrawlerName() + INDEX_SUFFIX_FOLDER)
                 .withSize(1000)
                 .withSort("path.virtual"));

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/AbstractWorkplaceSearchITCase.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/AbstractWorkplaceSearchITCase.java
@@ -44,6 +44,8 @@ import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -75,7 +77,7 @@ public abstract class AbstractWorkplaceSearchITCase extends AbstractFsCrawlerITC
         urlConnection.getResponseCode();
     }
 
-    protected FsCrawlerImpl startCrawler(final String jobName, FsSettings fsSettings, TimeValue duration)
+    protected FsCrawlerImpl startCrawler(final String jobName, final String customSourceId, FsSettings fsSettings, TimeValue duration)
             throws Exception {
         logger.info("  --> starting crawler [{}]", jobName);
 
@@ -99,7 +101,7 @@ public abstract class AbstractWorkplaceSearchITCase extends AbstractFsCrawlerITC
         refresh();
 
         try (WPSearchClient wpClient = createClient()) {
-            countTestHelper(wpClient, null, duration);
+            countTestHelper(wpClient, customSourceId, null, duration);
         }
 
         return crawler;
@@ -109,12 +111,13 @@ public abstract class AbstractWorkplaceSearchITCase extends AbstractFsCrawlerITC
      * Check that we have the expected number of docs or at least one if expected is null
      *
      * @param wpClient  Elasticsearch request to run.
+     * @param sourceId  The custom source id if any
      * @param expected  expected number of docs. Null if at least 1.
      * @param timeout   Time before we declare a failure
      * @return the search response if further tests are needed
      * @throws Exception in case of error
      */
-    public static String countTestHelper(final WPSearchClient wpClient, final Long expected, final TimeValue timeout) throws Exception {
+    public static String countTestHelper(final WPSearchClient wpClient, final String sourceId, final Long expected, final TimeValue timeout) throws Exception {
 
         final String[] response = new String[1];
 
@@ -127,7 +130,7 @@ public abstract class AbstractWorkplaceSearchITCase extends AbstractFsCrawlerITC
             // Let's search for entries
             try {
                 refresh();
-                response[0] = wpClient.search(null, null);
+                response[0] = wpClient.search(null, sourceId == null ? null : Collections.singletonMap("content_source_id", List.of(sourceId)));
             } catch (RuntimeException | IOException e) {
                 staticLogger.warn("error caught", e);
                 return -1;

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/WPSearchAllDocumentsIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/WPSearchAllDocumentsIT.java
@@ -110,7 +110,7 @@ public class WPSearchAllDocumentsIT extends AbstractWorkplaceSearchITCase {
             try (FsCrawlerImpl crawler = new FsCrawlerImpl(metadataDir, fsSettings, LOOP_INFINITE, false);
                  WPSearchClient wpClient = createClient()) {
                 crawler.start();
-                countTestHelper(wpClient, numFiles, TimeValue.timeValueMinutes(5));
+                countTestHelper(wpClient, customSourceId, numFiles, TimeValue.timeValueMinutes(5));
             }
 
             logger.info("  --> checking that files have expected content");

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/WPSearchAllDocumentsIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/WPSearchAllDocumentsIT.java
@@ -108,7 +108,7 @@ public class WPSearchAllDocumentsIT extends AbstractWorkplaceSearchITCase {
 
             // Create the crawler and wait until we have all docs
             try (FsCrawlerImpl crawler = new FsCrawlerImpl(metadataDir, fsSettings, LOOP_INFINITE, false);
-                 WPSearchClient wpClient = createClient();) {
+                 WPSearchClient wpClient = createClient()) {
                 crawler.start();
                 countTestHelper(wpClient, numFiles, TimeValue.timeValueMinutes(5));
             }
@@ -179,7 +179,7 @@ public class WPSearchAllDocumentsIT extends AbstractWorkplaceSearchITCase {
                 content == null ? "" : " and contains [" + content + "]");
 
         try (WPSearchClient client = createClient()) {
-            Map<String, List<String>> filters = new HashMap<>();
+            Map<String, Object> filters = new HashMap<>();
             if (filename != null) {
                 filters.put("name", Collections.singletonList(filename));
             }

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/WPSearchClientIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/WPSearchClientIT.java
@@ -22,6 +22,7 @@ package fr.pilato.elasticsearch.crawler.fs.test.integration.workplacesearch;
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.jayway.jsonpath.JsonPath;
 import fr.pilato.elasticsearch.crawler.fs.client.ESSearchRequest;
+import fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil;
 import fr.pilato.elasticsearch.crawler.fs.framework.TimeValue;
 import fr.pilato.elasticsearch.crawler.fs.thirdparty.wpsearch.WPSearchClient;
 import org.junit.After;
@@ -132,8 +133,8 @@ public class WPSearchClientIT extends AbstractWorkplaceSearchITCase {
             countTestHelper(client, 1L, TimeValue.timeValueSeconds(5));
 
             // We can now get the document
-            Object document = client.getDocument(id);
-            documentChecker(document, List.of("foo.txt"), List.of("Foo"));
+            String document = client.getDocument(id);
+            documentChecker(JsonUtil.parseJson(document), List.of("foo.txt"), List.of("Foo"));
 
             // Get a non existing document
             assertThat(client.getDocument("thisiddoesnotexist"), nullValue());

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/WPSearchClientIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/WPSearchClientIT.java
@@ -112,7 +112,7 @@ public class WPSearchClientIT extends AbstractWorkplaceSearchITCase {
             for (int i = 0; i < ids.size(); i++) {
                 // Let's remove one document and wait until it's done
                 logger.info("   --> removing one document");
-                client.destroyDocument(customSourceId, ids.get(i));
+                client.destroyDocument(ids.get(i));
                 countTestHelper(client, Long.valueOf(ids.size() - 1 - i), TimeValue.timeValueSeconds(5));
             }
         }
@@ -203,7 +203,7 @@ public class WPSearchClientIT extends AbstractWorkplaceSearchITCase {
             document.put("id", "testSendAndRemoveADocument");
             document.put("title", "To be deleted " + RandomizedTest.randomAsciiLettersOfLength(10));
             client.indexDocument(document);
-            client.destroyDocument(customSourceId, "testSendAndRemoveADocument");
+            client.destroyDocument("testSendAndRemoveADocument");
         }
     }
 

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/WPSearchClientIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/WPSearchClientIT.java
@@ -89,7 +89,7 @@ public class WPSearchClientIT extends AbstractWorkplaceSearchITCase {
             client.indexDocument(fakeDocumentAsMap(RandomizedTest.randomAsciiLettersOfLength(10), "Foo Bar Baz", "EN", "foobarbaz", "Foo", "Bar", "Baz"));
 
             // We need to wait until it's done
-            String json = countTestHelper(client, 4L, TimeValue.timeValueSeconds(5));
+            String json = countTestHelper(client, customSourceId, 4L, TimeValue.timeValueSeconds(5));
 
             // We read the ids of the documents so we can remove them then
             List<String> ids = JsonPath.read(json, "$.results[*].id.raw");
@@ -112,7 +112,7 @@ public class WPSearchClientIT extends AbstractWorkplaceSearchITCase {
                 // Let's remove one document and wait until it's done
                 logger.info("   --> removing one document");
                 client.destroyDocument(ids.get(i));
-                countTestHelper(client, Long.valueOf(ids.size() - 1 - i), TimeValue.timeValueSeconds(5));
+                countTestHelper(client, customSourceId, Long.valueOf(ids.size() - 1 - i), TimeValue.timeValueSeconds(5));
             }
         }
     }
@@ -130,7 +130,7 @@ public class WPSearchClientIT extends AbstractWorkplaceSearchITCase {
             client.indexDocument(fakeDocumentAsMap(id, "Foo", "EN", "foo", "Foo"));
 
             // We need to wait until it's done
-            countTestHelper(client, 1L, TimeValue.timeValueSeconds(5));
+            countTestHelper(client, customSourceId, 1L, TimeValue.timeValueSeconds(5));
 
             // We can now get the document
             String document = client.getDocument(id);

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/WPSearchIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/WPSearchIT.java
@@ -19,9 +19,14 @@
 
 package fr.pilato.elasticsearch.crawler.fs.test.integration.workplacesearch;
 
+import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.jayway.jsonpath.JsonPath;
+import fr.pilato.elasticsearch.crawler.fs.client.ESBoolQuery;
+import fr.pilato.elasticsearch.crawler.fs.client.ESMatchQuery;
+import fr.pilato.elasticsearch.crawler.fs.client.ESSearchHit;
 import fr.pilato.elasticsearch.crawler.fs.client.ESSearchRequest;
 import fr.pilato.elasticsearch.crawler.fs.client.ESSearchResponse;
+import fr.pilato.elasticsearch.crawler.fs.client.ESTermQuery;
 import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerIllegalConfigurationException;
 import fr.pilato.elasticsearch.crawler.fs.framework.TimeValue;
 import fr.pilato.elasticsearch.crawler.fs.service.FsCrawlerDocumentService;
@@ -33,8 +38,6 @@ import fr.pilato.elasticsearch.crawler.fs.settings.Server;
 import fr.pilato.elasticsearch.crawler.fs.settings.ServerUrl;
 import fr.pilato.elasticsearch.crawler.fs.settings.WorkplaceSearch;
 import fr.pilato.elasticsearch.crawler.fs.thirdparty.wpsearch.WPSearchClient;
-import org.hamcrest.Matcher;
-import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
@@ -44,13 +47,12 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Map;
+import java.util.List;
 
 import static fr.pilato.elasticsearch.crawler.fs.client.WorkplaceSearchClientUtil.generateDefaultCustomSourceName;
 import static fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil.parseJson;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.hamcrest.Matchers.containsString;
 
 /**
  * Test workplace search
@@ -219,6 +221,187 @@ public class WPSearchIT extends AbstractWorkplaceSearchITCase {
                 assertThat(JsonPath.read(document, "$.results[0].created_at.raw"), notNullValue());
                 assertThat(JsonPath.read(document, "$.results[0].last_modified.raw"), notNullValue());
             }
+        } catch (FsCrawlerIllegalConfigurationException e) {
+            Assume.assumeNoException("We don't have a compatible client for this version of the stack.", e);
+        }
+    }
+
+    @Test
+    public void testCrud() throws Exception {
+        String crawlerName = sourceName;
+        Fs fs = startCrawlerDefinition().build();
+        FsSettings fsSettings = FsSettings.builder(crawlerName)
+                .setFs(fs)
+                .setElasticsearch(Elasticsearch.builder()
+                        .setNodes(Collections.singletonList(new ServerUrl(testClusterUrl)))
+                        .setUsername(testClusterUser)
+                        .setPassword(testClusterPass)
+                        .build())
+                .setWorkplaceSearch(WorkplaceSearch.builder()
+                        .setServer(new ServerUrl(testWorkplaceUrl))
+                        .setBulkSize(1)
+                        .setFlushInterval(TimeValue.timeValueSeconds(1))
+                        .build())
+                .build();
+        sourceName = generateDefaultCustomSourceName(crawlerName);
+
+        try (FsCrawlerDocumentService documentService = new FsCrawlerDocumentServiceWorkplaceSearchImpl(metadataDir, fsSettings)) {
+            documentService.start();
+
+            String customSourceId = getSourceIdFromSourceName(sourceName);
+            assertThat("Custom source id should be found for source " + sourceName, customSourceId, notNullValue());
+
+            String id = RandomizedTest.randomAsciiLettersOfLength(10);
+
+            documentService.index(null, id, fakeDocument("Foo", "EN", "foo", "Foo"), null);
+            documentService.flush();
+
+            try (WPSearchClient client = createClient()) {
+                // We need to wait until it's done
+                countTestHelper(client, 1L, TimeValue.timeValueSeconds(5));
+            }
+
+            assertThat(documentService.exists(null, id), is(true));
+            assertThat(documentService.exists(null, "nonexistingid"), is(false));
+            ESSearchHit hit = documentService.get(null, id);
+
+            assertThat(hit, notNullValue());
+            documentChecker(hit.getSourceAsObject(), List.of("foo.txt"), List.of("Foo"));
+        } catch (FsCrawlerIllegalConfigurationException e) {
+            Assume.assumeNoException("We don't have a compatible client for this version of the stack.", e);
+        }
+    }
+
+    @Test
+    public void testSearch() throws Exception {
+        String crawlerName = sourceName;
+        Fs fs = startCrawlerDefinition().build();
+        FsSettings fsSettings = FsSettings.builder(crawlerName)
+                .setFs(fs)
+                .setElasticsearch(Elasticsearch.builder()
+                        .setNodes(Collections.singletonList(new ServerUrl(testClusterUrl)))
+                        .setUsername(testClusterUser)
+                        .setPassword(testClusterPass)
+                        .build())
+                .setWorkplaceSearch(WorkplaceSearch.builder()
+                        .setServer(new ServerUrl(testWorkplaceUrl))
+                        .setBulkSize(1)
+                        .setFlushInterval(TimeValue.timeValueSeconds(1))
+                        .build())
+                .build();
+        sourceName = generateDefaultCustomSourceName(crawlerName);
+
+        try (FsCrawlerDocumentService documentService = new FsCrawlerDocumentServiceWorkplaceSearchImpl(metadataDir, fsSettings)) {
+            documentService.start();
+
+            String customSourceId = getSourceIdFromSourceName(sourceName);
+            assertThat("Custom source id should be found for source " + sourceName, customSourceId, notNullValue());
+
+            String id = RandomizedTest.randomAsciiLettersOfLength(10);
+
+            documentService.index(null, id, fakeDocument("Foo", "EN", "foo", "Foo"), null);
+            documentService.index(null, RandomizedTest.randomAsciiLettersOfLength(10), fakeDocument("Bar", "FR", "bar", "Bar"), null);
+            documentService.index(null, RandomizedTest.randomAsciiLettersOfLength(10), fakeDocument("Baz", "DE", "baz", "Baz"), null);
+            documentService.index(null, RandomizedTest.randomAsciiLettersOfLength(10), fakeDocument("Foo Bar Baz", "EN", "foobarbaz", "Foo", "Bar", "Baz"), null);
+
+            try (WPSearchClient client = createClient()) {
+                // We need to wait until it's done
+                countTestHelper(client, 4L, TimeValue.timeValueSeconds(5));
+            }
+
+            {
+                // Search for all
+                ESSearchResponse response = documentService.search(new ESSearchRequest());
+                assertThat(response.getTotalHits(), is(4L));
+                assertThat(response.getHits(), hasSize(4));
+                for (ESSearchHit hit : response.getHits()) {
+                    assertThat(hit, notNullValue());
+                    documentChecker(hit.getSourceAsObject(),
+                            Arrays.asList("foo.txt", "bar.txt", "baz.txt", "foobarbaz.txt"),
+                            Arrays.asList("Foo", "Bar", "Baz", "Foo Bar Baz"));
+                }
+            }
+
+            {
+                // Search for full text (we don't specify a field name)
+                ESSearchResponse response = documentService.search(new ESSearchRequest().withESQuery(
+                        new ESMatchQuery(null, "foo")
+                ));
+                assertThat(response.getTotalHits(), is(2L));
+                assertThat(response.getHits(), hasSize(2));
+                for (ESSearchHit hit : response.getHits()) {
+                    assertThat(hit, notNullValue());
+                    documentChecker(hit.getSourceAsObject(),
+                            Arrays.asList("foo.txt", "foobarbaz.txt"),
+                            Arrays.asList("Foo", "Foo Bar Baz"));
+                }
+            }
+
+            {
+                // Filter (we specify a field name within a term query)
+                ESSearchResponse response = documentService.search(new ESSearchRequest().withESQuery(
+                        new ESTermQuery("author", "Mister Foo")
+                ));
+                assertThat(response.getTotalHits(), is(1L));
+                assertThat(response.getHits(), hasSize(1));
+                for (ESSearchHit hit : response.getHits()) {
+                    assertThat(hit, notNullValue());
+                    documentChecker(hit.getSourceAsObject(),
+                            Arrays.asList("foo.txt", "foobarbaz.txt"),
+                            Arrays.asList("Foo", "Foo Bar Baz"));
+                }
+            }
+
+            {
+                // Filter (we specify a field name within a term query)
+                ESSearchResponse response = documentService.search(new ESSearchRequest().withESQuery(
+                        new ESTermQuery("language", "EN")
+                ));
+                assertThat(response.getTotalHits(), is(2L));
+                assertThat(response.getHits(), hasSize(2));
+                for (ESSearchHit hit : response.getHits()) {
+                    assertThat(hit, notNullValue());
+                    documentChecker(hit.getSourceAsObject(),
+                            Arrays.asList("foo.txt", "foobarbaz.txt"),
+                            Arrays.asList("Foo", "Foo Bar Baz"));
+                }
+            }
+
+            {
+                // Filter (we specify a field name within 2 terms query wrapped in a bool query)
+                ESSearchResponse response = documentService.search(new ESSearchRequest().withESQuery(
+                        new ESBoolQuery()
+                                .addMust(new ESTermQuery("language", "EN"))
+                                .addMust(new ESTermQuery("author", "Mister Foo"))
+                ));
+                assertThat(response.getTotalHits(), is(1L));
+                assertThat(response.getHits(), hasSize(1));
+                for (ESSearchHit hit : response.getHits()) {
+                    assertThat(hit, notNullValue());
+                    documentChecker(hit.getSourceAsObject(),
+                            Arrays.asList("foo.txt", "foobarbaz.txt"),
+                            Arrays.asList("Foo", "Foo Bar Baz"));
+                }
+            }
+
+            {
+                // Full text with filters
+                ESSearchResponse response = documentService.search(new ESSearchRequest().withESQuery(
+                        new ESBoolQuery()
+                                .addMust(new ESTermQuery("language", "EN"))
+                                .addMust(new ESMatchQuery(null, "title"))
+                                .addMust(new ESTermQuery("author", "Mister Foo"))
+                ));
+                assertThat(response.getTotalHits(), is(1L));
+                assertThat(response.getHits(), hasSize(1));
+                for (ESSearchHit hit : response.getHits()) {
+                    assertThat(hit, notNullValue());
+                    documentChecker(hit.getSourceAsObject(),
+                            Arrays.asList("foo.txt", "foobarbaz.txt"),
+                            Arrays.asList("Foo", "Foo Bar Baz"));
+                }
+            }
+
         } catch (FsCrawlerIllegalConfigurationException e) {
             Assume.assumeNoException("We don't have a compatible client for this version of the stack.", e);
         }

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/WPSearchIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/WPSearchIT.java
@@ -266,7 +266,8 @@ public class WPSearchIT extends AbstractWorkplaceSearchITCase {
             ESSearchHit hit = documentService.get(null, id);
 
             assertThat(hit, notNullValue());
-            documentChecker(hit.getSourceAsObject(), List.of("foo.txt"), List.of("Foo"));
+            Object document = parseJson(hit.getSourceAsString());
+            documentChecker(document, List.of("foo.txt"), List.of("Foo"));
         } catch (FsCrawlerIllegalConfigurationException e) {
             Assume.assumeNoException("We don't have a compatible client for this version of the stack.", e);
         }

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/WPSearchIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/WPSearchIT.java
@@ -104,10 +104,10 @@ public class WPSearchIT extends AbstractWorkplaceSearchITCase {
             String customSourceId = getSourceIdFromSourceName(sourceName);
             assertThat("Custom source id should be found for source " + sourceName, customSourceId, notNullValue());
 
-            startCrawler(crawlerName, fsSettings, TimeValue.timeValueSeconds(10));
+            startCrawler(crawlerName, customSourceId, fsSettings, TimeValue.timeValueSeconds(10));
             try (WPSearchClient client = createClient()) {
                 // We need to wait until it's done
-                String json = countTestHelper(client, 1L, TimeValue.timeValueSeconds(1));
+                String json = countTestHelper(client, customSourceId, 1L, TimeValue.timeValueSeconds(1));
                 Object document = parseJson(json);
                 // We can check the meta data to check the custom source id
                 assertThat(JsonPath.read(document, "$.results[0]._meta.content_source_id"), is(customSourceId));
@@ -152,10 +152,10 @@ public class WPSearchIT extends AbstractWorkplaceSearchITCase {
         try (FsCrawlerDocumentService documentService = new FsCrawlerDocumentServiceWorkplaceSearchImpl(metadataDir, fsSettings)) {
             documentService.start();
 
-            startCrawler(crawlerName, fsSettings, TimeValue.timeValueSeconds(10));
+            startCrawler(crawlerName, customSourceId, fsSettings, TimeValue.timeValueSeconds(10));
             try (WPSearchClient client = createClient()) {
                 // We need to wait until it's done
-                String json = countTestHelper(client, 1L, TimeValue.timeValueSeconds(1));
+                String json = countTestHelper(client, customSourceId, 1L, TimeValue.timeValueSeconds(1));
                 Object document = parseJson(json);
                 // We can check the meta data to check the custom source id
                 assertThat(JsonPath.read(document, "$.results[0]._meta.content_source_id"), is(customSourceId));
@@ -201,10 +201,10 @@ public class WPSearchIT extends AbstractWorkplaceSearchITCase {
             String customSourceId = getSourceIdFromSourceName(sourceName);
             assertThat("Custom source id should be found for source " + sourceName, customSourceId, notNullValue());
 
-            startCrawler(getCrawlerName(), fsSettings, TimeValue.timeValueSeconds(10));
+            startCrawler(getCrawlerName(), customSourceId, fsSettings, TimeValue.timeValueSeconds(10));
             try (WPSearchClient client = createClient()) {
                 // We need to wait until it's done
-                String json = countTestHelper(client, 1L, TimeValue.timeValueSeconds(1));
+                String json = countTestHelper(client, customSourceId, 1L, TimeValue.timeValueSeconds(1));
                 Object document = parseJson(json);
                 // We can check the meta data to check the custom source id
                 assertThat(JsonPath.read(document, "$.results[0]._meta.content_source_id"), is(customSourceId));
@@ -259,7 +259,7 @@ public class WPSearchIT extends AbstractWorkplaceSearchITCase {
 
             try (WPSearchClient client = createClient()) {
                 // We need to wait until it's done
-                countTestHelper(client, 1L, TimeValue.timeValueSeconds(5));
+                countTestHelper(client, customSourceId, 1L, TimeValue.timeValueSeconds(5));
             }
 
             assertThat(documentService.exists(null, id), is(true));
@@ -308,7 +308,7 @@ public class WPSearchIT extends AbstractWorkplaceSearchITCase {
 
             try (WPSearchClient client = createClient()) {
                 // We need to wait until it's done
-                countTestHelper(client, 4L, TimeValue.timeValueSeconds(5));
+                countTestHelper(client, customSourceId, 4L, TimeValue.timeValueSeconds(5));
             }
 
             {
@@ -448,10 +448,10 @@ public class WPSearchIT extends AbstractWorkplaceSearchITCase {
             String customSourceId = getSourceIdFromSourceName(sourceName);
             assertThat("Custom source id should be found for source " + sourceName, customSourceId, notNullValue());
 
-            startCrawler(crawlerName, fsSettings, TimeValue.timeValueSeconds(10));
+            startCrawler(crawlerName, customSourceId, fsSettings, TimeValue.timeValueSeconds(10));
             try (WPSearchClient client = createClient()) {
                 // We need to wait until it's done
-                String json = countTestHelper(client, 2L, TimeValue.timeValueSeconds(1));
+                String json = countTestHelper(client, customSourceId, 2L, TimeValue.timeValueSeconds(1));
                 Object document = parseJson(json);
                 // We can check the meta data to check the custom source id
                 assertThat(JsonPath.read(document, "$.results[0]._meta.content_source_id"), is(customSourceId));

--- a/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/WPSearchIT.java
+++ b/integration-tests/it-common/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/WPSearchIT.java
@@ -28,6 +28,7 @@ import fr.pilato.elasticsearch.crawler.fs.client.ESSearchRequest;
 import fr.pilato.elasticsearch.crawler.fs.client.ESSearchResponse;
 import fr.pilato.elasticsearch.crawler.fs.client.ESTermQuery;
 import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerIllegalConfigurationException;
+import fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil;
 import fr.pilato.elasticsearch.crawler.fs.framework.TimeValue;
 import fr.pilato.elasticsearch.crawler.fs.service.FsCrawlerDocumentService;
 import fr.pilato.elasticsearch.crawler.fs.service.FsCrawlerDocumentServiceWorkplaceSearchImpl;
@@ -317,7 +318,7 @@ public class WPSearchIT extends AbstractWorkplaceSearchITCase {
                 assertThat(response.getHits(), hasSize(4));
                 for (ESSearchHit hit : response.getHits()) {
                     assertThat(hit, notNullValue());
-                    documentChecker(hit.getSourceAsObject(),
+                    documentChecker(JsonUtil.parseJson(hit.getSourceAsString()),
                             Arrays.asList("foo.txt", "bar.txt", "baz.txt", "foobarbaz.txt"),
                             Arrays.asList("Foo", "Bar", "Baz", "Foo Bar Baz"));
                 }
@@ -332,7 +333,7 @@ public class WPSearchIT extends AbstractWorkplaceSearchITCase {
                 assertThat(response.getHits(), hasSize(2));
                 for (ESSearchHit hit : response.getHits()) {
                     assertThat(hit, notNullValue());
-                    documentChecker(hit.getSourceAsObject(),
+                    documentChecker(JsonUtil.parseJson(hit.getSourceAsString()),
                             Arrays.asList("foo.txt", "foobarbaz.txt"),
                             Arrays.asList("Foo", "Foo Bar Baz"));
                 }
@@ -347,7 +348,7 @@ public class WPSearchIT extends AbstractWorkplaceSearchITCase {
                 assertThat(response.getHits(), hasSize(1));
                 for (ESSearchHit hit : response.getHits()) {
                     assertThat(hit, notNullValue());
-                    documentChecker(hit.getSourceAsObject(),
+                    documentChecker(JsonUtil.parseJson(hit.getSourceAsString()),
                             Arrays.asList("foo.txt", "foobarbaz.txt"),
                             Arrays.asList("Foo", "Foo Bar Baz"));
                 }
@@ -362,7 +363,7 @@ public class WPSearchIT extends AbstractWorkplaceSearchITCase {
                 assertThat(response.getHits(), hasSize(2));
                 for (ESSearchHit hit : response.getHits()) {
                     assertThat(hit, notNullValue());
-                    documentChecker(hit.getSourceAsObject(),
+                    documentChecker(JsonUtil.parseJson(hit.getSourceAsString()),
                             Arrays.asList("foo.txt", "foobarbaz.txt"),
                             Arrays.asList("Foo", "Foo Bar Baz"));
                 }
@@ -379,7 +380,7 @@ public class WPSearchIT extends AbstractWorkplaceSearchITCase {
                 assertThat(response.getHits(), hasSize(1));
                 for (ESSearchHit hit : response.getHits()) {
                     assertThat(hit, notNullValue());
-                    documentChecker(hit.getSourceAsObject(),
+                    documentChecker(JsonUtil.parseJson(hit.getSourceAsString()),
                             Arrays.asList("foo.txt", "foobarbaz.txt"),
                             Arrays.asList("Foo", "Foo Bar Baz"));
                 }
@@ -397,7 +398,7 @@ public class WPSearchIT extends AbstractWorkplaceSearchITCase {
                 assertThat(response.getHits(), hasSize(1));
                 for (ESSearchHit hit : response.getHits()) {
                     assertThat(hit, notNullValue());
-                    documentChecker(hit.getSourceAsObject(),
+                    documentChecker(JsonUtil.parseJson(hit.getSourceAsString()),
                             Arrays.asList("foo.txt", "foobarbaz.txt"),
                             Arrays.asList("Foo", "Foo Bar Baz"));
                 }

--- a/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/RestServer.java
+++ b/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/RestServer.java
@@ -50,8 +50,8 @@ public class RestServer {
             // in fr.pilato.elasticsearch.crawler.fs.rest package
             final ResourceConfig rc = new ResourceConfig()
                     .registerInstances(
-                            new ServerStatusApi(managementService.getClient(), settings),
-                            new UploadApi(settings, documentService.getClient()))
+                            new ServerStatusApi(managementService, settings),
+                            new UploadApi(settings, documentService))
                     .register(MultiPartFeature.class)
                     .register(RestJsonProvider.class)
                     .register(JacksonFeature.class)

--- a/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/ServerStatusApi.java
+++ b/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/ServerStatusApi.java
@@ -22,6 +22,7 @@ package fr.pilato.elasticsearch.crawler.fs.rest;
 
 import fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchClient;
 import fr.pilato.elasticsearch.crawler.fs.framework.Version;
+import fr.pilato.elasticsearch.crawler.fs.service.FsCrawlerManagementService;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -36,11 +37,11 @@ import java.io.IOException;
 @Path("/")
 public class ServerStatusApi extends RestApi {
 
-    private final ElasticsearchClient esClient;
+    private final FsCrawlerManagementService managementService;
     private final FsSettings settings;
 
-    ServerStatusApi(ElasticsearchClient esClient, FsSettings settings) {
-        this.esClient = esClient;
+    ServerStatusApi(FsCrawlerManagementService managementService, FsSettings settings) {
+        this.managementService = managementService;
         this.settings = settings;
     }
 
@@ -49,7 +50,7 @@ public class ServerStatusApi extends RestApi {
     public ServerStatusResponse getStatus() throws IOException {
         ServerStatusResponse status = new ServerStatusResponse();
         status.setVersion(Version.getVersion());
-        status.setElasticsearch(esClient.getVersion());
+        status.setElasticsearch(managementService.getVersion());
         status.setOk(true);
         status.setSettings(settings);
         return status;


### PR DESCRIPTION
Instead of making WorkplaceSearchClient extending ElasticsearchClient, we are now making all of them not dependant. So the ElasticsearchClient is not anymore injected into the WorkplaceSearchClient which can run on its own.