### PR TITLE
Switch to the new sonatype service

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,8 +54,8 @@ downloadUrlV6 = "https://repo1.maven.org/maven2/fr/pilato/elasticsearch/crawler/
 downloadUrlV7 = "https://repo1.maven.org/maven2/fr/pilato/elasticsearch/crawler/fscrawler-es7/%s/fscrawler-es7-%s.zip" % (version, version)
 
 if release.endswith('-SNAPSHOT'):
-    downloadUrlV6 = "https://oss.sonatype.org/content/repositories/snapshots/fr/pilato/elasticsearch/crawler/fscrawler-es6/%s/" % release
-    downloadUrlV7 = "https://oss.sonatype.org/content/repositories/snapshots/fr/pilato/elasticsearch/crawler/fscrawler-es7/%s/" % release
+    downloadUrlV6 = "https://s01.oss.sonatype.org/content/repositories/snapshots/fr/pilato/elasticsearch/crawler/fscrawler-es6/%s/" % release
+    downloadUrlV7 = "https://s01.oss.sonatype.org/content/repositories/snapshots/fr/pilato/elasticsearch/crawler/fscrawler-es7/%s/" % release
 
 # -- General configuration ---------------------------------------------------
 
@@ -252,8 +252,8 @@ rst_prolog = rst_prolog + """
 .. _Download_URL_V7: {fmt_downloadUrl_V7}
 .. _Maven_Central_V6: https://repo1.maven.org/maven2/fr/pilato/elasticsearch/crawler/fscrawler-es6/
 .. _Maven_Central_V7: https://repo1.maven.org/maven2/fr/pilato/elasticsearch/crawler/fscrawler-es7/
-.. _Sonatype_V6: https://oss.sonatype.org/content/repositories/snapshots/fr/pilato/elasticsearch/crawler/fscrawler-es6/
-.. _Sonatype_V7: https://oss.sonatype.org/content/repositories/snapshots/fr/pilato/elasticsearch/crawler/fscrawler-es7/
+.. _Sonatype_V6: https://s01.oss.sonatype.org/content/repositories/snapshots/fr/pilato/elasticsearch/crawler/fscrawler-es6/
+.. _Sonatype_V7: https://s01.oss.sonatype.org/content/repositories/snapshots/fr/pilato/elasticsearch/crawler/fscrawler-es7/
 """.format(
 fmt_tika_version=config.get('3rdParty', 'TikaVersion'),
 fmt_es_version6=config.get('3rdParty', 'ElasticsearchVersion6'),

--- a/docs/source/dev/release.rst
+++ b/docs/source/dev/release.rst
@@ -14,7 +14,7 @@ The release script will:
 * Build the final artifacts using release profile (signing artifacts and generating all needed files)
 * Tag the version
 * Prepare the announcement email
-* Deploy to https://oss.sonatype.org/
+* Deploy to https://s01.oss.sonatype.org/
 * Prepare the next SNAPSHOT version
 * Commit the change
 * Release the Sonatype staging repository

--- a/pom.xml
+++ b/pom.xml
@@ -422,7 +422,7 @@
                     <extensions>true</extensions>
                     <configuration>
                         <serverId>sonatype-nexus-staging</serverId>
-                        <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                        <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                         <autoReleaseAfterClose>false</autoReleaseAfterClose>
                     </configuration>
                 </plugin>
@@ -997,11 +997,11 @@
     <distributionManagement>
         <snapshotRepository>
             <id>sonatype-nexus-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
             <id>sonatype-nexus-staging</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
 
@@ -1018,7 +1018,7 @@
         <repository>
             <id>oss-snapshots</id>
             <name>Sonatype OSS Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
             <releases><enabled>false</enabled></releases>
             <snapshots><enabled>true</enabled></snapshots>
         </repository>

--- a/release.sh
+++ b/release.sh
@@ -188,7 +188,7 @@ git checkout -q ${CURRENT_BRANCH}
 if [ ${DRY_RUN} -eq 0 ]
 then
     echo "Inspect Sonatype staging repositories"
-    open https://oss.sonatype.org/#stagingRepositories
+    open https://s01.oss.sonatype.org/#stagingRepositories
 
     if promptyn "Is the staging repository ok?"
     then


### PR DESCRIPTION
We were using `oss.sonatype.org` and we now can use `s01.oss.sonatype.org`.