### PR TITLE
`fs.ocr.enabled` is always false

### DIFF
--- a/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaInstance.java
+++ b/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaInstance.java
@@ -74,6 +74,7 @@ public class TikaInstance {
      * @param fs fs settings
      */
     private static void initTika(Fs fs) {
+        ocrActivated = fs.getOcr().isEnabled();
         initContext(fs);
         initParser(fs);
     }
@@ -88,9 +89,7 @@ public class TikaInstance {
             // PDF content might be extracted multiple times.
             pdfParser.getPDFParserConfig().setExtractBookmarksText(false);
 
-            ocrActivated = fs.getOcr().isEnabled();
-
-            if (ocrActivated) {
+             if (ocrActivated) {
                 logger.debug("OCR is activated.");
                 ocrParser = new TesseractOCRParser();
                 if (fs.getOcr().getPath() != null) {


### PR DESCRIPTION
…e within initContext Method)

Tesseract does not work properly in ocr enable.
The reason is in TikaInstance.java ocrActivated = fs.getOcr().isEnabled(); there is a problem with
It operates in the order of initTika > initContext > initParser,
but the ocrActivated check is in initParser,
so it is always false in initContext.

thus
```
     private static void initTika(Fs fs) {
        ocrActivated = fs.getOcr().isEnabled();  <- insert
         initContext(fs);
         initParser(fs);
     }

    private static void initParser(Fs fs) {
        if (parser == null) {
            PDFParser pdfParser = new PDFParser();
            DefaultParser defaultParser;
            TesseractOCRParser ocrParser;

            // To solve https://issues.apache.org/jira/browse/TIKA-3364
            // PDF content might be extracted multiple times.
            pdfParser.getPDFParserConfig().setExtractBookmarksText(false);

//            ocrActivated = fs.getOcr().isEnabled();   <- delete
```
correction is required as