### PR TITLE
Add support for `jq` based transformations

### DIFF
--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentServiceElasticsearchImpl.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentServiceElasticsearchImpl.java
@@ -34,15 +34,22 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import static fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil.serialize;
+import static fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil.transform;
 
 public class FsCrawlerDocumentServiceElasticsearchImpl implements FsCrawlerDocumentService {
 
     private static final Logger logger = LogManager.getLogger(FsCrawlerDocumentServiceElasticsearchImpl.class);
 
     private final IElasticsearchClient client;
+    private final String transformation;
 
     public FsCrawlerDocumentServiceElasticsearchImpl(Path config, FsSettings settings) {
         this.client = new ElasticsearchClient(config, settings);
+        this.transformation = settings.getElasticsearch().getJsonTransform();
+
+        if (transformation != null) {
+            logger.debug("Elasticsearch Document Service configured with JSON transformation");
+        }
     }
 
     public IElasticsearchClient getClient() {
@@ -78,6 +85,9 @@ public class FsCrawlerDocumentServiceElasticsearchImpl implements FsCrawlerDocum
 
     @Override
     public void indexRawJson(String index, String id, String json, String pipeline) {
+        if (transformation != null) {
+            json = transform(json, transformation);
+        }
         logger.debug("Indexing {}/{}?pipeline={}", index, id, pipeline);
         client.indexRawJson(index, id, json, pipeline);
     }

--- a/docs/source/admin/fs/elasticsearch.rst
+++ b/docs/source/admin/fs/elasticsearch.rst
@@ -839,7 +839,7 @@ Transformations
 
 .. warning::
 
-      Transformations depend on `java-jq`, which bridges to the native `jq` library. The current release does not support CPU architectures like `aarch64` on linux.
+      Transformations depend on `java-jq`, which bridges to the native (embedded) `jq` library. The current release does not support CPU architectures like `aarch64` on linux, macos and windows.
 
 Deletes the content field before indexing the document
 

--- a/docs/source/admin/fs/elasticsearch.rst
+++ b/docs/source/admin/fs/elasticsearch.rst
@@ -32,6 +32,8 @@ Here is a list of Elasticsearch settings (under ``elasticsearch.`` prefix)`:
 +-----------------------------------+---------------------------+---------------------------------+
 | ``elasticsearch.ssl_verification``| ``true``                  | :ref:`credentials`              |
 +-----------------------------------+---------------------------+---------------------------------+
+| ``elasticsearch.json_transform``  | ``null``                  | `JQ transformation`             |
++-----------------------------------+---------------------------+---------------------------------+
 
 Index settings
 ^^^^^^^^^^^^^^
@@ -830,3 +832,19 @@ Or run some aggregations on top of them, like:
      }
    }
 
+.. _transformations:
+
+Transformations
+^^^^^^^^^^^^^^^
+
+.. warning::
+
+      Transformations depend on `java-jq`, which bridges to the native `jq` library. The current release does not support CPU architectures like `aarch64` on linux.
+
+Deletes the content field before indexing the document
+
+.. code:: yaml
+
+    name: "test"
+    elasticsearch:
+      json_transform: ". | del(.content)"

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -69,6 +69,13 @@
             <artifactId>json-path</artifactId>
         </dependency>
 
+        <!-- JQ dependencies -->
+        <dependency>
+            <groupId>com.arakelian</groupId>
+            <artifactId>java-jq</artifactId>
+            <version>1.3.0</version>
+        </dependency>
+
         <!-- Logging dependencies -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/JsonUtil.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/JsonUtil.java
@@ -156,7 +156,7 @@ public class JsonUtil {
 
     /**
      * Parse a JSON Document using JSON Path and return a DocumentContext
-     * @param json json to parse
+     * @param json  json to parse
      * @return an Object which can be used as an input for {@link com.jayway.jsonpath.DocumentContext#read(String, Predicate...)}
      */
     public static DocumentContext parseJsonAsDocumentContext(String json) {

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/JsonUtil.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/JsonUtil.java
@@ -36,6 +36,11 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Predicate;
 import com.jayway.jsonpath.spi.json.JsonSmartJsonProvider;
 import com.jayway.jsonpath.spi.mapper.JsonSmartMappingProvider;
+import com.arakelian.jq.ImmutableJqLibrary;
+import com.arakelian.jq.ImmutableJqRequest;
+import com.arakelian.jq.JqLibrary;
+import com.arakelian.jq.JqRequest;
+import com.arakelian.jq.JqResponse;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -51,6 +56,7 @@ public class JsonUtil {
             .mappingProvider(new JsonSmartMappingProvider())
             .build();
 
+    private static final JqLibrary library = ImmutableJqLibrary.of();
 
     static {
         SimpleModule fscrawler = new SimpleModule("FsCrawler", new Version(2, 0, 0, null,
@@ -117,6 +123,21 @@ public class JsonUtil {
             return mapper.readValue(stream, new TypeReference<>() {});
         } catch (IOException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    public static String transform(String json, String transform) {
+        final JqRequest request = ImmutableJqRequest.builder()
+                .lib(library)
+                .input(json)
+                .filter(transform)
+                .build();
+
+        final JqResponse response = request.execute();
+        if (response.hasErrors()) {
+            throw new IllegalArgumentException(response.getErrors().get(0));
+        } else {
+            return response.getOutput();
         }
     }
 

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/JsonUtil.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/JsonUtil.java
@@ -156,7 +156,6 @@ public class JsonUtil {
 
     /**
      * Parse a JSON Document using JSON Path and return a DocumentContext
-     * 
      * @param json json to parse
      * @return an Object which can be used as an input for {@link com.jayway.jsonpath.DocumentContext#read(String, Predicate...)}
      */

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/JsonUtil.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/JsonUtil.java
@@ -125,8 +125,7 @@ public class JsonUtil {
 
     public static Map<String, Object> asMap(InputStream stream) {
         try {
-            return mapper.readValue(stream, new TypeReference<>() {
-            });
+            return mapper.readValue(stream, new TypeReference<>() {});
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -159,8 +158,7 @@ public class JsonUtil {
      * Parse a JSON Document using JSON Path and return a DocumentContext
      * 
      * @param json json to parse
-     * @return an Object which can be used as an input for
-     *         {@link com.jayway.jsonpath.DocumentContext#read(String, Predicate...)}
+     * @return an Object which can be used as an input for {@link com.jayway.jsonpath.DocumentContext#read(String, Predicate...)}
      */
     public static DocumentContext parseJsonAsDocumentContext(String json) {
         return JsonPath.using(configuration).parse(json);

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/JsonUtilTest.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/JsonUtilTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import static fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil.parseJsonAsDocumentContext;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertTrue;
 
 public class JsonUtilTest extends AbstractFSCrawlerTestCase {
 
@@ -60,4 +61,39 @@ public class JsonUtilTest extends AbstractFSCrawlerTestCase {
         assertThat(context.read("$.attributes.owner"), is("dpilato"));
         assertThat(context.read("$.attributes.permissions"), is(644));
     }
+
+    @Test
+    public void testJqTransform() {
+        String json = "{\n" +
+                "   \"content\":\"Some Text\",\n" +
+                "   \"file\":{\n" +
+                "      \"extension\":\"txt\",\n" +
+                "      \"content_type\":\"text/plain; charset=ISO-8859-1\",\n" +
+                "      \"created\":\"2022-02-08T21:57:51.000+00:00\",\n" +
+                "      \"last_modified\":\"2022-02-08T21:57:51.394+00:00\",\n" +
+                "      \"last_accessed\":\"2022-02-08T21:57:51.394+00:00\",\n" +
+                "      \"indexing_date\":\"2022-02-08T21:57:52.033+00:00\",\n" +
+                "      \"filesize\":12230,\n" +
+                "      \"filename\":\"roottxtfile.txt\",\n" +
+                "      \"url\":\"file:///var/folders/xn/47mdpxd12vq4zrjhkwbhd5_r0000gn/T/junit16929133427221182897/resources/test_attributes/roottxtfile.txt\"\n"
+                +
+                "   },\n" +
+                "   \"path\":{\n" +
+                "      \"root\":\"e366ee2f42db246720b82a82fdb4e15e\",\n" +
+                "      \"virtual\":\"/roottxtfile.txt\",\n" +
+                "      \"real\":\"/var/folders/xn/47mdpxd12vq4zrjhkwbhd5_r0000gn/T/junit16929133427221182897/resources/test_attributes/roottxtfile.txt\"\n"
+                +
+                "   },\n" +
+                "   \"attributes\":{\n" +
+                "      \"owner\":\"dpilato\",\n" +
+                "      \"group\":\"staff\",\n" +
+                "      \"permissions\":644\n" +
+                "   }\n" +
+                "}";
+
+        var result = JsonUtil.transform(json, "del(.content)");
+        assertTrue(!result.contains("\"content\":\"Some Text\""));
+
+    }
+
 }

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/JsonUtilTest.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/JsonUtilTest.java
@@ -45,14 +45,12 @@ public class JsonUtilTest extends AbstractFSCrawlerTestCase {
                 "      \"indexing_date\":\"2022-02-08T21:57:52.033+00:00\",\n" +
                 "      \"filesize\":12230,\n" +
                 "      \"filename\":\"roottxtfile.txt\",\n" +
-                "      \"url\":\"file:///var/folders/xn/47mdpxd12vq4zrjhkwbhd5_r0000gn/T/junit16929133427221182897/resources/test_attributes/roottxtfile.txt\"\n"
-                +
+                "      \"url\":\"file:///var/folders/xn/47mdpxd12vq4zrjhkwbhd5_r0000gn/T/junit16929133427221182897/resources/test_attributes/roottxtfile.txt\"\n" +
                 "   },\n" +
                 "   \"path\":{\n" +
                 "      \"root\":\"e366ee2f42db246720b82a82fdb4e15e\",\n" +
                 "      \"virtual\":\"/roottxtfile.txt\",\n" +
-                "      \"real\":\"/var/folders/xn/47mdpxd12vq4zrjhkwbhd5_r0000gn/T/junit16929133427221182897/resources/test_attributes/roottxtfile.txt\"\n"
-                +
+                "      \"real\":\"/var/folders/xn/47mdpxd12vq4zrjhkwbhd5_r0000gn/T/junit16929133427221182897/resources/test_attributes/roottxtfile.txt\"\n" +
                 "   },\n" +
                 "   \"attributes\":{\n" +
                 "      \"owner\":\"dpilato\",\n" +
@@ -86,14 +84,12 @@ public class JsonUtilTest extends AbstractFSCrawlerTestCase {
                 "      \"indexing_date\":\"2022-02-08T21:57:52.033+00:00\",\n" +
                 "      \"filesize\":12230,\n" +
                 "      \"filename\":\"roottxtfile.txt\",\n" +
-                "      \"url\":\"file:///var/folders/xn/47mdpxd12vq4zrjhkwbhd5_r0000gn/T/junit16929133427221182897/resources/test_attributes/roottxtfile.txt\"\n"
-                +
+                "      \"url\":\"file:///var/folders/xn/47mdpxd12vq4zrjhkwbhd5_r0000gn/T/junit16929133427221182897/resources/test_attributes/roottxtfile.txt\"\n" +
                 "   },\n" +
                 "   \"path\":{\n" +
                 "      \"root\":\"e366ee2f42db246720b82a82fdb4e15e\",\n" +
                 "      \"virtual\":\"/roottxtfile.txt\",\n" +
-                "      \"real\":\"/var/folders/xn/47mdpxd12vq4zrjhkwbhd5_r0000gn/T/junit16929133427221182897/resources/test_attributes/roottxtfile.txt\"\n"
-                +
+                "      \"real\":\"/var/folders/xn/47mdpxd12vq4zrjhkwbhd5_r0000gn/T/junit16929133427221182897/resources/test_attributes/roottxtfile.txt\"\n" +
                 "   },\n" +
                 "   \"attributes\":{\n" +
                 "      \"owner\":\"dpilato\",\n" +

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/JsonUtilTest.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/JsonUtilTest.java
@@ -26,7 +26,9 @@ import org.junit.Test;
 import static fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil.parseJsonAsDocumentContext;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isOneOf;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeThat;
 
 public class JsonUtilTest extends AbstractFSCrawlerTestCase {
 
@@ -43,12 +45,14 @@ public class JsonUtilTest extends AbstractFSCrawlerTestCase {
                 "      \"indexing_date\":\"2022-02-08T21:57:52.033+00:00\",\n" +
                 "      \"filesize\":12230,\n" +
                 "      \"filename\":\"roottxtfile.txt\",\n" +
-                "      \"url\":\"file:///var/folders/xn/47mdpxd12vq4zrjhkwbhd5_r0000gn/T/junit16929133427221182897/resources/test_attributes/roottxtfile.txt\"\n" +
+                "      \"url\":\"file:///var/folders/xn/47mdpxd12vq4zrjhkwbhd5_r0000gn/T/junit16929133427221182897/resources/test_attributes/roottxtfile.txt\"\n"
+                +
                 "   },\n" +
                 "   \"path\":{\n" +
                 "      \"root\":\"e366ee2f42db246720b82a82fdb4e15e\",\n" +
                 "      \"virtual\":\"/roottxtfile.txt\",\n" +
-                "      \"real\":\"/var/folders/xn/47mdpxd12vq4zrjhkwbhd5_r0000gn/T/junit16929133427221182897/resources/test_attributes/roottxtfile.txt\"\n" +
+                "      \"real\":\"/var/folders/xn/47mdpxd12vq4zrjhkwbhd5_r0000gn/T/junit16929133427221182897/resources/test_attributes/roottxtfile.txt\"\n"
+                +
                 "   },\n" +
                 "   \"attributes\":{\n" +
                 "      \"owner\":\"dpilato\",\n" +
@@ -64,6 +68,13 @@ public class JsonUtilTest extends AbstractFSCrawlerTestCase {
 
     @Test
     public void testJqTransform() {
+
+        String arch = System.getProperty("os.arch");
+        String name = System.getProperty("os.name");
+
+        assumeThat("JQ transforms skipped because of platform", name + "/" + arch,
+                isOneOf("win/x86", "linux/x86", "linux/amd64", /* "linux/aarch64", */ "mac/x86_64"));
+
         String json = "{\n" +
                 "   \"content\":\"Some Text\",\n" +
                 "   \"file\":{\n" +

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestJsonTransformIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestJsonTransformIT.java
@@ -21,12 +21,12 @@ package fr.pilato.elasticsearch.crawler.fs.test.integration.elasticsearch;
 
 import fr.pilato.elasticsearch.crawler.fs.client.ESPrefixQuery;
 import fr.pilato.elasticsearch.crawler.fs.client.ESSearchRequest;
-import fr.pilato.elasticsearch.crawler.fs.client.ESTermQuery;
 import fr.pilato.elasticsearch.crawler.fs.settings.Elasticsearch;
 import fr.pilato.elasticsearch.crawler.fs.settings.Fs;
 import fr.pilato.elasticsearch.crawler.fs.test.integration.AbstractFsCrawlerITCase;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeThat;
+import static org.hamcrest.Matchers.*;
 
 import org.junit.Test;
 
@@ -35,30 +35,38 @@ import org.junit.Test;
  */
 public class FsCrawlerTestJsonTransformIT extends AbstractFsCrawlerITCase {
 
-    @Test
-    public void test_json_transform() throws Exception {
-        Fs fs = startCrawlerDefinition()
-                .setIndexContent(true)
-                .build();
+        @Test
+        public void test_json_transform() throws Exception {
 
-        Elasticsearch es = endCrawlerDefinition(getCrawlerName());
-        es.setJsonTransform(". | del(.content)");
+                String arch = System.getProperty("os.arch");
+                String name = System.getProperty("os.name");
 
-        crawler = startCrawler(getCrawlerName(), fs, es, null);
+                assumeThat("JQ transforms skipped because of platform", name + "/" + arch,
+                                isOneOf("win/x86", "linux/x86", "linux/amd64", /* "linux/aarch64", */ "mac/x86_64"));
 
-        // We expect to have one file
-        countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
+                Fs fs = startCrawlerDefinition()
+                                .setIndexContent(true)
+                                .build();
 
-        // We expect to find zero documents with any content and we know "text" is part
-        // of a keyword in content
-        countTestHelper(
-                new ESSearchRequest().withIndex(getCrawlerName()).withESQuery(new ESPrefixQuery("content", "text")),
-                0L, null);
+                Elasticsearch es = endCrawlerDefinition(getCrawlerName());
+                es.setJsonTransform(". | del(.content)"); // just delete the content field for the test
 
-        // We expect to still have a content_type as we did content indexing and only
-        // deleted the content field afterwards
-        countTestHelper(new ESSearchRequest().withIndex(getCrawlerName())
-                .withESQuery(new ESPrefixQuery("file.content_type", "text")), 1L, null);
+                crawler = startCrawler(getCrawlerName(), fs, es, null);
 
-    }
+                // We expect to have one file
+                countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
+
+                // We expect to find zero documents with any content and we know "text" is part
+                // of a keyword in content
+                countTestHelper(
+                                new ESSearchRequest().withIndex(getCrawlerName())
+                                                .withESQuery(new ESPrefixQuery("content", "text")),
+                                0L, null);
+
+                // We expect to still have a content_type as we did content indexing and only
+                // deleted the content field afterwards
+                countTestHelper(new ESSearchRequest().withIndex(getCrawlerName())
+                                .withESQuery(new ESPrefixQuery("file.content_type", "text")), 1L, null);
+
+        }
 }

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestJsonTransformIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestJsonTransformIT.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package fr.pilato.elasticsearch.crawler.fs.test.integration.elasticsearch;
+
+import fr.pilato.elasticsearch.crawler.fs.client.ESPrefixQuery;
+import fr.pilato.elasticsearch.crawler.fs.client.ESSearchRequest;
+import fr.pilato.elasticsearch.crawler.fs.client.ESTermQuery;
+import fr.pilato.elasticsearch.crawler.fs.settings.Elasticsearch;
+import fr.pilato.elasticsearch.crawler.fs.settings.Fs;
+import fr.pilato.elasticsearch.crawler.fs.test.integration.AbstractFsCrawlerITCase;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Test json transform settings
+ */
+public class FsCrawlerTestJsonTransformIT extends AbstractFsCrawlerITCase {
+
+    @Test
+    public void test_json_transform() throws Exception {
+        Fs fs = startCrawlerDefinition()
+                .setIndexContent(true)
+                .build();
+
+        Elasticsearch es = endCrawlerDefinition(getCrawlerName());
+        es.setJsonTransform(". | del(.content)");
+
+        crawler = startCrawler(getCrawlerName(), fs, es, null);
+
+        // We expect to have one file
+        countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
+
+        // We expect to find zero documents with any content and we know "text" is part
+        // of a keyword in content
+        countTestHelper(
+                new ESSearchRequest().withIndex(getCrawlerName()).withESQuery(new ESPrefixQuery("content", "text")),
+                0L, null);
+
+        // We expect to still have a content_type as we did content indexing and only
+        // deleted the content field afterwards
+        countTestHelper(new ESSearchRequest().withIndex(getCrawlerName())
+                .withESQuery(new ESPrefixQuery("file.content_type", "text")), 1L, null);
+
+    }
+}

--- a/runtest.sh
+++ b/runtest.sh
@@ -1,0 +1,4 @@
+mvn verify -Dtests.class=fr.pilato.elasticsearch.crawler.fs.test.integration.elasticsearch.FsCrawlerTestJsonTransformIT \
+    -Dtests.cluster.user=elastic \
+    -Dtests.cluster.pass=MIqe71xtsibbufYCd8VAfSTD \
+    -Dtests.cluster.url=https://my-deployment-a23909.es.europe-west3.gcp.cloud.es.io

--- a/runtest.sh
+++ b/runtest.sh
@@ -1,4 +1,0 @@
-mvn verify -Dtests.class=fr.pilato.elasticsearch.crawler.fs.test.integration.elasticsearch.FsCrawlerTestJsonTransformIT \
-    -Dtests.cluster.user=elastic \
-    -Dtests.cluster.pass=MIqe71xtsibbufYCd8VAfSTD \
-    -Dtests.cluster.url=https://my-deployment-a23909.es.europe-west3.gcp.cloud.es.io

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Elasticsearch.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Elasticsearch.java
@@ -48,14 +48,15 @@ public class Elasticsearch {
     private String pipeline;
     private String pathPrefix;
     private boolean sslVerification = true;
+    private String jsonTransform = null;
 
     public Elasticsearch() {
 
     }
 
     private Elasticsearch(List<ServerUrl> nodes, String index, String indexFolder, int bulkSize,
-                          TimeValue flushInterval, ByteSizeValue byteSize, String username, String password, String pipeline,
-                          String pathPrefix, boolean sslVerification) {
+            TimeValue flushInterval, ByteSizeValue byteSize, String username, String password, String pipeline,
+            String pathPrefix, boolean sslVerification, String jsonTransform) {
         this.nodes = nodes;
         this.index = index;
         this.indexFolder = indexFolder;
@@ -67,6 +68,7 @@ public class Elasticsearch {
         this.pipeline = pipeline;
         this.pathPrefix = pathPrefix;
         this.sslVerification = sslVerification;
+        this.jsonTransform = jsonTransform;
     }
 
     public static Builder builder() {
@@ -153,6 +155,14 @@ public class Elasticsearch {
         this.sslVerification = sslVerification;
     }
 
+    public String getJsonTransform() {
+        return jsonTransform;
+    }
+
+    public void setJsonTransform(String jsonTransform) {
+        this.jsonTransform = jsonTransform;
+    }
+
     @SuppressWarnings("UnusedReturnValue")
     public static class Builder {
         private List<ServerUrl> nodes = Collections.singletonList(NODE_DEFAULT);
@@ -166,6 +176,7 @@ public class Elasticsearch {
         private String pipeline = null;
         private String pathPrefix = null;
         private boolean sslVerification = true;
+        private String jsonTransform = null;
 
         public Builder setNodes(List<ServerUrl> nodes) {
             this.nodes = nodes;
@@ -222,8 +233,14 @@ public class Elasticsearch {
             return this;
         }
 
+        public Builder setJsonTransform(String jsonTransform) {
+            this.jsonTransform = jsonTransform;
+            return this;
+        }
+
         public Elasticsearch build() {
-            return new Elasticsearch(nodes, index, indexFolder, bulkSize, flushInterval, byteSize, username, password, pipeline, pathPrefix, sslVerification);
+            return new Elasticsearch(nodes, index, indexFolder, bulkSize, flushInterval, byteSize, username, password,
+                    pipeline, pathPrefix, sslVerification, jsonTransform);
         }
     }
 
@@ -243,6 +260,7 @@ public class Elasticsearch {
         if (!Objects.equals(pipeline, that.pipeline)) return false;
         if (!Objects.equals(pathPrefix, that.pathPrefix)) return false;
         if (!Objects.equals(sslVerification, that.sslVerification)) return false;
+        if (!Objects.equals(jsonTransform, that.jsonTransform)) return false;
         return Objects.equals(flushInterval, that.flushInterval);
 
     }
@@ -258,6 +276,7 @@ public class Elasticsearch {
         result = 31 * result + bulkSize;
         result = 31 * result + (flushInterval != null ? flushInterval.hashCode() : 0);
         result = 31 * result + (sslVerification? 1: 0);
+        result = 31 * result + (jsonTransform != null ? jsonTransform.hashCode() : 0);
         return result;
     }
 
@@ -273,6 +292,7 @@ public class Elasticsearch {
                 ", pipeline='" + pipeline + '\'' +
                 ", pathPrefix='" + pathPrefix + '\'' +
                 ", sslVerification='" + sslVerification + '\'' +
+                ", jsonTransform='" + jsonTransform + '\'' +
                 '}';
     }
 }

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Elasticsearch.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Elasticsearch.java
@@ -54,7 +54,9 @@ public class Elasticsearch {
 
     }
 
-    private Elasticsearch(List<ServerUrl> nodes, String index, String indexFolder, int bulkSize, TimeValue flushInterval, ByteSizeValue byteSize, String username, String password, String pipeline, String pathPrefix, boolean sslVerification, String jsonTransform) {
+    private Elasticsearch(List<ServerUrl> nodes, String index, String indexFolder, int bulkSize,
+            TimeValue flushInterval, ByteSizeValue byteSize, String username, String password, String pipeline,
+            String pathPrefix, boolean sslVerification, String jsonTransform) {
         this.nodes = nodes;
         this.index = index;
         this.indexFolder = indexFolder;

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Elasticsearch.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Elasticsearch.java
@@ -54,9 +54,7 @@ public class Elasticsearch {
 
     }
 
-    private Elasticsearch(List<ServerUrl> nodes, String index, String indexFolder, int bulkSize,
-            TimeValue flushInterval, ByteSizeValue byteSize, String username, String password, String pipeline,
-            String pathPrefix, boolean sslVerification, String jsonTransform) {
+    private Elasticsearch(List<ServerUrl> nodes, String index, String indexFolder, int bulkSize, TimeValue flushInterval, ByteSizeValue byteSize, String username, String password, String pipeline, String pathPrefix, boolean sslVerification, String jsonTransform) {
         this.nodes = nodes;
         this.index = index;
         this.indexFolder = indexFolder;
@@ -239,8 +237,7 @@ public class Elasticsearch {
         }
 
         public Elasticsearch build() {
-            return new Elasticsearch(nodes, index, indexFolder, bulkSize, flushInterval, byteSize, username, password,
-                    pipeline, pathPrefix, sslVerification, jsonTransform);
+            return new Elasticsearch(nodes, index, indexFolder, bulkSize, flushInterval, byteSize, username, password, pipeline, pathPrefix, sslVerification, jsonTransform);
         }
     }
 


### PR DESCRIPTION
In some situations, relying on ES for mapping values before indexing might not be enough. For those scenarios, this feature might be helpful as it allows the full power of the [jq](https://stedolan.github.io/jq/) JSON processor to apply on every document via the `elasticsearch.json_transform` config variable.

In your scenario we need to get one special field that is part of `meta.raw.custom.XXX` but can only be matched via regex and ignore all other custom fields to prevent the amount of our indexed fields growing without our control.

This comes with the drawback of using a library with embedded native components and therefore limited support for platforms i.e. no `aarch64/arm64` support currently. The testcases  `assumeThat` a supported platform is used.

I put this as draft as this PR is unsolicited and not related to anything discussed in other issues yet.
