### PR TITLE
Switch from openjdk to eclipse-temurin

### DIFF
--- a/distribution/src/main/docker/Dockerfile
+++ b/distribution/src/main/docker/Dockerfile
@@ -1,12 +1,13 @@
-FROM openjdk:15.0.2-jdk-slim-buster
+FROM eclipse-temurin:17-jdk
 
 ARG langsPkg
 
 RUN set -ex \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    "gettext-base=0.19.*" \
+    gettext-base \
     procps \
+    curl \
     ${langsPkg} \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/distribution/src/main/docker/Dockerfile
+++ b/distribution/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jdk
+FROM openjdk:17-jdk-slim-bullseye
 
 ARG langsPkg
 


### PR DESCRIPTION
This PR proposes the following changes:

* Change from openjdk to the LTS distribution of the eclipse foundation (this also makes sure the undelying Debian distribution is updated to current stable)
* Remove version pinning of gettext-base for Debian bullseye compat
* Add curl to use docker healthchecks when using fscrawler in rest mode