### PR TITLE
Downgrade Tika to 2.4.0 (Ocr issue)

### DIFF
--- a/docs/source/fscrawler.ini
+++ b/docs/source/fscrawler.ini
@@ -2,7 +2,7 @@
 Version=2.10-SNAPSHOT
 
 [3rdParty]
-TikaVersion=2.4.1
+TikaVersion=2.4.0
 ElasticsearchVersion6=6.8.23
 ElasticsearchVersion7=7.17.6
 ElasticsearchVersion8=8.4.1

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <elasticsearch6.version>6.8.23</elasticsearch6.version>
         <elasticsearch.version>${elasticsearch8.version}</elasticsearch.version>
 
-        <tika.version>2.4.1</tika.version>
+        <tika.version>2.4.0</tika.version>
         <jackson.version>2.13.4</jackson.version>
         <jsonpath.version>2.7.0</jsonpath.version>
         <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
Closes #1480.
Related to #1513.