### PR TITLE
Support `elasticsearch.byte_size`

### DIFF
--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -235,6 +235,7 @@ public class ElasticsearchClient implements IElasticsearchClient {
                 ElasticsearchBulkRequest::new)
                 .setBulkActions(settings.getElasticsearch().getBulkSize())
                 .setFlushInterval(settings.getElasticsearch().getFlushInterval())
+                .setByteSize(settings.getElasticsearch().getByteSize())
                 .build();
     }
 

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerBulkProcessorTest.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerBulkProcessorTest.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to David Pilato under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package fr.pilato.elasticsearch.crawler.fs.framework.bulk;
+
+import fr.pilato.elasticsearch.crawler.fs.framework.ByteSizeUnit;
+import fr.pilato.elasticsearch.crawler.fs.framework.ByteSizeValue;
+import fr.pilato.elasticsearch.crawler.fs.framework.TimeValue;
+import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static com.carrotsearch.randomizedtesting.RandomizedTest.randomIntBetween;
+import static fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil.serialize;
+import static org.junit.Assert.*;
+
+public class FsCrawlerBulkProcessorTest extends AbstractFSCrawlerTestCase {
+    private static final TestBean PAYLOAD = new TestBean("bar");
+    private static final int PAYLOAD_SIZE = serialize(PAYLOAD).getBytes().length + 12 /* for the json payload field overhead */;
+
+    @Test
+    public void testBulkProcessorMaxActions() throws IOException {
+        int maxActions = randomIntBetween(1, 1000);
+        TestBulkListener listener = new TestBulkListener();
+        FsCrawlerBulkProcessor<TestOperation, TestBulkRequest, TestBulkResponse> bulkProcessor =
+                new FsCrawlerBulkProcessor<>(
+                        new TestEngine(),
+                        listener,
+                        maxActions,
+                        null,
+                        new ByteSizeValue(1, ByteSizeUnit.MB),
+                        TestBulkRequest::new);
+
+        generatePayload(bulkProcessor, 1, maxActions - 1);
+        assertEquals(0, listener.nbSuccessfulExecutions);
+        generatePayload(bulkProcessor, maxActions, 1);
+        assertEquals(1, listener.nbSuccessfulExecutions);
+        generatePayload(bulkProcessor, maxActions + 1, 1);
+        bulkProcessor.close();
+        assertEquals(2, listener.nbSuccessfulExecutions);
+    }
+
+    @Test
+    public void testBulkProcessorNullSize() throws IOException {
+        int maxActions = randomIntBetween(1, 1000);
+        TestBulkListener listener = new TestBulkListener();
+        FsCrawlerBulkProcessor<TestOperation, TestBulkRequest, TestBulkResponse> bulkProcessor =
+                new FsCrawlerBulkProcessor<>(
+                        new TestEngine(),
+                        listener,
+                        maxActions,
+                        null,
+                        null,
+                        TestBulkRequest::new);
+
+        generatePayload(bulkProcessor, 1, maxActions - 1);
+        assertEquals(0, listener.nbSuccessfulExecutions);
+        generatePayload(bulkProcessor, maxActions, 1);
+        assertEquals(1, listener.nbSuccessfulExecutions);
+        generatePayload(bulkProcessor, maxActions + 1, 1);
+        bulkProcessor.close();
+        assertEquals(2, listener.nbSuccessfulExecutions);
+    }
+
+    @Test
+    public void testBulkProcessorZeroSize() throws IOException {
+        int maxActions = randomIntBetween(1, 1000);
+        TestBulkListener listener = new TestBulkListener();
+        FsCrawlerBulkProcessor<TestOperation, TestBulkRequest, TestBulkResponse> bulkProcessor =
+                new FsCrawlerBulkProcessor<>(
+                        new TestEngine(),
+                        listener,
+                        maxActions,
+                        null,
+                        new ByteSizeValue(0, ByteSizeUnit.MB),
+                        TestBulkRequest::new);
+
+        generatePayload(bulkProcessor, 1, maxActions - 1);
+        assertEquals(0, listener.nbSuccessfulExecutions);
+        generatePayload(bulkProcessor, maxActions, 1);
+        assertEquals(1, listener.nbSuccessfulExecutions);
+        generatePayload(bulkProcessor, maxActions + 1, 1);
+        bulkProcessor.close();
+        assertEquals(2, listener.nbSuccessfulExecutions);
+    }
+
+    @Test
+    public void testBulkProcessorMaxSize() throws IOException {
+        int maxActions = randomIntBetween(1, 1000);
+        TestBulkListener listener = new TestBulkListener();
+        FsCrawlerBulkProcessor<TestOperation, TestBulkRequest, TestBulkResponse> bulkProcessor =
+                new FsCrawlerBulkProcessor<>(
+                        new TestEngine(),
+                        listener,
+                        0,
+                        null,
+                        new ByteSizeValue((long) maxActions * PAYLOAD_SIZE, ByteSizeUnit.BYTES),
+                        TestBulkRequest::new);
+
+        generatePayload(bulkProcessor, 1, maxActions - 1);
+        assertEquals(0, listener.nbSuccessfulExecutions);
+        generatePayload(bulkProcessor, maxActions, 1);
+        assertEquals(1, listener.nbSuccessfulExecutions);
+        generatePayload(bulkProcessor, maxActions + 1, maxActions - 1);
+        assertEquals(1, listener.nbSuccessfulExecutions);
+        generatePayload(bulkProcessor, 2 * maxActions, 1);
+        assertEquals(2, listener.nbSuccessfulExecutions);
+        generatePayload(bulkProcessor, 2 * maxActions + 1, 1);
+        bulkProcessor.close();
+        assertEquals(3, listener.nbSuccessfulExecutions);
+    }
+
+    @Test
+    public void testBulkProcessorFlushInterval() throws IOException, InterruptedException {
+        int maxActions = randomIntBetween(1, 1000);
+        TimeValue flushInterval = TimeValue.timeValueMillis(randomIntBetween(500, 2000));
+        TestBulkListener listener = new TestBulkListener();
+        FsCrawlerBulkProcessor<TestOperation, TestBulkRequest, TestBulkResponse> bulkProcessor =
+                new FsCrawlerBulkProcessor<>(new TestEngine(), listener, 0, flushInterval, null, TestBulkRequest::new);
+
+        // We don't load immediately the bulk processor
+        Thread.sleep(100);
+
+        generatePayload(bulkProcessor, 1, maxActions);
+        assertEquals(0, listener.nbSuccessfulExecutions);
+
+        Thread.sleep(flushInterval.millis());
+
+        assertEquals(1, listener.nbSuccessfulExecutions);
+        bulkProcessor.close();
+        assertEquals(1, listener.nbSuccessfulExecutions);
+    }
+
+    private void generatePayload(FsCrawlerBulkProcessor<TestOperation, TestBulkRequest, TestBulkResponse> bulkProcessor, int start, int size) {
+        for (int i = start; i < start + size; i++) {
+            logger.trace("Adding a new operation [{}]", i);
+            bulkProcessor.add(new TestOperation(PAYLOAD));
+        }
+    }
+
+}

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerBulkTest.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerBulkTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to David Pilato under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package fr.pilato.elasticsearch.crawler.fs.framework.bulk;
+
+import fr.pilato.elasticsearch.crawler.fs.framework.ByteSizeUnit;
+import fr.pilato.elasticsearch.crawler.fs.framework.ByteSizeValue;
+import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
+import org.junit.Test;
+
+import static com.carrotsearch.randomizedtesting.RandomizedTest.randomIntBetween;
+import static fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil.serialize;
+import static org.junit.Assert.assertEquals;
+
+public class FsCrawlerBulkTest extends AbstractFSCrawlerTestCase {
+    private static final TestBean PAYLOAD = new TestBean("bar");
+    private static final int PAYLOAD_SIZE = serialize(PAYLOAD).getBytes().length + 12 /* for the json payload field overhead */;
+
+    @Test
+    public void testBulkRequestLimitsMaxActions() {
+        int maxActions = randomIntBetween(1, 1000);
+        FsCrawlerBulkRequest<TestOperation> bulk = generateBulk(maxActions, new ByteSizeValue(1, ByteSizeUnit.MB));
+        generateAndTest(bulk, 1, maxActions - 1, false);
+        generateAndTest(bulk, maxActions, 1, true);
+    }
+
+    @Test
+    public void testBulkRequestLimitsMaxSize() {
+        int firstSize = randomIntBetween(1, 1000);
+        int secondSize = 1;
+        FsCrawlerBulkRequest<TestOperation> bulk = generateBulk(0, new ByteSizeValue((long) firstSize * PAYLOAD_SIZE, ByteSizeUnit.BYTES));
+        generateAndTest(bulk, 1, firstSize - 1, false);
+        generateAndTest(bulk, firstSize, secondSize, true);
+    }
+
+    @Test
+    public void testBulkRequestLimitsNullSize() {
+        int maxActions = randomIntBetween(1, 1000);
+        FsCrawlerBulkRequest<TestOperation> bulk = generateBulk(maxActions, null);
+        generateAndTest(bulk, 1, maxActions - 1, false);
+        generateAndTest(bulk, maxActions, 1, true);
+    }
+
+    @Test
+    public void testBulkRequestLimitsZeroSize() {
+        int maxActions = randomIntBetween(1, 1000);
+        FsCrawlerBulkRequest<TestOperation> bulk = generateBulk(maxActions, new ByteSizeValue(0, ByteSizeUnit.KB));
+        generateAndTest(bulk, 1, maxActions - 1, false);
+        generateAndTest(bulk, maxActions, 1, true);
+    }
+
+    @Test
+    public void testBulkRequestNoLimits() {
+        int nbActions = randomIntBetween(1, 1000);
+        FsCrawlerBulkRequest<TestOperation> bulk = generateBulk(0, null);
+        generateAndTest(bulk, 1, nbActions, false);
+    }
+
+    private void generateAndTest(FsCrawlerBulkRequest<TestOperation> bulk, int start, int size, boolean overTheLimit) {
+        logger.debug("adding {} actions to the bulk which contains {} actions", size, bulk.numberOfActions());
+        generatePayload(bulk, start, size);
+        logger.debug("is over the limit after {} actions and {} bytes? {}", start + size - 1, bulk.totalByteSize(), bulk.isOverTheLimit());
+        assertEquals(overTheLimit, bulk.isOverTheLimit());
+        assertEquals(start + size - 1, bulk.numberOfActions());
+    }
+
+    private FsCrawlerBulkRequest<TestOperation> generateBulk(Integer maxActions, ByteSizeValue maxBulkSize) {
+        logger.debug("Creating a new bulk request with maxActions [{}] and maxBulkSize [{}]", maxActions, maxBulkSize);
+        FsCrawlerBulkRequest<TestOperation> bulk = new TestBulkRequest();
+        bulk.maxNumberOfActions(maxActions);
+        bulk.maxBulkSize(maxBulkSize);
+        return bulk;
+    }
+
+    private void generatePayload(FsCrawlerBulkRequest<TestOperation> bulk, int start, int size) {
+        for (int i = start; i < start + size; i++) {
+            logger.trace("Adding a new operation [{}]", i);
+            bulk.add(new TestOperation(PAYLOAD));
+        }
+    }
+}

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/TestBean.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/TestBean.java
@@ -1,0 +1,13 @@
+package fr.pilato.elasticsearch.crawler.fs.framework.bulk;
+
+public class TestBean {
+    private final String test;
+
+    public TestBean(String test) {
+        this.test = test;
+    }
+
+    public String getTest() {
+        return test;
+    }
+}

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/TestBulkListener.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/TestBulkListener.java
@@ -1,0 +1,24 @@
+package fr.pilato.elasticsearch.crawler.fs.framework.bulk;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+class TestBulkListener extends FsCrawlerSimpleBulkProcessorListener<TestOperation, TestBulkRequest, TestBulkResponse> {
+    Logger logger = LogManager.getLogger(TestBulkListener.class);
+    TestBulkRequest latestRequest;
+    int nbSuccessfulExecutions = 0;
+
+    @Override
+    public void beforeBulk(long executionId, TestBulkRequest request) {
+        logger.trace("Execution [{}] starting", nbSuccessfulExecutions, request.numberOfActions());
+        super.beforeBulk(executionId, request);
+    }
+
+    @Override
+    public void afterBulk(long executionId, TestBulkRequest request, TestBulkResponse response) {
+        logger.trace("Execution [{}] done", nbSuccessfulExecutions);
+        latestRequest = request;
+        nbSuccessfulExecutions++;
+        super.afterBulk(executionId, request, response);
+    }
+}

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/TestBulkRequest.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/TestBulkRequest.java
@@ -1,0 +1,5 @@
+package fr.pilato.elasticsearch.crawler.fs.framework.bulk;
+
+class TestBulkRequest extends FsCrawlerBulkRequest<TestOperation> {
+
+}

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/TestBulkResponse.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/TestBulkResponse.java
@@ -1,0 +1,5 @@
+package fr.pilato.elasticsearch.crawler.fs.framework.bulk;
+
+class TestBulkResponse extends FsCrawlerBulkResponse<TestOperation> {
+
+}

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/TestEngine.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/TestEngine.java
@@ -1,0 +1,8 @@
+package fr.pilato.elasticsearch.crawler.fs.framework.bulk;
+
+class TestEngine implements Engine<TestOperation, TestBulkRequest, TestBulkResponse> {
+    @Override
+    public TestBulkResponse bulk(TestBulkRequest request) {
+        return new TestBulkResponse();
+    }
+}

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/TestOperation.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/TestOperation.java
@@ -1,0 +1,22 @@
+package fr.pilato.elasticsearch.crawler.fs.framework.bulk;
+
+public class TestOperation implements FsCrawlerOperation<TestOperation> {
+    TestBean payload;
+
+    public TestOperation(TestBean payload) {
+        this.payload = payload;
+    }
+
+    @Override
+    public int compareTo(TestOperation request) {
+        return 0;
+    }
+
+    public void payload(TestBean payload) {
+        this.payload = payload;
+    }
+
+    public TestBean getPayload() {
+        return payload;
+    }
+}

--- a/framework/src/test/resources/log4j2.xml
+++ b/framework/src/test/resources/log4j2.xml
@@ -9,7 +9,7 @@
       </Console>
    </Appenders>
    <Loggers>
-      <Logger name="fr.pilato.elasticsearch.crawler.fs.framework" level="trace" additivity="false">
+      <Logger name="fr.pilato.elasticsearch.crawler.fs.framework" level="debug" additivity="false">
          <AppenderRef ref="CONSOLE"/>
       </Logger>
       <Logger name="fr.pilato.elasticsearch.crawler.fs.test" level="info" additivity="false">


### PR DESCRIPTION
This was removed by mistake when we got rid of the Elasticsearch client.
This is added back with this PR.

This PR is based on @kamalsharma9001 work in #1835 but I wanted to refactor it a bit.

Thanks for the initial code!

