### PR TITLE
fix(sec): upgrade urllib3 to 2.0.7

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -56,7 +56,7 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 typing-extensions==4.7.1
     # via importlib-metadata
-urllib3==2.0.6
+urllib3==2.0.7
     # via requests
 zipp==3.15.0
     # via importlib-metadata


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in urllib3 2.0.6
- [CVE-2023-45803](https://www.oscs1024.com/hd/CVE-2023-45803)


### What did I do？
Upgrade urllib3 from 2.0.6 to 2.0.7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS