### PR TITLE
Fix REST error 500 when wrong field name is used

### DIFF
--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractRestITCase.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractRestITCase.java
@@ -213,7 +213,7 @@ public abstract class AbstractRestITCase extends AbstractITCase {
         void check(ESSearchHit hit);
     }
 
-    private static final Map<String, Object> debugOption = new HashMap<>();
+    protected static final Map<String, Object> debugOption = new HashMap<>();
 
     static {
         debugOption.put("debug", true);

--- a/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/DocumentApi.java
+++ b/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/DocumentApi.java
@@ -164,6 +164,13 @@ public class DocumentApi extends RestApi {
         // Create the Doc object
         Doc doc = new Doc();
 
+        if (d == null) {
+            UploadResponse response = new UploadResponse();
+            response.setOk(false);
+            response.setMessage("No file has been sent or you are not using [file] as the field name.");
+            return response;
+        }
+
         String filename = new String(d.getFileName().getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
         long filesize = d.getSize();
 


### PR DESCRIPTION
Instead of producing a NPE, we now catch the problem (using the wrong field name `file` and return a proper error message.

Closes #1748.