### PR TITLE
Revert "Remove `a52f2ab6-086b-4285-a7a1-78ecdc6404ba` vulnerability id"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -405,12 +405,6 @@
                     <groupId>org.sonatype.ossindex.maven</groupId>
                     <artifactId>ossindex-maven-plugin</artifactId>
                     <version>3.1.0</version>
-                    <configuration>
-                        <!-- Todo remove this when https://github.com/OSSIndex/vulns/issues/204 is fixed -->
-                        <excludeVulnerabilityIds>
-                            <excludeVulnerabilityId>a52f2ab6-086b-4285-a7a1-78ecdc6404ba</excludeVulnerabilityId>
-                        </excludeVulnerabilityIds>
-                    </configuration>
                     <executions>
                         <execution>
                             <id>audit-dependencies</id>


### PR DESCRIPTION
Reverts dadoonet/fscrawler#1275 as https://github.com/OSSIndex/vulns/issues/204 has been fixed.