### PR TITLE
`latest` docker tag should be only the latest stable version

### DIFF
--- a/distribution/es7/pom.xml
+++ b/distribution/es7/pom.xml
@@ -18,9 +18,9 @@
         <!-- We use this tag to make easy using docker pull dadoonet/fscrawler:noocr -->
         <docker.noocr.tags.0>noocr</docker.noocr.tags.0>
 
-        <!-- The ocr version will be the default one for anyone trying docker pull dadoonet/fscrawler -->
-        <docker.ocr.tags.0>latest</docker.ocr.tags.0>
-        <docker.ocr.tags.1>${project.version}</docker.ocr.tags.1>
+        <!-- The ocr version will be the default one for anyone trying docker pull dadoonet/fscrawler:VERSION -->
+        <docker.ocr.tags.0>${project.version}</docker.ocr.tags.0>
+        <docker.ocr.tags.1>latest</docker.ocr.tags.1>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1116,6 +1116,10 @@
         </profile>
         <profile>
             <id>release</id>
+            <properties>
+                <!-- The ocr version will be the default one for anyone trying docker pull dadoonet/fscrawler -->
+                <docker.ocr.tags.1>latest</docker.ocr.tags.1>
+            </properties>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
When pulling the default docker image `dadoonet/fscrawler`, we are actually getting the latest build, which means the latest SNAPSHOT version.

```sh
docker pull dadoonet/fscrawler
```

With this change, we are making sure that we only use the `latest` tag when doing the release.

People can still get the latest SNAPSHOT version by running:

```sh
docker pull dadoonet/fscrawler:2.8-SNAPSHOT
```

Closes #1227