### PR TITLE
Do not hide YAML parsing errors

### DIFF
--- a/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
+++ b/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
@@ -332,7 +332,12 @@ public class FsCrawlerCli {
         }
 
         logger.debug("Starting job [{}]...", jobName);
-        fsSettings = loadSettings(configDir, jobName);
+        try {
+            fsSettings = loadSettings(configDir, jobName);
+        } catch (Exception e) {
+            logger.fatal("Cannot parse the configuration file: {}", e.getMessage());
+            throw e;
+        }
 
         if (fsSettings == null) {
             logger.debug("job [{}] does not exist.", jobName);

--- a/cli/src/test/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCliTest.java
+++ b/cli/src/test/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCliTest.java
@@ -19,6 +19,7 @@
 
 package fr.pilato.elasticsearch.crawler.fs.cli;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import fr.pilato.elasticsearch.crawler.fs.beans.FsJob;
 import fr.pilato.elasticsearch.crawler.fs.beans.FsJobFileHandler;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
@@ -33,6 +34,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.copyDefaultResources;
+import static fr.pilato.elasticsearch.crawler.fs.settings.FsSettingsFileHandler.SETTINGS_YAML;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -94,5 +96,22 @@ public class FsCrawlerCliTest extends AbstractFSCrawlerTestCase {
         FsCrawlerCli.main(args);
 
         assertThat(Files.exists(jobDir.resolve(FsJobFileHandler.FILENAME)), is(false));
+    }
+
+    @Test(expected = JsonParseException.class)
+    public void testWithWrongSettingsFile() throws Exception {
+        String jobName = "fscrawler_wrong_settings";
+
+        Path jobDir = metadataDir.resolve(jobName);
+        Files.createDirectories(jobDir);
+        Files.writeString(jobDir.resolve(SETTINGS_YAML), "" +
+                "name: \"test\"\n" +
+                "fs:\n" +
+                "  url: \"/path/to/docs\"\n" +
+                // Wrong indentation
+                " follow_symlink: false\n");
+
+        String[] args = { "--config_dir", metadataDir.toString(), "--loop", "1", jobName };
+        FsCrawlerCli.main(args);
     }
 }

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsFileHandler.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsFileHandler.java
@@ -22,6 +22,7 @@ package fr.pilato.elasticsearch.crawler.fs.settings;
 import fr.pilato.elasticsearch.crawler.fs.framework.MetaFileHandler;
 
 import java.io.IOException;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 
 /**
@@ -46,7 +47,7 @@ public class FsSettingsFileHandler extends MetaFileHandler {
         try {
             // We try the yml first
             return readAsYaml(jobname);
-        } catch (IOException e) {
+        } catch (NoSuchFileException e) {
             // Then we try json
             return readAsJson(jobname);
         }


### PR DESCRIPTION
When parsing a wrong yaml file, we are today catching the error and behave as if the file was not existing and proposes the user to create the missing file: 

```
job [jobname] does not exist
Do you want to create it (Y/N)?
```

This is leading users to wrong assumptions.

This change now prints a meaningful error while exiting:

```
17:13:00,521 FATAL [f.p.e.c.f.c.FsCrawlerCli] Cannot parse the configuration file: while parsing a block mapping
 in 'reader', line 1, column 1:
    name: "test"
    ^
expected <block end>, but found '<block mapping start>'
 in 'reader', line 4, column 2:
     follow_symlink: false
     ^

 at [Source: (StringReader); line: 4, column: 2]
```

Closes #1767.