### PR TITLE
Allow loading external jars

### DIFF
--- a/contrib/docker-compose-example-elasticsearch/docker-compose.yml
+++ b/contrib/docker-compose-example-elasticsearch/docker-compose.yml
@@ -131,6 +131,7 @@ services:
       - ../../test-documents/src/main/resources/documents/:/tmp/es:ro
       - ${PWD}/config:/root/.fscrawler
       - ${PWD}/logs:/usr/share/fscrawler/logs
+      - ${PWD}/external:/usr/share/fscrawler/external
     depends_on:
       elasticsearch:
         condition: service_healthy

--- a/contrib/docker-compose-example-fscrawler/docker-compose.yml
+++ b/contrib/docker-compose-example-fscrawler/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - ../../test-documents/src/main/resources/documents/:/tmp/es:ro
       - ${PWD}/config:/root/.fscrawler
       - ${PWD}/logs:/usr/share/fscrawler/logs
+      - ${PWD}/external:/usr/share/fscrawler/external
     ports:
       - ${FSCRAWLER_PORT}:8080
     command: fscrawler idx --rest

--- a/contrib/docker-compose-example-workplace/docker-compose.yml
+++ b/contrib/docker-compose-example-workplace/docker-compose.yml
@@ -182,6 +182,7 @@ services:
       - ../../test-documents/src/main/resources/documents/:/tmp/es:ro
       - ${PWD}/config:/root/.fscrawler
       - ${PWD}/logs:/usr/share/fscrawler/logs
+      - ${PWD}/external:/usr/share/fscrawler/external
     depends_on:
       enterprisesearch:
         condition: service_healthy

--- a/distribution/src/main/assembly/assembly.xml
+++ b/distribution/src/main/assembly/assembly.xml
@@ -37,5 +37,9 @@
                 <include>log4j2-file.xml</include>
             </includes>
         </fileSet>
+        <fileSet>
+            <directory>src/main/external</directory>
+            <outputDirectory>external</outputDirectory>
+        </fileSet>
     </fileSets>
 </assembly>

--- a/distribution/src/main/external/README.txt
+++ b/distribution/src/main/external/README.txt
@@ -1,0 +1,1 @@
+You can place here your external jars (and their dependencies).

--- a/distribution/src/main/scripts/fscrawler
+++ b/distribution/src/main/scripts/fscrawler
@@ -20,7 +20,7 @@ FS_HOME=`dirname "$SCRIPT"`/..
 
 # make FS_HOME absolute
 FS_HOME=`cd "$FS_HOME"; pwd`
-FS_CLASSPATH="$FS_HOME/lib/*"
+FS_CLASSPATH="$FS_HOME/lib/*:$FS_HOME/external/*"
 
 if [ -x "$JAVA_HOME/bin/java" ]; then
     JAVA="$JAVA_HOME/bin/java"

--- a/distribution/src/main/scripts/fscrawler.bat
+++ b/distribution/src/main/scripts/fscrawler.bat
@@ -37,7 +37,7 @@ set JAVA_OPTS=%JAVA_OPTS% -Dlog4j2.formatMsgNoLookups=true
 REM If the user defined FS_JAVA_OPTS, we will use it to start the crawler
 set JAVA_OPTS=%JAVA_OPTS% %FS_JAVA_OPTS%
 
-set FS_CLASSPATH=%FS_HOME%/lib/*
+set FS_CLASSPATH="%FS_HOME%/lib/*";"%FS_HOME%/external/*"
 
 SET params='%*'
 
@@ -69,7 +69,7 @@ FOR /F "usebackq tokens=1* delims= " %%A IN (!params!) DO (
 	)
 )
 
-%JAVA% %JAVA_OPTS% -cp "%FS_CLASSPATH%" "${distribution.mainClassName}" !newparams!
+%JAVA% %JAVA_OPTS% -cp %FS_CLASSPATH% "${distribution.mainClassName}" !newparams!
 REM Return to original directory
 POPD
 ENDLOCAL

--- a/docs/source/admin/layout.rst
+++ b/docs/source/admin/layout.rst
@@ -1,0 +1,49 @@
+.. _layout:
+
+Directory layout
+================
+
+The directory layout of the project is as follows:
+
+.. code-block:: none
+
+    .
+    ├── NOTICE
+    ├── LICENSE
+    ├── README.md
+    ├── bin
+    │   ├── fscrawler
+    │   └── fscrawler.bat
+    ├── config
+    │   ├── log4j2.xml
+    │   └── log4j2-file.xml
+    ├── external
+    ├── lib
+    └── logs
+        ├── documents.log
+        └── fscrawler.log
+
+The ``bin`` directory contains the scripts to run FSCrawler.
+
+The ``config`` directory contains the configuration files. See `Configuring the logger`_.
+
+The ``external`` directory contains the external libraries you could add to FSCrawler. For example, if you want to
+add the ``jai-imageio-jpeg2000`` library to add support for JPEG2000 images, you can download it from
+`Maven Central <https://central.sonatype.com/search?q=g:com.github.jai-imageio>`_ and put the
+``jai-imageio-jpeg2000-1.4.0.jar`` file in the ``external`` directory.
+
+As this directory is empty by default, you can also mount it when using Docker images:
+
+.. code:: sh
+
+   docker run -it --rm \
+        -v ~/.fscrawler:/root/.fscrawler \
+        -v ~/tmp:/tmp/es:ro \
+        -v "$PWD/external:/usr/share/fscrawler/external" \
+        dadoonet/fscrawler fscrawler job_name
+
+See also `Using docker`_ and `Using docker compose`_.
+
+The ``lib`` directory contains the FSCrawler jar file and all the dependencies.
+
+The ``logs`` directory contains the log files. See `Configuring the logger`_.

--- a/docs/source/admin/layout.rst
+++ b/docs/source/admin/layout.rst
@@ -25,7 +25,11 @@ The directory layout of the project is as follows:
 
 The ``bin`` directory contains the scripts to run FSCrawler.
 
-The ``config`` directory contains the configuration files. See `Configuring the logger`_.
+The ``lib`` directory contains the FSCrawler jar file and all the dependencies.
+
+.. versionadded:: 2.10
+
+The ``config`` directory contains the configuration files. See :ref:`logger`.
 
 The ``external`` directory contains the external libraries you could add to FSCrawler. For example, if you want to
 add the ``jai-imageio-jpeg2000`` library to add support for JPEG2000 images, you can download it from
@@ -42,8 +46,6 @@ As this directory is empty by default, you can also mount it when using Docker i
         -v "$PWD/external:/usr/share/fscrawler/external" \
         dadoonet/fscrawler fscrawler job_name
 
-See also `Using docker`_ and `Using docker compose`_.
+See also :ref:`docker` and :ref:`docker-compose`.
 
-The ``lib`` directory contains the FSCrawler jar file and all the dependencies.
-
-The ``logs`` directory contains the log files. See `Configuring the logger`_.
+The ``logs`` directory contains the log files. See :ref:`logger`.

--- a/docs/source/admin/status.rst
+++ b/docs/source/admin/status.rst
@@ -1,5 +1,5 @@
 Status files
-------------
+============
 
 Once the crawler is running, it will write status information and
 statistics in:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -49,10 +49,11 @@ This crawler helps to index binary documents such as PDF, Open Office, MS Office
    :caption: Administration Guide
    :maxdepth: 3
 
-   admin/status
+   admin/layout
    admin/cli-options
    admin/jvm-settings
    admin/logger
+   admin/status
    admin/fs/index
    admin/fs/simple
    admin/fs/local-fs
@@ -111,9 +112,9 @@ Incompatible 3rd party library licenses
 =======================================
 
 To support JPEG 2000 (JPX/JP2) images, you need to manually add |JPEG2000_version|_ library to
-the ``lib`` directory::
+the ``external`` directory::
 
-    cd lib
+    cd external
     wget https://repo1.maven.org/maven2/com/github/jai-imageio/jai-imageio-jpeg2000/1.4.0/jai-imageio-jpeg2000-1.4.0.jar
 
 See

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -119,7 +119,7 @@ the ``external`` directory::
 
 See
 `pdfbox documentation <https://pdfbox.apache.org/2.0/dependencies.html#jai-image-io>`__
-for more details.
+for more details about the license details.
 
 Special thanks
 ==============

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -89,6 +89,8 @@ mount it as well:
         -v "$PWD/external:/usr/share/fscrawler/external" \
         dadoonet/fscrawler fscrawler job_name
 
+.. _docker-compose:
+
 Using docker compose
 --------------------
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -27,7 +27,7 @@ Download FSCrawler
 
         You can also download a **SNAPSHOT** version from |Sonatype|_.
 
-See `Directory layout`_ to know more about the content of the distribution.
+See :ref:`layout` to know more about the content of the distribution.
 
 .. _docker:
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -27,22 +27,7 @@ Download FSCrawler
 
         You can also download a **SNAPSHOT** version from |Sonatype|_.
 
-The distribution contains:
-
-::
-
-   $ tree
-   .
-   ├── LICENSE
-   ├── NOTICE
-   ├── README.md
-   ├── bin
-   │   ├── fscrawler
-   │   └── fscrawler.bat
-   ├── config
-   │   └── log4j2.xml
-   └── lib
-       ├── ... All needed jars
+See `Directory layout`_ to know more about the content of the distribution.
 
 .. _docker:
 
@@ -72,7 +57,10 @@ You can run FSCrawler with:
 
 .. code:: sh
 
-   docker run -it --rm -v ~/.fscrawler:/root/.fscrawler -v ~/tmp:/tmp/es:ro dadoonet/fscrawler fscrawler job_name
+   docker run -it --rm \
+        -v ~/.fscrawler:/root/.fscrawler \
+        -v ~/tmp:/tmp/es:ro \
+        dadoonet/fscrawler fscrawler job_name
 
 On the first run, if the job does not exist yet in ``~/.fscrawler``, FSCrawler will ask you if you want to create it:
 
@@ -90,6 +78,16 @@ On the first run, if the job does not exist yet in ``~/.fscrawler``, FSCrawler w
     Remember to change the URL of your elasticsearch instance as the container won't be able to see it
     running under the default ``127.0.0.1``. You will need to use the actual IP address of the host.
 
+If you need to add a 3rd party library (jar) or your Tika custom jar, you can put it in a ``external`` directory and
+mount it as well:
+
+.. code:: sh
+
+   docker run -it --rm \
+        -v ~/.fscrawler:/root/.fscrawler \
+        -v ~/tmp:/tmp/es:ro \
+        -v "$PWD/external:/usr/share/fscrawler/external" \
+        dadoonet/fscrawler fscrawler job_name
 
 Using docker compose
 --------------------
@@ -104,6 +102,8 @@ In this section, the following directory layout is assumed:
   │       └── _settings.yaml
   ├── data
   │   └── <your files>
+  ├── external
+  │   └── <3rd party jars if needed>
   ├── logs
   │   └── <fscrawler logs>
   └── docker-compose.yml
@@ -278,6 +278,7 @@ And, prepare the following ``docker-compose.yml``. You will find this example in
           - ../../test-documents/src/main/resources/documents/:/tmp/es:ro
           - ${PWD}/config:/root/.fscrawler
           - ${PWD}/logs:/usr/share/fscrawler/logs
+          - ${PWD}/external:/usr/share/fscrawler/external
         depends_on:
           elasticsearch:
             condition: service_healthy
@@ -519,6 +520,7 @@ And, prepare the following ``docker-compose.yml``. You will find this example in
           - ../../test-documents/src/main/resources/documents/:/tmp/es:ro
           - ${PWD}/config:/root/.fscrawler
           - ${PWD}/logs:/usr/share/fscrawler/logs
+          - ${PWD}/external:/usr/share/fscrawler/external
         depends_on:
           enterprisesearch:
             condition: service_healthy


### PR DESCRIPTION
This will help to add easily missing jars (because of license issues) but also custom jars and may be in the future some plugins.

The new layout is now:

```txt
    .
    ├── NOTICE
    ├── LICENSE
    ├── README.md
    ├── bin
    │   ├── fscrawler
    │   └── fscrawler.bat
    ├── config
    │   ├── log4j2.xml
    │   └── log4j2-file.xml
    ├── external
    ├── lib
    └── logs
        ├── documents.log
        └── fscrawler.log
```

The `external` directory contains the external libraries you could add to FSCrawler. For example, if you want to add the `jai-imageio-jpeg2000` library to add support for JPEG2000 images, you can download it from [Maven Central](https://central.sonatype.com/search?q=g:com.github.jai-imageio) and put the `jai-imageio-jpeg2000-1.4.0.jar` file in the `external` directory.

This should also work in the Docker context by mounting the `external` dir:

```sh
docker run -it --rm \
   -v ~/.fscrawler:/root/.fscrawler \
   -v ~/tmp:/tmp/es:ro \
   -v "$PWD/external:/usr/share/fscrawler/external" \
   dadoonet/fscrawler fscrawler job_name
```

Hopefully this could close the following issues:

* #1769
* #1459