### PR TITLE
Increase cvss score threshold

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1038,6 +1038,9 @@
                     <plugin>
                         <groupId>org.sonatype.ossindex.maven</groupId>
                         <artifactId>ossindex-maven-plugin</artifactId>
+                        <configuration>
+                            <cvssScoreThreshold>7.0</cvssScoreThreshold>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Instead of failing when we have a positive score (`>0`), we only fail above 7.0.