### PR TITLE
Update Workplace Search mapping

### DIFF
--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/WorkplaceSearchClientUtil.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/WorkplaceSearchClientUtil.java
@@ -88,29 +88,34 @@ public abstract class WorkplaceSearchClientUtil {
         // Id
         document.put("id", id);
 
-        // Index content
+        // General Fields
+        // https://www.elastic.co/guide/en/workplace-search/current/workplace-search-custom-api-sources.html#_general_fields
         document.put("body", doc.getContent());
-
-        // Index main metadata
+        document.put("comments", doc.getMeta().getComments());
+        // description field is not set
+        document.put("tags", doc.getMeta().getKeywords());
         // We use the name of the file if no title has been found in the document metadata
         document.put("title", FsCrawlerUtil.isNullOrEmpty(doc.getMeta().getTitle()) ? doc.getFile().getFilename() : doc.getMeta().getTitle());
-        document.put("author", doc.getMeta().getAuthor());
-        document.put("keywords", doc.getMeta().getKeywords());
-        document.put("language", doc.getMeta().getLanguage());
-        document.put("comments", doc.getMeta().getComments());
-
-        // Index main file attributes
-        document.put("name", doc.getFile().getFilename());
-        document.put("mime_type", doc.getFile().getContentType());
-        document.put("extension", doc.getFile().getExtension());
-        document.put("size", doc.getFile().getFilesize());
-        document.put("text_size", doc.getFile().getIndexedChars());
-        document.put("last_modified", toRFC3339(doc.getFile().getLastModified()));
-        document.put("created_at", toRFC3339(doc.getFile().getCreated()));
-
-        // Index main path attributes
+        document.put("type", "File");
         document.put("url", urlPrefix + doc.getPath().getVirtual());
+
+        // File/Document Fields
+        // https://www.elastic.co/guide/en/workplace-search/current/workplace-search-custom-api-sources.html#_filedocument_fields
+        document.put("extension", doc.getFile().getExtension());
+        document.put("mime_type", doc.getFile().getContentType());
         document.put("path", doc.getPath().getReal());
+        document.put("size", doc.getFile().getFilesize());
+
+        // People/Human Fields
+        // https://www.elastic.co/guide/en/workplace-search/current/workplace-search-custom-api-sources.html#_peoplehuman_fields
+        document.put("created_by", doc.getMeta().getAuthor());
+
+        // Non Workplace Search Standard Fields
+        document.put("name", doc.getFile().getFilename());
+        document.put("language", doc.getMeta().getLanguage());
+        document.put("text_size", doc.getFile().getIndexedChars());
+        document.put("created_at", toRFC3339(doc.getFile().getCreated()));
+        document.put("last_modified", toRFC3339(doc.getFile().getLastModified()));
 
         return document;
     }

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/WPSearchIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/workplacesearch/WPSearchIT.java
@@ -323,7 +323,7 @@ public class WPSearchIT extends AbstractWorkplaceSearchITCase {
             {
                 // Filter (we specify a field name within a term query)
                 ESSearchResponse response = documentService.search(new ESSearchRequest().withESQuery(
-                        new ESTermQuery("author", "Mister Foo")
+                        new ESTermQuery("created_by", "Mister Foo")
                 ));
                 assertThat(response.getTotalHits(), is(1L));
                 assertThat(response.getHits(), hasSize(1));
@@ -355,7 +355,7 @@ public class WPSearchIT extends AbstractWorkplaceSearchITCase {
                 ESSearchResponse response = documentService.search(new ESSearchRequest().withESQuery(
                         new ESBoolQuery()
                                 .addMust(new ESTermQuery("language", "EN"))
-                                .addMust(new ESTermQuery("author", "Mister Foo"))
+                                .addMust(new ESTermQuery("created_by", "Mister Foo"))
                 ));
                 assertThat(response.getTotalHits(), is(1L));
                 assertThat(response.getHits(), hasSize(1));
@@ -373,7 +373,7 @@ public class WPSearchIT extends AbstractWorkplaceSearchITCase {
                         new ESBoolQuery()
                                 .addMust(new ESTermQuery("language", "EN"))
                                 .addMust(new ESMatchQuery(null, "title"))
-                                .addMust(new ESTermQuery("author", "Mister Foo"))
+                                .addMust(new ESTermQuery("created_by", "Mister Foo"))
                 ));
                 assertThat(response.getTotalHits(), is(1L));
                 assertThat(response.getHits(), hasSize(1));

--- a/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/7/_wpsearch_settings.json
+++ b/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/7/_wpsearch_settings.json
@@ -1,21 +1,23 @@
 {
   "name": "SOURCE_NAME",
+  "context": "organization",
   "schema": {
-    "title": "text",
-    "name": "text",
     "body": "text",
-    "url": "text",
-    "author": "text",
-    "keywords": "text",
-    "language": "text",
     "comments": "text",
-    "mime_type": "text",
+    "tags": "text",
+    "title": "text",
+    "type": "text",
+    "url": "text",
     "extension": "text",
+    "mime_type": "text",
+    "path": "text",
     "size": "number",
+    "created_by": "text",
+    "name": "text",
+    "language": "text",
     "text_size": "number",
-    "last_modified": "date",
     "created_at": "date",
-    "path": "text"
+    "last_modified": "date"
   },
   "display": {
     "title_field": "title",
@@ -23,15 +25,15 @@
     "description_field": "body",
     "url_field": "url",
     "media_type_field": "mime_type",
-    "created_by_field": "author",
+    "created_by_field": "created_by",
     "detail_fields": [
       {
-        "field_name": "author",
+        "field_name": "created_by",
         "label": "Author"
       },
       {
-        "field_name": "keywords",
-        "label": "Keywords"
+        "field_name": "tags",
+        "label": "Tags"
       },
       {
         "field_name": "language",
@@ -48,10 +50,6 @@
       {
         "field_name": "comments",
         "label": "Comments"
-      },
-      {
-        "field_name": "mime_type",
-        "label": "Mime Type"
       },
       {
         "field_name": "extension",
@@ -75,6 +73,37 @@
       }
     ],
     "color": "#000000"
+  },
+  "facets":
+  {
+    "overrides":
+    [
+      {
+        "display_name": "Media Type",
+        "field": "mime_type",
+        "enabled": true
+      },
+      {
+        "display_name": "Extension",
+        "field": "extension",
+        "enabled": true
+      },
+      {
+        "display_name": "Tags",
+        "field": "tags",
+        "enabled": true
+      },
+      {
+        "display_name": "Created By",
+        "field": "created_by",
+        "enabled": true
+      },
+      {
+        "display_name": "Language",
+        "field": "language",
+        "enabled": true
+      }
+    ]
   },
   "is_searchable": true
 }

--- a/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/8/_wpsearch_settings.json
+++ b/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/_default/8/_wpsearch_settings.json
@@ -1,21 +1,23 @@
 {
   "name": "SOURCE_NAME",
+  "context": "organization",
   "schema": {
-    "title": "text",
-    "name": "text",
     "body": "text",
-    "url": "text",
-    "author": "text",
-    "keywords": "text",
-    "language": "text",
     "comments": "text",
-    "mime_type": "text",
+    "tags": "text",
+    "title": "text",
+    "type": "text",
+    "url": "text",
     "extension": "text",
+    "mime_type": "text",
+    "path": "text",
     "size": "number",
+    "created_by": "text",
+    "name": "text",
+    "language": "text",
     "text_size": "number",
-    "last_modified": "date",
     "created_at": "date",
-    "path": "text"
+    "last_modified": "date"
   },
   "display": {
     "title_field": "title",
@@ -23,15 +25,15 @@
     "description_field": "body",
     "url_field": "url",
     "media_type_field": "mime_type",
-    "created_by_field": "author",
+    "created_by_field": "created_by",
     "detail_fields": [
       {
-        "field_name": "author",
+        "field_name": "created_by",
         "label": "Author"
       },
       {
-        "field_name": "keywords",
-        "label": "Keywords"
+        "field_name": "tags",
+        "label": "Tags"
       },
       {
         "field_name": "language",
@@ -48,10 +50,6 @@
       {
         "field_name": "comments",
         "label": "Comments"
-      },
-      {
-        "field_name": "mime_type",
-        "label": "Mime Type"
       },
       {
         "field_name": "extension",
@@ -75,6 +73,37 @@
       }
     ],
     "color": "#000000"
+  },
+  "facets":
+  {
+    "overrides":
+    [
+      {
+        "display_name": "Media Type",
+        "field": "mime_type",
+        "enabled": true
+      },
+      {
+        "display_name": "Extension",
+        "field": "extension",
+        "enabled": true
+      },
+      {
+        "display_name": "Tags",
+        "field": "tags",
+        "enabled": true
+      },
+      {
+        "display_name": "Created By",
+        "field": "created_by",
+        "enabled": true
+      },
+      {
+        "display_name": "Language",
+        "field": "language",
+        "enabled": true
+      }
+    ]
   },
   "is_searchable": true
 }

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsMappingTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsMappingTest.java
@@ -665,6 +665,7 @@ public class FsMappingTest extends AbstractFSCrawlerMetadataTestCase {
         logger.info("Settings used for workplace search v7 : " + settings);
         assertThat(settings, is("{\n" +
                 "  \"name\": \"SOURCE_NAME\",\n" +
+                "  \"context\": \"organization\",\n" +
                 "  \"schema\": {\n" +
                 "    \"body\": \"text\",\n" +
                 "    \"comments\": \"text\",\n" +
@@ -716,10 +717,6 @@ public class FsMappingTest extends AbstractFSCrawlerMetadataTestCase {
                 "        \"label\": \"Comments\"\n" +
                 "      },\n" +
                 "      {\n" +
-                "        \"field_name\": \"mime_type\",\n" +
-                "        \"label\": \"Mime Type\"\n" +
-                "      },\n" +
-                "      {\n" +
                 "        \"field_name\": \"extension\",\n" +
                 "        \"label\": \"Extension\"\n" +
                 "      },\n" +
@@ -741,6 +738,37 @@ public class FsMappingTest extends AbstractFSCrawlerMetadataTestCase {
                 "      }\n" +
                 "    ],\n" +
                 "    \"color\": \"#000000\"\n" +
+                "  },\n" +
+                "  \"facets\":\n" +
+                "  {\n" +
+                "    \"overrides\":\n" +
+                "    [\n" +
+                "      {\n" +
+                "        \"display_name\": \"Media Type\",\n" +
+                "        \"field\": \"mime_type\",\n" +
+                "        \"enabled\": true\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"display_name\": \"Extension\",\n" +
+                "        \"field\": \"extension\",\n" +
+                "        \"enabled\": true\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"display_name\": \"Tags\",\n" +
+                "        \"field\": \"tags\",\n" +
+                "        \"enabled\": true\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"display_name\": \"Created By\",\n" +
+                "        \"field\": \"created_by\",\n" +
+                "        \"enabled\": true\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"display_name\": \"Language\",\n" +
+                "        \"field\": \"language\",\n" +
+                "        \"enabled\": true\n" +
+                "      }\n" +
+                "    ]\n" +
                 "  },\n" +
                 "  \"is_searchable\": true\n" +
                 "}\n"));
@@ -1070,6 +1098,7 @@ public class FsMappingTest extends AbstractFSCrawlerMetadataTestCase {
         logger.info("Settings used for workplace search v8 : " + settings);
         assertThat(settings, is("{\n" +
                 "  \"name\": \"SOURCE_NAME\",\n" +
+                "  \"context\": \"organization\",\n" +
                 "  \"schema\": {\n" +
                 "    \"body\": \"text\",\n" +
                 "    \"comments\": \"text\",\n" +
@@ -1121,10 +1150,6 @@ public class FsMappingTest extends AbstractFSCrawlerMetadataTestCase {
                 "        \"label\": \"Comments\"\n" +
                 "      },\n" +
                 "      {\n" +
-                "        \"field_name\": \"mime_type\",\n" +
-                "        \"label\": \"Mime Type\"\n" +
-                "      },\n" +
-                "      {\n" +
                 "        \"field_name\": \"extension\",\n" +
                 "        \"label\": \"Extension\"\n" +
                 "      },\n" +
@@ -1146,6 +1171,37 @@ public class FsMappingTest extends AbstractFSCrawlerMetadataTestCase {
                 "      }\n" +
                 "    ],\n" +
                 "    \"color\": \"#000000\"\n" +
+                "  },\n" +
+                "  \"facets\":\n" +
+                "  {\n" +
+                "    \"overrides\":\n" +
+                "    [\n" +
+                "      {\n" +
+                "        \"display_name\": \"Media Type\",\n" +
+                "        \"field\": \"mime_type\",\n" +
+                "        \"enabled\": true\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"display_name\": \"Extension\",\n" +
+                "        \"field\": \"extension\",\n" +
+                "        \"enabled\": true\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"display_name\": \"Tags\",\n" +
+                "        \"field\": \"tags\",\n" +
+                "        \"enabled\": true\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"display_name\": \"Created By\",\n" +
+                "        \"field\": \"created_by\",\n" +
+                "        \"enabled\": true\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"display_name\": \"Language\",\n" +
+                "        \"field\": \"language\",\n" +
+                "        \"enabled\": true\n" +
+                "      }\n" +
+                "    ]\n" +
                 "  },\n" +
                 "  \"is_searchable\": true\n" +
                 "}\n"));

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsMappingTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsMappingTest.java
@@ -666,21 +666,22 @@ public class FsMappingTest extends AbstractFSCrawlerMetadataTestCase {
         assertThat(settings, is("{\n" +
                 "  \"name\": \"SOURCE_NAME\",\n" +
                 "  \"schema\": {\n" +
-                "    \"title\": \"text\",\n" +
-                "    \"name\": \"text\",\n" +
                 "    \"body\": \"text\",\n" +
-                "    \"url\": \"text\",\n" +
-                "    \"author\": \"text\",\n" +
-                "    \"keywords\": \"text\",\n" +
-                "    \"language\": \"text\",\n" +
                 "    \"comments\": \"text\",\n" +
-                "    \"mime_type\": \"text\",\n" +
+                "    \"tags\": \"text\",\n" +
+                "    \"title\": \"text\",\n" +
+                "    \"type\": \"text\",\n" +
+                "    \"url\": \"text\",\n" +
                 "    \"extension\": \"text\",\n" +
+                "    \"mime_type\": \"text\",\n" +
+                "    \"path\": \"text\",\n" +
                 "    \"size\": \"number\",\n" +
+                "    \"created_by\": \"text\",\n" +
+                "    \"name\": \"text\",\n" +
+                "    \"language\": \"text\",\n" +
                 "    \"text_size\": \"number\",\n" +
-                "    \"last_modified\": \"date\",\n" +
                 "    \"created_at\": \"date\",\n" +
-                "    \"path\": \"text\"\n" +
+                "    \"last_modified\": \"date\"\n" +
                 "  },\n" +
                 "  \"display\": {\n" +
                 "    \"title_field\": \"title\",\n" +
@@ -688,15 +689,15 @@ public class FsMappingTest extends AbstractFSCrawlerMetadataTestCase {
                 "    \"description_field\": \"body\",\n" +
                 "    \"url_field\": \"url\",\n" +
                 "    \"media_type_field\": \"mime_type\",\n" +
-                "    \"created_by_field\": \"author\",\n" +
+                "    \"created_by_field\": \"created_by\",\n" +
                 "    \"detail_fields\": [\n" +
                 "      {\n" +
-                "        \"field_name\": \"author\",\n" +
+                "        \"field_name\": \"created_by\",\n" +
                 "        \"label\": \"Author\"\n" +
                 "      },\n" +
                 "      {\n" +
-                "        \"field_name\": \"keywords\",\n" +
-                "        \"label\": \"Keywords\"\n" +
+                "        \"field_name\": \"tags\",\n" +
+                "        \"label\": \"Tags\"\n" +
                 "      },\n" +
                 "      {\n" +
                 "        \"field_name\": \"language\",\n" +
@@ -1070,21 +1071,22 @@ public class FsMappingTest extends AbstractFSCrawlerMetadataTestCase {
         assertThat(settings, is("{\n" +
                 "  \"name\": \"SOURCE_NAME\",\n" +
                 "  \"schema\": {\n" +
-                "    \"title\": \"text\",\n" +
-                "    \"name\": \"text\",\n" +
                 "    \"body\": \"text\",\n" +
-                "    \"url\": \"text\",\n" +
-                "    \"author\": \"text\",\n" +
-                "    \"keywords\": \"text\",\n" +
-                "    \"language\": \"text\",\n" +
                 "    \"comments\": \"text\",\n" +
-                "    \"mime_type\": \"text\",\n" +
+                "    \"tags\": \"text\",\n" +
+                "    \"title\": \"text\",\n" +
+                "    \"type\": \"text\",\n" +
+                "    \"url\": \"text\",\n" +
                 "    \"extension\": \"text\",\n" +
+                "    \"mime_type\": \"text\",\n" +
+                "    \"path\": \"text\",\n" +
                 "    \"size\": \"number\",\n" +
+                "    \"created_by\": \"text\",\n" +
+                "    \"name\": \"text\",\n" +
+                "    \"language\": \"text\",\n" +
                 "    \"text_size\": \"number\",\n" +
-                "    \"last_modified\": \"date\",\n" +
                 "    \"created_at\": \"date\",\n" +
-                "    \"path\": \"text\"\n" +
+                "    \"last_modified\": \"date\"\n" +
                 "  },\n" +
                 "  \"display\": {\n" +
                 "    \"title_field\": \"title\",\n" +
@@ -1092,15 +1094,15 @@ public class FsMappingTest extends AbstractFSCrawlerMetadataTestCase {
                 "    \"description_field\": \"body\",\n" +
                 "    \"url_field\": \"url\",\n" +
                 "    \"media_type_field\": \"mime_type\",\n" +
-                "    \"created_by_field\": \"author\",\n" +
+                "    \"created_by_field\": \"created_by\",\n" +
                 "    \"detail_fields\": [\n" +
                 "      {\n" +
-                "        \"field_name\": \"author\",\n" +
+                "        \"field_name\": \"created_by\",\n" +
                 "        \"label\": \"Author\"\n" +
                 "      },\n" +
                 "      {\n" +
-                "        \"field_name\": \"keywords\",\n" +
-                "        \"label\": \"Keywords\"\n" +
+                "        \"field_name\": \"tags\",\n" +
+                "        \"label\": \"Tags\"\n" +
                 "      },\n" +
                 "      {\n" +
                 "        \"field_name\": \"language\",\n" +


### PR DESCRIPTION
Workplace Search was not having faceted navigation for FSCrawler source.

<img width="680" alt="image" src="https://user-images.githubusercontent.com/274222/193848679-cf9881b0-e389-45de-8f6c-82168240616a.png">

The field names have changed as per https://www.elastic.co/guide/en/workplace-search/current/workplace-search-custom-api-sources.html#custom-api-source-recommended-field-names specification.

We now add default faceted navigation without relying on the field names.

<img width="1233" alt="image" src="https://user-images.githubusercontent.com/274222/194121254-d88b60c8-0441-4704-bebf-4d0424199f7c.png">


Closes #1515.