### PR TITLE
XMLDocParser should not extract empty field names

### DIFF
--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestXmlSupportIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestXmlSupportIT.java
@@ -57,4 +57,27 @@ public class FsCrawlerTestXmlSupportIT extends AbstractFsCrawlerITCase {
             logger.info("{}", hit.getSource());
         }
     }
+
+    /**
+     * Test case for issue #1753: <a href="https://github.com/dadoonet/fscrawler/issues/1753">https://github.com/dadoonet/fscrawler/issues/1753</a> :
+     * invalid json generated from XML
+     */
+    @Test
+    public void test_xml_not_readable() throws Exception {
+        Fs fs = startCrawlerDefinition()
+                .setXmlSupport(true)
+                .build();
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        ESSearchResponse response = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
+
+        countTestHelper(new ESSearchRequest()
+                .withIndex(getCrawlerName())
+                .withESQuery(new ESMatchQuery("Tag.$", "Content")),
+                1L, null);
+
+        logger.info("XML documents converted to:");
+        for (ESSearchHit hit : response.getHits()) {
+            logger.info("{}", hit.getSource());
+        }
+    }
 }

--- a/integration-tests/src/test/resources-binary/samples/test_xml_not_readable/sample.xml
+++ b/integration-tests/src/test/resources-binary/samples/test_xml_not_readable/sample.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Task>
+ <Tag attr="false">Content</Tag>
+</Task>

--- a/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/XmlDocParser.java
+++ b/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/XmlDocParser.java
@@ -41,7 +41,7 @@ public class XmlDocParser {
     private static final ObjectMapper xmlMapper;
 
     static {
-        xmlMapper = new XmlMapper();
+        xmlMapper = XmlMapper.xmlBuilder().nameForTextElement("$").build();
     }
 
     public static String generate(InputStream inputStream) {

--- a/tika/src/test/java/fr/pilato/elasticsearch/crawler/fs/tika/DocParserTestCase.java
+++ b/tika/src/test/java/fr/pilato/elasticsearch/crawler/fs/tika/DocParserTestCase.java
@@ -25,6 +25,14 @@ import java.io.InputStream;
 
 public class DocParserTestCase extends AbstractFSCrawlerTestCase {
     InputStream getBinaryContent(String filename) {
-        return getClass().getResourceAsStream("/documents/" + filename);
+        return getBinaryContent("/documents", filename);
+    }
+
+    InputStream getBinaryContent(String root, String filename) {
+        if (root == null) {
+            // We try in the same classpath
+            return getClass().getResourceAsStream(filename);
+        }
+        return getClass().getResourceAsStream(root + "/" + filename);
     }
 }

--- a/tika/src/test/java/fr/pilato/elasticsearch/crawler/fs/tika/XmlDocParserTest.java
+++ b/tika/src/test/java/fr/pilato/elasticsearch/crawler/fs/tika/XmlDocParserTest.java
@@ -21,7 +21,6 @@ package fr.pilato.elasticsearch.crawler.fs.tika;
 
 import org.junit.Test;
 
-import java.io.IOException;
 import java.io.InputStream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -30,7 +29,7 @@ import static org.hamcrest.Matchers.is;
 public class XmlDocParserTest extends DocParserTestCase {
 
     @Test
-    public void testXml() throws IOException {
+    public void testXml() {
         String doc = extractFromFile("issue-163.xml");
         assertThat(doc, is("{\"version\":\"1.0\",\"subscription-update\":{\"subscriptionid\":\"0\",\"requestid\":\"0\"," +
                 "\"last_push\":\"2016-06-03 06:21:34\",\"current_push\":\"2016-06-03 06:21:37\",\"exec\":\"0.002\"," +
@@ -38,9 +37,21 @@ public class XmlDocParserTest extends DocParserTestCase {
     }
 
     @Test
-    public void testXmlNestedObjects() throws IOException {
+    public void testXmlNestedObjects() {
         String doc = extractFromFile("issue-592.xml");
         assertThat(doc, is("{\"object\":[{\"id\":\"1\",\"name\":\"foo\"},{\"id\":\"2\",\"name\":\"bar\"}]}"));
+    }
+
+    @Test
+    public void testXmlNotReadable() {
+        String doc = extractFromFile(null, "issue-1753.xml");
+        assertThat(doc, is("{\"Tag\":{\"attr\":\"false\",\"$\":\"Content\"}}"));
+    }
+
+
+    private String extractFromFile(String root, String filename) {
+        InputStream data = getBinaryContent(root, filename);
+        return XmlDocParser.generate(data);
     }
 
     private String extractFromFile(String filename) {

--- a/tika/src/test/resources/fr/pilato/elasticsearch/crawler/fs/tika/issue-1753.xml
+++ b/tika/src/test/resources/fr/pilato/elasticsearch/crawler/fs/tika/issue-1753.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Task>
+ <Tag attr="false">Content</Tag>
+</Task>


### PR DESCRIPTION
If we have a structure like:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<Task>
 <Tag attr="false">Content</Tag>
</Task>
```

The default XMLParser is generating an empty field name for the content:

```json
{
  "Tag": {
     "attr":"false",
     "":"Content"
  }
}
```

This change generates instead a default field name `$`:

```json
{
  "Tag": {
     "attr":"false",
     "$":"Content"
  }
}
```

Closes #1753.