### PR TITLE
fix: not working optional libraries (e.g. jpeg2000)

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -45,6 +45,8 @@
         <docker.ocr.assembly.descriptor>${docker.noocr.assembly.descriptor}</docker.ocr.assembly.descriptor>
         <docker.ocr.assembly.mode>${docker.noocr.assembly.mode}</docker.ocr.assembly.mode>
         <docker.ocr.args.langsPkg>imagemagick tesseract-ocr tesseract-ocr-all</docker.ocr.args.langsPkg>
+
+        <distribution.mainClassName>fr.pilato.elasticsearch.crawler.fs.cli.FsCrawler</distribution.mainClassName>
     </properties>
 
     <dependencies>
@@ -85,8 +87,7 @@
                 <configuration>
                     <archive>
                         <manifest>
-                            <addClasspath>true</addClasspath>
-                            <mainClass>fr.pilato.elasticsearch.crawler.fs.cli.FsCrawler</mainClass>
+                            <mainClass>${distribution.mainClassName}</mainClass>
                         </manifest>
                     </archive>
                 </configuration>

--- a/distribution/src/main/scripts/fscrawler
+++ b/distribution/src/main/scripts/fscrawler
@@ -52,4 +52,4 @@ esac
 # If the user defined FS_JAVA_OPTS, we will use it to start the crawler
 JAVA_OPTS="$JAVA_OPTS $FS_JAVA_OPTS"
 
-exec "$JAVA" ${JAVA_OPTS} -cp "$FS_CLASSPATH" -jar "$FS_HOME/lib/${project.build.finalName}.jar" "$@"
+exec "$JAVA" ${JAVA_OPTS} -cp "$FS_CLASSPATH" "${distribution.mainClassName}" "$@"

--- a/distribution/src/main/scripts/fscrawler.bat
+++ b/distribution/src/main/scripts/fscrawler.bat
@@ -66,7 +66,7 @@ FOR /F "usebackq tokens=1* delims= " %%A IN (!params!) DO (
 	)
 )
 
-%JAVA% %JAVA_OPTS% -cp "%FS_CLASSPATH%" -jar "%FS_HOME%/lib/${project.build.finalName}.jar" !newparams!
+%JAVA% %JAVA_OPTS% -cp "%FS_CLASSPATH%" "${distribution.mainClassName}" !newparams!
 REM Return to original directory
 POPD
 ENDLOCAL


### PR DESCRIPTION
Fixes #927 

This MR fixes that optional libraries, for example `com.github.jai-imageio.jai-imageio-jpeg2000` not loading.

The problem is that only libraries in `Class-Path` in `MANIFEST.MF` in `fscrawler-es7-2.X.jar` are loaded and not the supplied ones in `-cp`.

`-cp` and `-jar` are mutually exclusive arguments where `-jar` has higher priority. With `-jar` the JVM uses the `MANIFEST.MF`'s  `Class-Path` exclusively and the manifest does not contain `jpeg2000` so it isn't loaded.