### PR TITLE
Update WorkplaceSearchClientUtil.java

### DIFF
--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/WorkplaceSearchClientUtil.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/WorkplaceSearchClientUtil.java
@@ -67,7 +67,7 @@ public abstract class WorkplaceSearchClientUtil {
         return name;
     }
 
-    public static String toRFC3339(Date d) {
+    public synchronized static String toRFC3339(Date d) {
         if (logger.isDebugEnabled() && d != null) {
             String format = RFC_3339.format(d);
             String finalDate = format.replaceAll("(\\d\\d)(\\d\\d)$", "$1:$2");


### PR DESCRIPTION
Hi @dadoonet,
My verification tool showed me that it is a pretty serious mistake when using the SimpleDateFormat data type. The error occurs when the SimpleDateFormat variable is changed a certain number of times and its format is not preserved. After researching the error a bit, I found the solution to define the function toRFC3339(Date d) as synchronized.