### PR TITLE
Add more default displayed fields

### DIFF
--- a/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/7/_wpsearch_settings.json
+++ b/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/7/_wpsearch_settings.json
@@ -22,6 +22,8 @@
     "subtitle_field": "name",
     "description_field": "body",
     "url_field": "url",
+    "media_type_field": "mime_type",
+    "created_by_field": "author",
     "detail_fields": [
       {
         "field_name": "author",

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsMappingTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsMappingTest.java
@@ -687,6 +687,8 @@ public class FsMappingTest extends AbstractFSCrawlerMetadataTestCase {
                 "    \"subtitle_field\": \"name\",\n" +
                 "    \"description_field\": \"body\",\n" +
                 "    \"url_field\": \"url\",\n" +
+                "    \"media_type_field\": \"mime_type\",\n" +
+                "    \"created_by_field\": \"author\",\n" +
                 "    \"detail_fields\": [\n" +
                 "      {\n" +
                 "        \"field_name\": \"author\",\n" +


### PR DESCRIPTION
The WorkplaceSearch documentation allows having more fields set by default. See https://www.elastic.co/guide/en/workplace-search/current/workplace-search-content-sources-api.html#update-content-source-api-request-params

Here we are now adding:

* `media_type_field` which will map to `mime_type`
* `created_by_field` which will map to `author`