### PR TITLE
Revert docker-maven-plugin upgrade to 0.43.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,7 +281,7 @@
                 <plugin>
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
-                    <version>0.43.4</version>
+                    <version>0.43.2</version>
                 </plugin>
 
                 <!-- For IT using Docker Compose -->


### PR DESCRIPTION
See #1695

This is caused by this change https://github.com/fabric8io/docker-maven-plugin/pull/1703

I tried a workaround but no luck. See in https://github.com/fabric8io/docker-maven-plugin/issues/1701#issuecomment-1768191085