### PR TITLE
Replace docker compose maven plugin by TestContainers

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17 and Maven Central Repository
+      - name: Set up JDK 21 and Maven Central Repository
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'adopt'
+          java-version: '21'
+          distribution: 'temurin'
           cache: 'maven'
           server-id: sonatype-nexus-snapshots
           server-username: MAVEN_USERNAME
@@ -31,11 +31,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17 and Maven Central Repository
+      - name: Set up JDK 21 and Maven Central Repository
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'adopt'
+          java-version: '21'
+          distribution: 'temurin'
           cache: 'maven'
           server-id: sonatype-nexus-snapshots
           server-username: MAVEN_USERNAME

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
-        distribution: 'adopt'
+        java-version: '21'
+        distribution: 'temurin'
         cache: 'maven'
     - name: Display Maven information
       run: mvn --version
@@ -28,11 +28,11 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'adopt'
+          java-version: '21'
+          distribution: 'temurin'
           cache: 'maven'
       - name: Run all the unit tests
         run: mvn --batch-mode install -Ddocker.skip -DskipIntegTests
@@ -43,11 +43,11 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'adopt'
+          java-version: '21'
+          distribution: 'temurin'
           cache: 'maven'
       - name: Cache Docker images
         uses: ScribeMD/docker-cache@0.5.0
@@ -63,11 +63,11 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'adopt'
+          java-version: '21'
+          distribution: 'temurin'
           cache: 'maven'
       - name: Cache Docker images
         uses: ScribeMD/docker-cache@0.5.0
@@ -83,11 +83,11 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'adopt'
+          java-version: '21'
+          distribution: 'temurin'
           cache: 'maven'
       - name: Cache Docker images
         uses: ScribeMD/docker-cache@0.5.0
@@ -103,11 +103,11 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'adopt'
+          java-version: '21'
+          distribution: 'temurin'
           cache: 'maven'
       - name: Cache Docker images
         uses: ScribeMD/docker-cache@0.5.0

--- a/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
+++ b/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
@@ -78,9 +78,6 @@ public class FsCrawlerCli {
         @Parameter(names = "--api_key", description = "Elasticsearch api key. See https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html")
         String apiKey = null;
 
-        @Parameter(names = "--access_token", description = "Elasticsearch access token. See https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-token.html")
-        String accessToken = null;
-
         @Parameter(names = "--username", description = "Elasticsearch username. (Deprecated - use --api_key or --access_token instead)")
         @Deprecated
         String username = null;
@@ -228,9 +225,8 @@ public class FsCrawlerCli {
      * @param fsSettings        the settings to modify
      * @param usernameCli       the username coming from the CLI if any (deprecated)
      * @param apiKeyCli         the api key coming from the CLI if any
-     * @param accessTokenCli    the access token coming from the CLI if any
      */
-    static void modifySettings(FsSettings fsSettings, String usernameCli, String apiKeyCli, String accessTokenCli) {
+    static void modifySettings(FsSettings fsSettings, String usernameCli, String apiKeyCli) {
         // Check default settings
         if (fsSettings.getFs() == null) {
             fsSettings.setFs(Fs.DEFAULT);
@@ -260,11 +256,6 @@ public class FsCrawlerCli {
         // Overwrite settings with command line values
         if (fsSettings.getElasticsearch().getApiKey() == null && apiKeyCli != null) {
             fsSettings.getElasticsearch().setApiKey(apiKeyCli);
-        }
-
-        // Overwrite settings with command line values
-        if (fsSettings.getElasticsearch().getAccessToken() == null && accessTokenCli != null) {
-            fsSettings.getElasticsearch().setAccessToken(accessTokenCli);
         }
     }
 
@@ -382,7 +373,7 @@ public class FsCrawlerCli {
             return;
         }
 
-        modifySettings(fsSettings, command.username, command.apiKey, command.accessToken);
+        modifySettings(fsSettings, command.username, command.apiKey);
         if (fsSettings.getElasticsearch().getUsername() != null && fsSettings.getElasticsearch().getPassword() == null && scanner != null) {
             FSCrawlerLogger.console("Password for {}:", fsSettings.getElasticsearch().getUsername());
             String password = scanner.next();

--- a/cli/src/test/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCliDefaultSettingsTest.java
+++ b/cli/src/test/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCliDefaultSettingsTest.java
@@ -83,12 +83,11 @@ public class FsCrawlerCliDefaultSettingsTest extends AbstractFSCrawlerTestCase {
         FsSettings settings = fsSettingsFileHandler.read("modify_settings_no_username");
         assertThat(settings.getFs(), nullValue());
         assertThat(settings.getElasticsearch(), nullValue());
-        modifySettings(settings, null, null, null);
+        modifySettings(settings, null, null);
         assertThat(settings.getFs(), notNullValue());
         assertThat(settings.getElasticsearch(), notNullValue());
         assertThat(settings.getElasticsearch().getUsername(), nullValue());
         assertThat(settings.getElasticsearch().getApiKey(), nullValue());
-        assertThat(settings.getElasticsearch().getAccessToken(), nullValue());
     }
 
     @Test
@@ -101,12 +100,11 @@ public class FsCrawlerCliDefaultSettingsTest extends AbstractFSCrawlerTestCase {
         FsSettings settings = fsSettingsFileHandler.read("modify_settings_with_username");
         assertThat(settings.getFs(), nullValue());
         assertThat(settings.getElasticsearch(), nullValue());
-        modifySettings(settings, "elastic", null, null);
+        modifySettings(settings, "elastic", null);
         assertThat(settings.getFs(), notNullValue());
         assertThat(settings.getElasticsearch(), notNullValue());
         assertThat(settings.getElasticsearch().getUsername(), is("elastic"));
         assertThat(settings.getElasticsearch().getApiKey(), nullValue());
-        assertThat(settings.getElasticsearch().getAccessToken(), nullValue());
     }
 
     @Test
@@ -119,30 +117,11 @@ public class FsCrawlerCliDefaultSettingsTest extends AbstractFSCrawlerTestCase {
         FsSettings settings = fsSettingsFileHandler.read("modify_settings_with_username");
         assertThat(settings.getFs(), nullValue());
         assertThat(settings.getElasticsearch(), nullValue());
-        modifySettings(settings, null, "my_api_key_base64_encoded", null);
+        modifySettings(settings, null, "my_api_key_base64_encoded");
         assertThat(settings.getFs(), notNullValue());
         assertThat(settings.getElasticsearch(), notNullValue());
         assertThat(settings.getElasticsearch().getUsername(), nullValue());
         assertThat(settings.getElasticsearch().getApiKey(), is("my_api_key_base64_encoded"));
-        assertThat(settings.getElasticsearch().getAccessToken(), nullValue());
-    }
-
-    @Test
-    public void testModifySettingsWithAccessToken() throws IOException {
-        FsSettingsFileHandler fsSettingsFileHandler = new FsSettingsFileHandler(metadataDir);
-        Path jobDir = metadataDir.resolve("modify_settings_with_username");
-        Files.createDirectories(jobDir);
-
-        Files.writeString(jobDir.resolve(SETTINGS_YAML), "name: \"modify_settings_with_username\"");
-        FsSettings settings = fsSettingsFileHandler.read("modify_settings_with_username");
-        assertThat(settings.getFs(), nullValue());
-        assertThat(settings.getElasticsearch(), nullValue());
-        modifySettings(settings, null, null, "my_access_token");
-        assertThat(settings.getFs(), notNullValue());
-        assertThat(settings.getElasticsearch(), notNullValue());
-        assertThat(settings.getElasticsearch().getUsername(), nullValue());
-        assertThat(settings.getElasticsearch().getApiKey(), nullValue());
-        assertThat(settings.getElasticsearch().getAccessToken(), is("my_access_token"));
     }
 
     @Test
@@ -162,12 +141,11 @@ public class FsCrawlerCliDefaultSettingsTest extends AbstractFSCrawlerTestCase {
         assertThat(settings.getServer(), notNullValue());
         assertThat(settings.getServer().getPort(), is(Server.PROTOCOL.SSH_PORT));
         assertThat(settings.getServer().getUsername(), nullValue());
-        modifySettings(settings, null, "my_api_key_base64_encoded", null);
+        modifySettings(settings, null, "my_api_key_base64_encoded");
         assertThat(settings.getFs(), notNullValue());
         assertThat(settings.getElasticsearch(), notNullValue());
         assertThat(settings.getElasticsearch().getUsername(), nullValue());
         assertThat(settings.getElasticsearch().getApiKey(), is("my_api_key_base64_encoded"));
-        assertThat(settings.getElasticsearch().getAccessToken(), nullValue());
         assertThat(settings.getServer().getPort(), is(Server.PROTOCOL.FTP_PORT));
         assertThat(settings.getServer().getUsername(), is("anonymous"));
     }
@@ -189,12 +167,11 @@ public class FsCrawlerCliDefaultSettingsTest extends AbstractFSCrawlerTestCase {
         assertThat(settings.getServer(), notNullValue());
         assertThat(settings.getServer().getPort(), is(Server.PROTOCOL.SSH_PORT));
         assertThat(settings.getServer().getUsername(), nullValue());
-        modifySettings(settings, null, "my_api_key_base64_encoded", null);
+        modifySettings(settings, null, "my_api_key_base64_encoded");
         assertThat(settings.getFs(), notNullValue());
         assertThat(settings.getElasticsearch(), notNullValue());
         assertThat(settings.getElasticsearch().getUsername(), nullValue());
         assertThat(settings.getElasticsearch().getApiKey(), is("my_api_key_base64_encoded"));
-        assertThat(settings.getElasticsearch().getAccessToken(), nullValue());
         assertThat(settings.getServer().getPort(), is(Server.PROTOCOL.SSH_PORT));
         assertThat(settings.getServer().getUsername(), nullValue());
     }

--- a/contrib/docker-compose-example-elasticsearch/.env
+++ b/contrib/docker-compose-example-elasticsearch/.env
@@ -11,7 +11,7 @@ ELASTIC_PASSWORD=changeme
 KIBANA_PASSWORD=changeme
 
 # Version of Elastic products
-STACK_VERSION=8.14.1
+STACK_VERSION=8.14.3
 
 # Set the cluster name
 CLUSTER_NAME=docker-cluster

--- a/contrib/docker-compose-it-v7/.env
+++ b/contrib/docker-compose-it-v7/.env
@@ -7,7 +7,7 @@ ELASTIC_PASSWORD=changeme
 KIBANA_PASSWORD=changeme
 
 # Version of Elastic products
-STACK_VERSION=7.17.19
+STACK_VERSION=7.17.23
 
 # Set the cluster name
 CLUSTER_NAME=docker-cluster

--- a/contrib/docker-compose-it/.env
+++ b/contrib/docker-compose-it/.env
@@ -7,7 +7,7 @@ ELASTIC_PASSWORD=changeme
 KIBANA_PASSWORD=changeme
 
 # Version of Elastic products
-STACK_VERSION=8.14.1
+STACK_VERSION=8.14.3
 
 # Set the cluster name
 CLUSTER_NAME=docker-cluster

--- a/docs/source/admin/cli-options.rst
+++ b/docs/source/admin/cli-options.rst
@@ -8,11 +8,9 @@ CLI options
 -  ``--config_dir`` defines directory where jobs are stored instead of
    default ``~/.fscrawler``.
 -  ``--api_key`` defines the Elasticsearch Api Key to use.
-   Do not use with ``--username`` or ``--access_token``. Read :ref:`credentials`.
--  ``--access_token`` defines the Elasticsearch Access Token to use.
-   Do not use with ``--username`` or ``--api_key``. Read :ref:`credentials`.
+   Do not use with ``--username``. Read :ref:`credentials`.
 -  ``--username`` defines the username to use (Deprecated).
-   Do not use with ``--api_key`` or ``--access_token``. Read :ref:`credentials`.
+   Do not use with ``--api_key``. Read :ref:`credentials`.
 -  ``--loop x`` defines the number of runs we want before exiting. See `Loop`_.
 -  ``--restart`` restart a job from scratch. See `Restart`_.
 -  ``--rest`` starts the REST service. See `Rest`_.

--- a/docs/source/admin/fs/elasticsearch.rst
+++ b/docs/source/admin/fs/elasticsearch.rst
@@ -30,8 +30,6 @@ Here is a list of Elasticsearch settings (under ``elasticsearch.`` prefix)`:
 +-----------------------------------+---------------------------+---------------------------------+
 | ``elasticsearch.api_key``         | ``null``                  | `API Key`_                      |
 +-----------------------------------+---------------------------+---------------------------------+
-| ``elasticsearch.access_token``    | ``null``                  | `Access Token`_                 |
-+-----------------------------------+---------------------------+---------------------------------+
 | ``elasticsearch.username``        | ``null``                  | :ref:`credentials`              |
 +-----------------------------------+---------------------------+---------------------------------+
 | ``elasticsearch.password``        | ``null``                  | :ref:`credentials`              |
@@ -305,7 +303,6 @@ If you have a secured cluster, you can use several methods to connect
 to it:
 
 - `API Key <https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html>`__
-- `Access Token <https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-token.html>`__
 - `Basic Authentication <https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html>`__ (not recommended / deprecated)
 
 API Key
@@ -341,59 +338,6 @@ Then you can use the encoded API Key in FSCrawler settings:
    name: "test"
    elasticsearch:
      api_key: "VnVhQ2ZHY0JDZGJrUW0tZTVhT3g6dWkybHAyYXhUTm1zeWFrdzl0dk5udw=="
-
-.. _credentials-access-token:
-
-Access Token
-~~~~~~~~~~~~
-
-.. versionadded:: 2.10
-
-Let's create an API Key named ``fscrawler``:
-
-.. code:: json
-
-    POST /_security/oauth2/token
-    {
-      "grant_type" : "client_credentials"
-    }
-
-This gives something like:
-
-.. code:: json
-
-    {
-      "access_token" : "dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==",
-      "type" : "Bearer",
-      "expires_in" : 1200,
-      "authentication" : {
-        "username" : "test_admin",
-        "roles" : [
-          "superuser"
-        ],
-        "full_name" : null,
-        "email" : null,
-        "metadata" : { },
-        "enabled" : true,
-        "authentication_realm" : {
-          "name" : "file",
-          "type" : "file"
-        },
-        "lookup_realm" : {
-          "name" : "file",
-          "type" : "file"
-        },
-        "authentication_type" : "realm"
-      }
-    }
-
-Then you can use the generated Access Token in FSCrawler settings:
-
-.. code:: yaml
-
-   name: "test"
-   elasticsearch:
-     access_token: "dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ=="
 
 Basic Authentication (deprecated)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/dev/build.rst
+++ b/docs/source/dev/build.rst
@@ -27,8 +27,7 @@ To build the project, run::
 
     mvn clean package
 
-The final artifacts are available in ``distribution/esX/target`` directory where ``X`` is the
-elasticsearch major version target.
+The final artifacts are available in ``distribution/target``.
 
 .. tip::
 
@@ -47,11 +46,25 @@ A HTTP server is also started on port 8080 during the integration tests, alterna
 Run tests from your IDE
 """""""""""""""""""""""
 
-To run integration tests from your IDE, you need to start tests in ``fscrawler-it-common`` module.
-But you need first to specify the Maven profile to use and rebuild the project.
+To run integration tests from your IDE, you need to start tests in ``fscrawler-it`` module.
+But you can specify the Maven profile to use and rebuild the project.
 
 * ``es-7x`` for Elasticsearch 7.x
 * ``es-6x`` for Elasticsearch 6.x
+
+Faster integration tests
+""""""""""""""""""""""""
+
+As we are using `Testcontainers <https://java.testcontainers.org/modules/elasticsearch/>`_,
+we can `reuse <https://java.testcontainers.org/features/reuse/>`_ the Elasticsearch container instead of having to restart
+one everytime.
+
+.. note:: You need to explicitly `enable this feature <https://java.testcontainers.org/features/reuse/>`_.
+
+If you run from the IDE, reusing containers is the default behavior. But if you run the CLI, you need
+to set ``tests.leaveTemporary`` to ``true``::
+
+    mvn verify -Dtests.leaveTemporary=true
 
 Run a specific test from your Terminal
 """"""""""""""""""""""""""""""""""""""
@@ -68,22 +81,28 @@ cluster, you need to provide a ``tests.cluster.url`` value. This will skip launc
 
 To run the test suite against an elasticsearch instance running locally, just run::
 
-    mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it-v7 -Dtests.cluster.url=http://localhost:9200
+    mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it -Dtests.cluster.url=http://localhost:9200
 
 .. tip::
 
     If you want to run against a version 6, run::
 
-        mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it-v6 -Dtests.cluster.url=http://localhost:9200
+        mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it -Dtests.cluster.url=http://localhost:9200
 
 .. hint::
 
-    If you are using a secured instance, use ``tests.cluster.user``, ``tests.cluster.pass`` and ``tests.cluster.url``::
+    If you are using a secured instance, use ``tests.cluster.user``, ``tests.cluster.apiKey``::
 
-        mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it-v7 \
+        mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it \
+            -Dtests.cluster.apiKey=APIKEYHERE \
+            -Dtests.cluster.url=https://127.0.0.1:9200 \
+
+    If you don't have an API Key, use ``tests.cluster.user``, ``tests.cluster.pass`` and ``tests.cluster.url``::
+
+        mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it \
             -Dtests.cluster.user=elastic \
             -Dtests.cluster.pass=changeme \
-            -Dtests.cluster.url=http://127.0.0.1:9200 \
+            -Dtests.cluster.url=https://127.0.0.1:9200 \
 
 .. hint::
 
@@ -91,16 +110,14 @@ To run the test suite against an elasticsearch instance running locally, just ru
     `Elasticsearch service by Elastic <https://www.elastic.co/cloud/elasticsearch-service>`_,
     you can also use ``tests.cluster.url`` to set where elasticsearch is running::
 
-        mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it-v7 \
-            -Dtests.cluster.user=elastic \
-            -Dtests.cluster.pass=changeme \
+        mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it \
+            -Dtests.cluster.apiKey=APIKEYHERE \
             -Dtests.cluster.url=https://XYZ.es.io:9243
 
     Or even easier, you can use the ``Cloud ID`` available on you Cloud Console::
 
-        mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it-v7 \
-            -Dtests.cluster.user=elastic \
-            -Dtests.cluster.pass=changeme \
+        mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it \
+            -Dtests.cluster.apiKey=APIKEYHERE \
             -Dtests.cluster.cloud_id=fscrawler:ZXVyb3BlLXdlc3QxLmdjcC5jbG91ZC5lcy5pbyQxZDFlYTk5Njg4Nzc0NWE2YTJiN2NiNzkzMTUzNDhhMyQyOTk1MDI3MzZmZGQ0OTI5OTE5M2UzNjdlOTk3ZmU3Nw==
 
 Using security feature
@@ -114,51 +131,6 @@ Secured tests are using by default ``changeme`` as the password.
 You can change this by using ``tests.cluster.pass`` option::
 
     mvn verify -Dtests.cluster.pass=mystrongpassword
-
-
-Testing Workplace Search connector
-""""""""""""""""""""""""""""""""""
-
-.. versionadded:: 2.7
-
-The Workplace Search integration is automatically tested when running the integration tests.
-The maven process will start both elasticsearch and enterprise search nodes. Note that this
-could take several minutes before to have it up and running.
-
-To test the Workplace Search connector against an existing cluster, you can provide the ``tests.cluster.url`` setting.
-This will skip launching the containers and all the test suite will run against this external cluster::
-
-    mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it-v7 \
-        -Dtests.cluster.url=http://localhost:9200 \
-        -Dtests.cluster.user=elastic \
-        -Dtests.cluster.pass=changeme \
-        -Dtests.workplace.url=http://localhost:3002
-
-.. note::
-
-    By default, ``tests.workplace.user`` and ``tests.workplace.pass`` are using the same values as for
-    ``tests.cluster.user`` and ``tests.cluster.pass``. But if you want to use another username and password
-    to connect to workplace search, you can override the settings::
-
-        mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it-v7 \
-            -Dtests.cluster.url=http://localhost:9200 \
-            -Dtests.cluster.user=elastic \
-            -Dtests.cluster.pass=changeme \
-            -Dtests.workplace.url=http://localhost:3002
-            -Dtests.workplace.user=enterprise_search \
-            -Dtests.workplace.pass=changeme
-
-To run Workplace Search tests against the
-`Enterprise Search service by Elastic <https://www.elastic.co/workplace-search>`_,
-you can also use something like::
-
-    mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it-v7 \
-        -Dtests.cluster.url=https://ALIAS.es.eu-west-3.aws.elastic-cloud.com:9243 \
-        -Dtests.cluster.user=elastic \
-        -Dtests.cluster.pass=changeme \
-        -Dtests.workplace.url=https://ALIAS.ent.eu-west-3.aws.elastic-cloud.com \
-        -Dtests.workplace.user=enterprise_search \
-        -Dtests.workplace.pass=changeme
 
 Changing the REST port
 """"""""""""""""""""""

--- a/docs/source/fscrawler.ini
+++ b/docs/source/fscrawler.ini
@@ -5,5 +5,5 @@ Version=2.10-SNAPSHOT
 TikaVersion=2.9.2
 ElasticsearchVersion6=6.8.23
 ElasticsearchVersion7=7.17.23
-ElasticsearchVersion8=8.14.1
+ElasticsearchVersion8=8.14.3
 JpegVersion=1.4.0

--- a/docs/source/fscrawler.ini
+++ b/docs/source/fscrawler.ini
@@ -4,6 +4,6 @@ Version=2.10-SNAPSHOT
 [3rdParty]
 TikaVersion=2.9.2
 ElasticsearchVersion6=6.8.23
-ElasticsearchVersion7=7.17.19
+ElasticsearchVersion7=7.17.23
 ElasticsearchVersion8=8.14.1
 JpegVersion=1.4.0

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -187,11 +187,9 @@ public class ElasticsearchClient implements IElasticsearchClient {
         ClientBuilder clientBuilder = ClientBuilder.newBuilder()
                 .withConfig(config);
 
-        // If we have an Api Key or an Access Token, let's use it. Otherwise, we will use basic auth
+        // If we have an Api Key let's use it. Otherwise, we will use basic auth
         if (!FsCrawlerUtil.isNullOrEmpty(settings.getElasticsearch().getApiKey())) {
             authorizationHeader = "ApiKey " + settings.getElasticsearch().getApiKey();
-        } else if (!FsCrawlerUtil.isNullOrEmpty(settings.getElasticsearch().getAccessToken())) {
-            authorizationHeader = "Bearer " + settings.getElasticsearch().getAccessToken();
         } else {
             HttpAuthenticationFeature feature = HttpAuthenticationFeature.basic(
                     settings.getElasticsearch().getUsername(),
@@ -848,20 +846,6 @@ public class ElasticsearchClient implements IElasticsearchClient {
 
         logger.debug("generated key [{}] for [{}]: [{}]", id, keyName, encodedApiKey);
         return encodedApiKey;
-    }
-
-    @Override
-    public String generateElasticsearchToken() throws ElasticsearchClientException {
-        String request = "{\"grant_type\":\"client_credentials\"}";
-        logger.debug("generate an Elasticsearch Access Token");
-        String response = httpPost("/_security/oauth2/token", request);
-
-        // Parse the response
-        DocumentContext document = parseJsonAsDocumentContext(response);
-        String token = document.read("$.access_token");
-
-        logger.debug("generated Elasticsearch Access Token: [{}]", token);
-        return token;
     }
 
     private void createIndex(Path jobMappingDir, int elasticsearchVersion, String indexSettingsFile, String indexName) throws Exception {

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/IElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/IElasticsearchClient.java
@@ -215,11 +215,4 @@ public interface IElasticsearchClient extends Closeable {
      * @return  the generated API key BASE64 encoded of key:value
      */
     String generateApiKey(String keyName) throws ElasticsearchClientException;
-
-
-    /**
-     * Generate an Elasticsearch Token (for tests purposes only)
-     * @return  the generated access token
-     */
-    String generateElasticsearchToken() throws ElasticsearchClientException;
 }

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -49,6 +49,11 @@
             <artifactId>MockFtpServer</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -96,24 +101,6 @@
                 </configuration>
             </plugin>
 
-            <!-- To start Docker Compose when running IT -->
-            <plugin>
-                <groupId>com.dkanejs.maven.plugins</groupId>
-                <artifactId>docker-compose-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>de.scravy</groupId>
-                <artifactId>waitfor-maven-plugin</artifactId>
-                <configuration>
-                    <checks>
-                        <check>
-                            <url>https://localhost:9200/</url>
-                            <statusCode>401</statusCode>
-                        </check>
-                    </checks>
-                </configuration>
-            </plugin>
-
             <plugin>
                 <groupId>com.carrotsearch.randomizedtesting</groupId>
                 <artifactId>junit4-maven-plugin</artifactId>
@@ -129,112 +116,19 @@
     </build>
 
     <profiles>
-        <profile>
-            <id>skip-docker-compose</id>
-            <activation>
-                <property>
-                    <name>tests.cluster.url</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.dkanejs.maven.plugins</groupId>
-                        <artifactId>docker-compose-maven-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>de.scravy</groupId>
-                        <artifactId>waitfor-maven-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>run-docker-compose</id>
-            <activation>
-                <property>
-                    <name>!tests.cluster.url</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.dkanejs.maven.plugins</groupId>
-                        <artifactId>docker-compose-maven-plugin</artifactId>
-                        <configuration>
-                            <skip>${skipIntegTests}</skip>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>de.scravy</groupId>
-                        <artifactId>waitfor-maven-plugin</artifactId>
-                        <configuration>
-                            <skip>${skipIntegTests}</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
         <!-- Profile for ES7 -->
         <profile>
             <id>es-7x</id>
             <properties>
                 <integ.elasticsearch.version>${elasticsearch7.version}</integ.elasticsearch.version>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.dkanejs.maven.plugins</groupId>
-                        <artifactId>docker-compose-maven-plugin</artifactId>
-                        <configuration>
-                            <envFile>${contrib.dir}/docker-compose-it-v7/.env</envFile>
-                            <composeFiles>
-                                <composeFile>${contrib.dir}/docker-compose-it-v7/docker-compose.yml</composeFile>
-                            </composeFiles>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
-        <!-- Profile for ES6: no https -->
+        <!-- Profile for ES6 -->
         <profile>
             <id>es-6x</id>
             <properties>
                 <integ.elasticsearch.version>${elasticsearch6.version}</integ.elasticsearch.version>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.dkanejs.maven.plugins</groupId>
-                        <artifactId>docker-compose-maven-plugin</artifactId>
-                        <configuration>
-                            <envFile>${contrib.dir}/docker-compose-it-v6/.env</envFile>
-                            <composeFiles>
-                                <composeFile>${contrib.dir}/docker-compose-it-v6/docker-compose.yml</composeFile>
-                            </composeFiles>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>de.scravy</groupId>
-                        <artifactId>waitfor-maven-plugin</artifactId>
-                        <configuration>
-                            <checks>
-                                <check>
-                                    <url>http://localhost:9200/</url>
-                                    <statusCode>401</statusCode>
-                                </check>
-                            </checks>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/TestContainerHelper.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/TestContainerHelper.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package fr.pilato.elasticsearch.crawler.fs.test.integration;
+
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * This creates a TestContainer Elasticsearch instance
+ */
+class TestContainerHelper {
+
+    private static final Logger log = LoggerFactory.getLogger(TestContainerHelper.class);
+
+    ElasticsearchContainer elasticsearch;
+    private byte[] certAsBytes;
+
+    /**
+     * Start the container
+     * @param  keepData keep the cluster running after the test and reuse it if possible
+     * @throws IOException in case of error
+     */
+    String startElasticsearch(boolean keepData) throws IOException {
+        Properties props = new Properties();
+        props.load(TestContainerHelper.class.getResourceAsStream("/elasticsearch.version.properties"));
+        String version = props.getProperty("version");
+        String password = props.getProperty("password");
+
+        // Start the container. This step might take some time...
+        log.info("Starting testcontainers with Elasticsearch [{}].", version);
+        elasticsearch = new ElasticsearchContainer(
+                DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
+                        .withTag(version))
+                // As for 7.x clusters, there's no https, api keys are disabled by default. We force it.
+                .withEnv("xpack.security.authc.api_key.enabled", "true")
+                .withReuse(keepData)
+                .withPassword(password);
+        elasticsearch.start();
+
+        // Try to get the https certificate if exists
+        try {
+            certAsBytes = elasticsearch.copyFileFromContainer(
+                    "/usr/share/elasticsearch/config/certs/http_ca.crt",
+                    IOUtils::toByteArray);
+            log.debug("Found an https elasticsearch cert for version [{}].", version);
+        } catch (Exception e) {
+            log.warn("We did not find the https elasticsearch cert for version [{}].", version);
+        }
+
+        String url = "https://" + elasticsearch.getHttpHostAddress();
+
+        log.info("Elasticsearch container is now running at {}", url);
+        return url;
+    }
+
+    /**
+     * Stop the container if running
+     */
+    void stopServices() {
+        if (elasticsearch != null) {
+            log.info("Stopping elasticsearch container running at {}", elasticsearch.getHttpHostAddress());
+            elasticsearch.stop();
+            elasticsearch = null;
+        }
+    }
+
+    public byte[] getCertAsBytes() {
+        return certAsBytes;
+    }
+}

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/TestContainerHelper.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/TestContainerHelper.java
@@ -76,17 +76,6 @@ class TestContainerHelper {
         return url;
     }
 
-    /**
-     * Stop the container if running
-     */
-    void stopServices() {
-        if (elasticsearch != null) {
-            log.info("Stopping elasticsearch container running at {}", elasticsearch.getHttpHostAddress());
-            elasticsearch.stop();
-            elasticsearch = null;
-        }
-    }
-
     public byte[] getCertAsBytes() {
         return certAsBytes;
     }

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/TestContainerHelper.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/TestContainerHelper.java
@@ -56,6 +56,8 @@ class TestContainerHelper {
                         .withTag(version))
                 // As for 7.x clusters, there's no https, api keys are disabled by default. We force it.
                 .withEnv("xpack.security.authc.api_key.enabled", "true")
+                // For 6.x clusters, we need to activate a trial
+                .withEnv("xpack.license.self_generated.type", "trial")
                 .withReuse(keepData)
                 .withPassword(password);
         elasticsearch.start();

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/ElasticsearchClientIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/ElasticsearchClientIT.java
@@ -581,7 +581,7 @@ public class ElasticsearchClientIT extends AbstractITCase {
                 .setNodes(List.of(
                         new ServerUrl("http://127.0.0.1:9206"),
                         new ServerUrl(testClusterUrl)))
-                .setCredentials(testApiKey, testAccessToken, testClusterUser, testClusterPass)
+                .setCredentials(testApiKey, testClusterUser, testClusterPass)
                 .setSslVerification(false)
                 .build();
         FsSettings fsSettings = FsSettings.builder("esClient").setElasticsearch(elasticsearch).build();
@@ -601,7 +601,7 @@ public class ElasticsearchClientIT extends AbstractITCase {
                         new ServerUrl(testClusterUrl),
                         new ServerUrl("http://127.0.0.1:9206"),
                         new ServerUrl(testClusterUrl)))
-                .setCredentials(testApiKey, testAccessToken, testClusterUser, testClusterPass)
+                .setCredentials(testApiKey, testClusterUser, testClusterPass)
                 .setSslVerification(false)
                 .build();
         FsSettings fsSettings = FsSettings.builder("esClient").setElasticsearch(elasticsearch).build();
@@ -634,7 +634,7 @@ public class ElasticsearchClientIT extends AbstractITCase {
                 .setNodes(List.of(
                         new ServerUrl("http://127.0.0.1:9206"),
                         new ServerUrl("http://127.0.0.1:9207")))
-                .setCredentials(testApiKey, testAccessToken, testClusterUser, testClusterPass)
+                .setCredentials(testApiKey, testClusterUser, testClusterPass)
                 .setSslVerification(false)
                 .build();
         FsSettings fsSettings = FsSettings.builder("esClient").setElasticsearch(elasticsearch).build();
@@ -654,7 +654,7 @@ public class ElasticsearchClientIT extends AbstractITCase {
         // Build a client with a non-running node
         Elasticsearch elasticsearch = Elasticsearch.builder()
                 .setNodes(List.of(new ServerUrl("http://127.0.0.1:9206")))
-                .setCredentials(testApiKey, testAccessToken, testClusterUser, testClusterPass)
+                .setCredentials(testApiKey, testClusterUser, testClusterPass)
                 .setSslVerification(false)
                 .build();
         FsSettings fsSettings = FsSettings.builder("esClient").setElasticsearch(elasticsearch).build();
@@ -695,14 +695,9 @@ public class ElasticsearchClientIT extends AbstractITCase {
             String key = esClient.generateApiKey("fscrawler-es-client-test");
             assertThat(key, notNullValue());
         } catch (Exception e) {
-            logger.warn("Can not create an API Key. You are probably using a version of Elasticsearch which does not support API Keys. " +
+            // creating derived api keys requires an explicit role descriptor that is empty (has no privileges)
+            logger.warn("Can not create an API Key. " +
                     "This is not a critical one as this code is only used in tests. So we skip it.", e);
         }
-    }
-
-    @Test
-    public void createElasticsearchAccessToken() throws ElasticsearchClientException {
-        String token = esClient.generateElasticsearchToken();
-        assertThat(token, notNullValue());
     }
 }

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/ElasticsearchClientIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/ElasticsearchClientIT.java
@@ -689,7 +689,7 @@ public class ElasticsearchClientIT extends AbstractITCase {
     }
 
     @Test
-    public void createApiKey() throws ElasticsearchClientException {
+    public void createApiKey() {
         // This is not a critical one as this code is only used in tests
         try {
             String key = esClient.generateApiKey("fscrawler-es-client-test");

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerRestFilenameAsIdIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerRestFilenameAsIdIT.java
@@ -44,7 +44,7 @@ public class FsCrawlerRestFilenameAsIdIT extends AbstractRestITCase {
         return FsSettings.builder(getCrawlerName())
                 .setFs(Fs.builder().setFilenameAsId(true).build())
                 .setRest(new Rest("http://127.0.0.1:" + testRestPort + "/fscrawler"))
-                .setElasticsearch(elasticsearchWithSecurity)
+                .setElasticsearch(elasticsearchConfiguration)
                 .build();
     }
 

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerRestIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerRestIT.java
@@ -56,7 +56,7 @@ public class FsCrawlerRestIT extends AbstractRestITCase {
     public FsSettings getFsSettings() {
         return FsSettings.builder(getCrawlerName())
                 .setRest(new Rest("http://127.0.0.1:" + testRestPort + "/fscrawler"))
-                .setElasticsearch(elasticsearchWithSecurity)
+                .setElasticsearch(elasticsearchConfiguration)
                 .build();
     }
 

--- a/integration-tests/src/test/resources/elasticsearch.version.properties
+++ b/integration-tests/src/test/resources/elasticsearch.version.properties
@@ -1,1 +1,2 @@
 version=${integ.elasticsearch.version}
+password=${tests.cluster.pass}

--- a/integration-tests/src/test/resources/log4j2.xml
+++ b/integration-tests/src/test/resources/log4j2.xml
@@ -24,15 +24,6 @@
       <Logger name="fr.pilato.elasticsearch.crawler.fs.service" level="info" additivity="false">
          <AppenderRef ref="CONSOLE"/>
       </Logger>
-      <Logger name="fr.pilato.elasticsearch.crawler.fs.thirdparty" level="info" additivity="false">
-         <AppenderRef ref="CONSOLE"/>
-      </Logger>
-      <Logger name="fr.pilato.elasticsearch.crawler.fs.thirdparty.wpsearch" level="info" additivity="false">
-         <AppenderRef ref="CONSOLE"/>
-      </Logger>
-      <Logger name="fr.pilato.elasticsearch.crawler.fs.client.WorkplaceSearchClient" level="info" additivity="false">
-         <AppenderRef ref="CONSOLE"/>
-      </Logger>
       <Logger name="fr.pilato.elasticsearch.crawler.fs.rest" level="info" additivity="false">
          <AppenderRef ref="CONSOLE"/>
       </Logger>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <!--suppress CheckTagEmptyBody -->
     <properties>
         <elasticsearch8.version>8.14.1</elasticsearch8.version>
-        <elasticsearch7.version>7.17.19</elasticsearch7.version>
+        <elasticsearch7.version>7.17.23</elasticsearch7.version>
         <elasticsearch6.version>6.8.23</elasticsearch6.version>
         <elasticsearch.version>${elasticsearch8.version}</elasticsearch.version>
 
@@ -62,14 +62,11 @@
         <contrib.dir>${project.basedir}/contrib</contrib.dir>
         <integ.elasticsearch.version>${elasticsearch.version}</integ.elasticsearch.version>
         <integ.elasticsearch.port>9200</integ.elasticsearch.port>
-        <integ.workplace.port>3002</integ.workplace.port>
         <tests.cluster.url></tests.cluster.url>
         <tests.cluster.cloud_id></tests.cluster.cloud_id>
+        <tests.cluster.apiKey></tests.cluster.apiKey>
         <tests.cluster.user>elastic</tests.cluster.user>
         <tests.cluster.pass>changeme</tests.cluster.pass>
-        <tests.workplace.url></tests.workplace.url>
-        <tests.workplace.user>${tests.cluster.user}</tests.workplace.user>
-        <tests.workplace.pass>${tests.cluster.pass}</tests.workplace.pass>
         <tests.rest.port>8080</tests.rest.port>
 
         <!-- Randomized testing framework -->
@@ -204,12 +201,11 @@
                             <java.awt.headless>true</java.awt.headless>
                             <tests.cluster.url>${tests.cluster.url}</tests.cluster.url>
                             <tests.cluster.cloud_id>${tests.cluster.cloud_id}</tests.cluster.cloud_id>
+                            <tests.cluster.apiKey>${tests.cluster.apiKey}</tests.cluster.apiKey>
                             <tests.cluster.user>${tests.cluster.user}</tests.cluster.user>
                             <tests.cluster.pass>${tests.cluster.pass}</tests.cluster.pass>
-                            <tests.workplace.url>${tests.workplace.url}</tests.workplace.url>
-                            <tests.workplace.user>${tests.workplace.user}</tests.workplace.user>
-                            <tests.workplace.pass>${tests.workplace.pass}</tests.workplace.pass>
                             <tests.rest.port>${tests.rest.port}</tests.rest.port>
+                            <tests.leaveTemporary>${tests.leaveTemporary}</tests.leaveTemporary>
                             <sun.net.http.allowRestrictedHeaders>true</sun.net.http.allowRestrictedHeaders>
                         </systemProperties>
                     </configuration>
@@ -269,81 +265,6 @@
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
                     <version>0.45.0</version>
-                </plugin>
-
-                <!-- For IT using Docker Compose -->
-                <plugin>
-                    <groupId>com.dkanejs.maven.plugins</groupId>
-                    <artifactId>docker-compose-maven-plugin</artifactId>
-                    <version>4.0.0</version>
-                    <configuration>
-                        <envFile>${contrib.dir}/docker-compose-it/.env</envFile>
-                        <envVars>
-                            <STACK_VERSION>${integ.elasticsearch.version}</STACK_VERSION>
-                            <ELASTIC_PASSWORD>${tests.cluster.pass}</ELASTIC_PASSWORD>
-                            <ES_PORT>${integ.elasticsearch.port}</ES_PORT>
-                            <ENTERPRISE_SEARCH_PORT>${integ.workplace.port}</ENTERPRISE_SEARCH_PORT>
-                            <LICENSE>trial</LICENSE>
-                        </envVars>
-                        <composeFiles>
-                            <composeFile>${contrib.dir}/docker-compose-it/docker-compose.yml</composeFile>
-                        </composeFiles>
-                        <services>
-                            <service>elasticsearch</service>
-                        </services>
-                        <ignorePullFailures>true</ignorePullFailures>
-                        <removeOrphans>true</removeOrphans>
-                        <removeVolumes>true</removeVolumes>
-                        <detachedMode>true</detachedMode>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <id>up</id>
-                            <phase>pre-integration-test</phase>
-                            <goals>
-                                <goal>down</goal>
-                                <goal>up</goal>
-                            </goals>
-                        </execution>
-                        <execution>
-                            <id>down</id>
-                            <phase>post-integration-test</phase>
-                            <goals>
-                                <goal>down</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
-                    <groupId>de.scravy</groupId>
-                    <artifactId>waitfor-maven-plugin</artifactId>
-                    <version>1.4</version>
-                    <configuration>
-                        <quiet>true</quiet>
-                        <chatty>false</chatty>
-                        <insecure>true</insecure>
-                        <redirect>false</redirect>
-                        <timeoutSeconds>600</timeoutSeconds>
-                        <checkEveryMillis>1000</checkEveryMillis>
-                        <!-- Each module should use its own checks like below -->
-                        <!--
-                        <checks>
-                            <check>
-                                <url>https://localhost:9200/</url>
-                                <statusCode>401</statusCode>
-                            </check>
-                        </checks>
-                        -->
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <id>wait-for-environment-to-be-up</id>
-                            <phase>pre-integration-test</phase>
-                            <goals>
-                                <goal>waitfor</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                 </plugin>
 
                 <!-- Generate the release zip file (run during package step) -->
@@ -844,6 +765,12 @@
                 <groupId>com.carrotsearch.randomizedtesting</groupId>
                 <artifactId>randomizedtesting-runner</artifactId>
                 <version>2.8.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>elasticsearch</artifactId>
+                <version>1.20.1</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
     <!--suppress CheckTagEmptyBody -->
     <properties>
-        <elasticsearch8.version>8.14.1</elasticsearch8.version>
+        <elasticsearch8.version>8.14.3</elasticsearch8.version>
         <elasticsearch7.version>7.17.23</elasticsearch7.version>
         <elasticsearch6.version>6.8.23</elasticsearch6.version>
         <elasticsearch.version>${elasticsearch8.version}</elasticsearch.version>

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Elasticsearch.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Elasticsearch.java
@@ -43,7 +43,7 @@ public class Elasticsearch {
     private TimeValue flushInterval = TimeValue.timeValueSeconds(5);
     private ByteSizeValue byteSize = new ByteSizeValue(10, ByteSizeUnit.MB);
     private String apiKey;
-    private String accessToken;
+
     /**
      * Username
      * @deprecated Use apiKey or accessToken instead
@@ -67,7 +67,7 @@ public class Elasticsearch {
     }
 
     private Elasticsearch(List<ServerUrl> nodes, String index, String indexFolder, int bulkSize,
-                          TimeValue flushInterval, ByteSizeValue byteSize, String apiKey, String accessToken,
+                          TimeValue flushInterval, ByteSizeValue byteSize, String apiKey,
                           String username, String password, String pipeline,
                           String pathPrefix, boolean sslVerification, boolean pushTemplates) {
         this.nodes = nodes;
@@ -76,7 +76,6 @@ public class Elasticsearch {
         this.bulkSize = bulkSize;
         this.flushInterval = flushInterval;
         this.byteSize = byteSize;
-        this.accessToken = accessToken;
         this.apiKey = apiKey;
         this.username = username;
         this.password = password;
@@ -136,14 +135,6 @@ public class Elasticsearch {
         this.apiKey = apiKey;
     }
 
-    public String getAccessToken() {
-        return accessToken;
-    }
-
-    public void setAccessToken(String accessToken) {
-        this.accessToken = accessToken;
-    }
-
     public String getUsername() {
         return username;
     }
@@ -151,7 +142,7 @@ public class Elasticsearch {
     /**
      * Provide the username to connect to Elasticsearch
      * @param username The username
-     * @deprecated Use {@link #setApiKey(String)} or {@link #setAccessToken(String)} instead
+     * @deprecated Use {@link #setApiKey(String)} instead
      */
     @Deprecated
     public void setUsername(String username) {
@@ -167,7 +158,7 @@ public class Elasticsearch {
     /**
      * Provide the password to connect to Elasticsearch
      * @param password The password
-     * @deprecated Use {@link #setApiKey(String)} or {@link #setAccessToken(String)} instead
+     * @deprecated Use {@link #setApiKey(String)} instead
      */
     @Deprecated
     @JsonProperty
@@ -223,7 +214,6 @@ public class Elasticsearch {
         private boolean sslVerification = true;
         private boolean pushTemplates = true;
         private String apiKey = null;
-        private String accessToken = null;
 
         public Builder setNodes(List<ServerUrl> nodes) {
             this.nodes = nodes;
@@ -260,16 +250,11 @@ public class Elasticsearch {
             return this;
         }
 
-        public Builder setAccessToken(String accessToken) {
-            this.accessToken = accessToken;
-            return this;
-        }
-
         /**
          * Set the username (for tests only)
          * @param username  Username
          * @return the current builder
-         * @deprecated Use {@link #setApiKey(String)} or {@link #setAccessToken(String)} instead
+         * @deprecated Use {@link #setApiKey(String)} instead
          */
         @Deprecated
         public Builder setUsername(String username) {
@@ -282,7 +267,7 @@ public class Elasticsearch {
          * Set the password (for tests only)
          * @param password  Password
          * @return the current builder
-         * @deprecated Use {@link #setApiKey(String)} or {@link #setAccessToken(String)} instead
+         * @deprecated Use {@link #setApiKey(String)} instead
          */
         @Deprecated
         public Builder setPassword(String password) {
@@ -293,20 +278,16 @@ public class Elasticsearch {
 
         /**
          * Set the credentials depending on what is available.
-         * This is a helper method to set either apiKey, accessToken or username/password.
+         * This is a helper method to set either apiKey or username/password.
          * @param apiKey        API Key (omitted if null)
-         * @param accessToken   Access Token (omitted if null)
          * @param username      Username (omitted if null)
          * @param password      Password (omitted if null)
          * @return the current builder
          */
-        public Builder setCredentials(String apiKey, String accessToken, String username, String password) {
+        public Builder setCredentials(String apiKey, String username, String password) {
             if (apiKey != null) {
                 logger.trace("using api key [{}]", apiKey);
                 this.setApiKey(apiKey);
-            } else if (accessToken != null) {
-                logger.trace("using access token [{}]", accessToken);
-                this.setAccessToken(accessToken);
             } else if (username != null && password != null) {
                 logger.trace("using login/password [{}]/[{}]", username, password);
                 this.setUsername(username);
@@ -337,7 +318,7 @@ public class Elasticsearch {
         }
 
         public Elasticsearch build() {
-            return new Elasticsearch(nodes, index, indexFolder, bulkSize, flushInterval, byteSize, apiKey, accessToken,
+            return new Elasticsearch(nodes, index, indexFolder, bulkSize, flushInterval, byteSize, apiKey,
                     username, password,
                     pipeline, pathPrefix, sslVerification, pushTemplates);
         }
@@ -355,7 +336,6 @@ public class Elasticsearch {
         if (!Objects.equals(index, that.index)) return false;
         if (!Objects.equals(indexFolder, that.indexFolder)) return false;
         if (!Objects.equals(apiKey, that.apiKey)) return false;
-        if (!Objects.equals(accessToken, that.accessToken)) return false;
         if (!Objects.equals(username, that.username)) return false;
         // We can't really test the password as it may be obfuscated
         if (!Objects.equals(pipeline, that.pipeline)) return false;
@@ -373,7 +353,6 @@ public class Elasticsearch {
         result = 31 * result + (indexFolder != null ? indexFolder.hashCode() : 0);
         result = 31 * result + (username != null ? username.hashCode() : 0);
         result = 31 * result + (apiKey != null ? apiKey.hashCode() : 0);
-        result = 31 * result + (accessToken != null ? accessToken.hashCode() : 0);
         result = 31 * result + (pipeline != null ? pipeline.hashCode() : 0);
         result = 31 * result + (pathPrefix != null ? pathPrefix.hashCode() : 0);
         result = 31 * result + bulkSize;

--- a/test-framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/framework/AbstractFSCrawlerTestCase.java
+++ b/test-framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/framework/AbstractFSCrawlerTestCase.java
@@ -57,13 +57,23 @@ import static org.junit.Assert.fail;
 @TimeoutSuite(millis = 5 * 60 * 1000)
 @ThreadLeakScope(ThreadLeakScope.Scope.SUITE)
 @ThreadLeakLingering(linger = 5000) // 5 sec lingering
-@ThreadLeakFilters(filters = AbstractFSCrawlerTestCase.TestContainerThreadFilter.class)
+@ThreadLeakFilters(filters = {
+        AbstractFSCrawlerTestCase.TestContainerThreadFilter.class,
+        AbstractFSCrawlerTestCase.JNACleanerThreadFilter.class
+})
 public abstract class AbstractFSCrawlerTestCase {
 
     public static class TestContainerThreadFilter implements ThreadFilter {
         @Override
         public boolean reject(Thread t) {
             return t.getThreadGroup() != null && "testcontainers".equals(t.getThreadGroup().getName());
+        }
+    }
+
+    public static class JNACleanerThreadFilter implements ThreadFilter {
+        @Override
+        public boolean reject(Thread t) {
+            return "JNA Cleaner".equals(t.getName());
         }
     }
 

--- a/test-framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/framework/AbstractFSCrawlerTestCase.java
+++ b/test-framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/framework/AbstractFSCrawlerTestCase.java
@@ -20,10 +20,8 @@ package fr.pilato.elasticsearch.crawler.fs.test.framework;
 
 import com.carrotsearch.randomizedtesting.RandomizedContext;
 import com.carrotsearch.randomizedtesting.RandomizedRunner;
-import com.carrotsearch.randomizedtesting.annotations.Listeners;
-import com.carrotsearch.randomizedtesting.annotations.ThreadLeakLingering;
-import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
-import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
+import com.carrotsearch.randomizedtesting.ThreadFilter;
+import com.carrotsearch.randomizedtesting.annotations.*;
 import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -59,7 +57,15 @@ import static org.junit.Assert.fail;
 @TimeoutSuite(millis = 5 * 60 * 1000)
 @ThreadLeakScope(ThreadLeakScope.Scope.SUITE)
 @ThreadLeakLingering(linger = 5000) // 5 sec lingering
+@ThreadLeakFilters(filters = AbstractFSCrawlerTestCase.TestContainerThreadFilter.class)
 public abstract class AbstractFSCrawlerTestCase {
+
+    public static class TestContainerThreadFilter implements ThreadFilter {
+        @Override
+        public boolean reject(Thread t) {
+            return t.getThreadGroup() != null && "testcontainers".equals(t.getThreadGroup().getName());
+        }
+    }
 
     protected static final Logger staticLogger = LogManager.getLogger(AbstractFSCrawlerTestCase.class);
     private static final String RANDOM = "random";


### PR DESCRIPTION
When the cluster is not available, we will be running Elasticsearch from TestContainers.

This PR also removes lot of leftovers when we removed the support for WorkPlace Search (#1832). ie, we don't need Access Token anymore.

We also updated Elasticsearch 7 to 7.17.23.

Closes #1773