### PR TITLE
Fixes #1229 Added procps apt package to container install

### DIFF
--- a/distribution/src/main/docker/Dockerfile
+++ b/distribution/src/main/docker/Dockerfile
@@ -6,6 +6,7 @@ RUN set -ex \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
     "gettext-base=0.19.*" \
+    procps \
     ${langsPkg} \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
procps contains the `ps` command. By default slim-buster does not have it installed.

This broke with Commit 9635e309369ffe8650d606b434aa10a826dec4d2 when ps was used to determine if a process is running.

