### PR TITLE
Update Dockerfile Base Image

### DIFF
--- a/distribution/src/main/docker/Dockerfile
+++ b/distribution/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-slim-bullseye
+FROM eclipse-temurin:17-jdk
 
 ARG langsPkg
 


### PR DESCRIPTION
The `openjdk` image has been [deprecated](https://github.com/docker-library/openjdk#deprecated) and the tag being used hasn't been updated in over a year. https://github.com/docker-library/openjdk/issues/505 suggests migrating to `eclipse-temurin` (as was originally suggested #1389) which is still being maintained. Upgrading also addresses [a number of vulnerabilities](https://hub.docker.com/layers/library/openjdk/17-slim-bullseye/images/sha256-779635c0c3d23cc8dbab2d8c1ee4cf2a9202e198dfc8f4c0b279824d9b8e0f22?context=explore) present in the image currently being used. 

Also, in case you're interested, this image is almost identical in size when compared with the previous image.