### PR TITLE
Depend on Tika BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -655,6 +655,13 @@
 
             <dependency>
                 <groupId>org.apache.tika</groupId>
+                <artifactId>tika-parent</artifactId>
+                <version>${tika.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tika</groupId>
                 <artifactId>tika-core</artifactId>
                 <version>${tika.version}</version>
             </dependency>
@@ -1041,15 +1048,6 @@
                         <artifactId>ossindex-maven-plugin</artifactId>
                         <configuration>
                             <cvssScoreThreshold>7.0</cvssScoreThreshold>
-                            <excludeVulnerabilityIds>
-                                <!-- TODO Remove when upgrading one of those libs:
-                                 - org.apache.tika:tika-parser-scientific-module:2.5.0
-                                   - edu.ucar:netcdf4:4.5.5
-                                     - edu.ucar:cdm:4.5.5
-                                       - com.google.protobuf:protobuf-java:jar:2.5.0
-                                See https://issues.apache.org/jira/browse/TIKA-2536?focusedCommentId=17627609 -->
-                                <excludeVulnerabilityId>CVE-2022-3171</excludeVulnerabilityId>
-                            </excludeVulnerabilityIds>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
And remove exclusion of `CVE-2022-3171` from the audit.

See 981c21d4b81d46eba8b378b38d2c184a2675b0c0