### PR TITLE
Deprecate `--debug` and `--trace`

### DIFF
--- a/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
+++ b/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
@@ -91,10 +91,12 @@ public class FsCrawlerCli {
         @Parameter(names = "--upgrade", description = "Upgrade elasticsearch indices from one old version to the last version.")
         boolean upgrade = false;
 
-        @Parameter(names = "--debug", description = "Debug mode")
+        @Deprecated
+        @Parameter(names = "--debug", description = "Debug mode (Deprecated - use FS_JAVA_OPTS=\"-DLOG_LEVEL=debug\" instead)")
         boolean debug = false;
 
-        @Parameter(names = "--trace", description = "Trace mode")
+        @Deprecated
+        @Parameter(names = "--trace", description = "Trace mode (Deprecated - use FS_JAVA_OPTS=\"-DLOG_LEVEL=trace\" instead)")
         boolean trace = false;
 
         @Parameter(names = "--silent", description = "Silent mode")
@@ -109,6 +111,15 @@ public class FsCrawlerCli {
         FsCrawlerCommand command = commandParser(args);
 
         if (command != null) {
+            if (command.debug) {
+                // Deprecated command line option
+                logger.warn("--debug option has been deprecated. Use FS_JAVA_OPTS=\"-DLOG_LEVEL=debug\" instead.");
+            }
+            if (command.trace) {
+                // Deprecated command line option
+                logger.warn("--trace option has been deprecated. Use FS_JAVA_OPTS=\"-DLOG_LEVEL=trace\" instead.");
+            }
+
             // We change the log level if needed
             changeLoggerContext(command);
 

--- a/cli/src/test/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCliCommandParserTest.java
+++ b/cli/src/test/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCliCommandParserTest.java
@@ -50,7 +50,6 @@ public class FsCrawlerCliCommandParserTest extends AbstractFSCrawlerTestCase {
                 "--rest",
                 "--upgrade",
                 "--restart",
-                "--debug",
                 "jobName"
         };
         FsCrawlerCli.FsCrawlerCommand command = FsCrawlerCli.commandParser(args);
@@ -61,8 +60,6 @@ public class FsCrawlerCliCommandParserTest extends AbstractFSCrawlerTestCase {
         assertThat(command.rest, is(true));
         assertThat(command.upgrade, is(true));
         assertThat(command.restart, is(true));
-        assertThat(command.debug, is(true));
-        assertThat(command.trace, is(false));
         assertThat(command.silent, is(false));
         assertThat(command.jobName.get(0), is("jobName"));
     }

--- a/docs/source/admin/cli-options.rst
+++ b/docs/source/admin/cli-options.rst
@@ -5,8 +5,6 @@ CLI options
 
 -  ``--help`` displays help
 -  ``--silent`` runs in silent mode. No output is generated on the console.
--  ``--debug`` runs in debug mode. This applies to log files only. See also :ref:`logger`.
--  ``--trace`` runs in trace mode (more verbose than debug). This applies to log files only. See also :ref:`logger`.
 -  ``--config_dir`` defines directory where jobs are stored instead of
    default ``~/.fscrawler``.
 -  ``--username`` defines the username to use when using an secured

--- a/docs/source/admin/logger.rst
+++ b/docs/source/admin/logger.rst
@@ -3,7 +3,7 @@
 Configuring the logger
 ======================
 
-In addition to the :ref:`cli-options`, FSCrawler comes with a default logger configuration which can be found in the
+FSCrawler comes with a default logger configuration which can be found in the
 FSCrawler installation dir as ``config/log4j2.xml`` file.
 
 You can modify it to suit your needs. It will be automatically reloaded every 30 seconds.


### PR DESCRIPTION
As we are supporting now the standard way for logging (see #1031), we can remove support for `--debug` and `--trace`.

Instead users can use:

```sh
FS_JAVA_OPTS="-DLOG_LEVEL=debug" bin/fscrawler
```

or

```sh
FS_JAVA_OPTS="-DLOG_LEVEL=trace" bin/fscrawler
```

That's producing the same effect at the end in a much more standard way.