### PR TITLE
Implement SSL Verification

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,7 +55,7 @@ jobs:
           key: fscrawler-docker-cache-${{ runner.os }}-${{ hashFiles('pom.xml') }}
         continue-on-error: true
       - name: Run the integration tests
-        run: mvn --batch-mode install -Ddocker.skip -DskipUnitTests -Dtests.parallelism=1
+        run: mvn --batch-mode install -Ddocker.skip -DskipUnitTests -Dtests.parallelism=1 -Dtests.output=always
 
   # We run integration tests with elastic stack 7
   it-es7:

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -116,35 +116,6 @@ public class ElasticsearchClient implements IElasticsearchClient {
             return;
         }
 
-            /*
-        if (settings.getPathPrefix() != null) {
-            builder.setPathPrefix(settings.getPathPrefix());
-        }
-
-        if (settings.getUsername() != null) {
-            if (settings.getSslVerification()) {
-                builder.setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider));
-            } else {
-                builder.setHttpClientConfigCallback(httpClientBuilder -> {
-                    SSLContext sc;
-                    try {
-                        sc = SSLContext.getInstance("SSL");
-                        sc.init(null, trustAllCerts, new SecureRandom());
-                    } catch (KeyManagementException | NoSuchAlgorithmException e) {
-                        logger.warn("Failed to get SSL Context", e);
-                        throw new RuntimeException(e);
-                    }
-                    httpClientBuilder.setSSLStrategy(new SSLIOSessionStrategy(sc, new NullHostNameVerifier()));
-                    httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
-                    return httpClientBuilder;
-                });
-            }
-        }
-
-        return builder;
-    }
-    */
-
         // Create the client
         ClientConfig config = new ClientConfig();
         // We need to suppress this, so we can do DELETE with body
@@ -196,7 +167,7 @@ public class ElasticsearchClient implements IElasticsearchClient {
         if (sslContext != null) {
             clientBuilder.sslContext(sslContext);
         }
-        client =  clientBuilder.build();
+        client = clientBuilder.build();
         if (logger.isTraceEnabled()) {
             client
 //                    .property(LoggingFeature.LOGGING_FEATURE_LOGGER_NAME_CLIENT, ElasticsearchClient.class.getName())
@@ -914,8 +885,12 @@ public class ElasticsearchClient implements IElasticsearchClient {
     }
 
     @SafeVarargs
-    private String httpCall(String method, String path, Object data, Map.Entry<String, Object>... params) throws ElasticsearchClientException {
+    private String httpCall(String method, String localPath, Object data, Map.Entry<String, Object>... params) throws ElasticsearchClientException {
         String node = getNode();
+        String path = localPath;
+        if (settings.getElasticsearch().getPathPrefix() != null) {
+            path = settings.getElasticsearch().getPathPrefix() + "/" + localPath;
+        }
         logger.trace("Calling {} {}/{} with params {}", method, node, path == null ? "" : path, params);
         try {
             Invocation.Builder callBuilder = prepareHttpCall(node, path, params);

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Elasticsearch.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Elasticsearch.java
@@ -61,6 +61,7 @@ public class Elasticsearch {
     private String pathPrefix;
     private boolean sslVerification = true;
     private boolean pushTemplates = true;
+    private String caCertificate;
 
     public Elasticsearch() {
 
@@ -69,7 +70,9 @@ public class Elasticsearch {
     private Elasticsearch(List<ServerUrl> nodes, String index, String indexFolder, int bulkSize,
                           TimeValue flushInterval, ByteSizeValue byteSize, String apiKey,
                           String username, String password, String pipeline,
-                          String pathPrefix, boolean sslVerification, boolean pushTemplates) {
+                          String pathPrefix, boolean sslVerification,
+                          String caCertificate,
+                          boolean pushTemplates) {
         this.nodes = nodes;
         this.index = index;
         this.indexFolder = indexFolder;
@@ -82,6 +85,7 @@ public class Elasticsearch {
         this.pipeline = pipeline;
         this.pathPrefix = pathPrefix;
         this.sslVerification = sslVerification;
+        this.caCertificate = caCertificate;
         this.pushTemplates = pushTemplates;
     }
 
@@ -199,6 +203,14 @@ public class Elasticsearch {
         this.pushTemplates = pushTemplates;
     }
 
+    public String getCaCertificate() {
+        return caCertificate;
+    }
+
+    public void setCaCertificate(String caCertificate) {
+        this.caCertificate = caCertificate;
+    }
+
     @SuppressWarnings("UnusedReturnValue")
     public static class Builder {
         private List<ServerUrl> nodes = Collections.singletonList(NODE_DEFAULT);
@@ -212,6 +224,7 @@ public class Elasticsearch {
         private String pipeline = null;
         private String pathPrefix = null;
         private boolean sslVerification = true;
+        private String caCertificate;
         private boolean pushTemplates = true;
         private String apiKey = null;
 
@@ -312,6 +325,11 @@ public class Elasticsearch {
             return this;
         }
 
+        public Builder setCaCertificate(String caCertificate) {
+            this.caCertificate = caCertificate;
+            return this;
+        }
+
         public Builder setPushTemplates(boolean pushTemplates) {
             this.pushTemplates = pushTemplates;
             return this;
@@ -320,7 +338,9 @@ public class Elasticsearch {
         public Elasticsearch build() {
             return new Elasticsearch(nodes, index, indexFolder, bulkSize, flushInterval, byteSize, apiKey,
                     username, password,
-                    pipeline, pathPrefix, sslVerification, pushTemplates);
+                    pipeline, pathPrefix,
+                    sslVerification, caCertificate,
+                    pushTemplates);
         }
     }
 
@@ -341,6 +361,7 @@ public class Elasticsearch {
         if (!Objects.equals(pipeline, that.pipeline)) return false;
         if (!Objects.equals(pathPrefix, that.pathPrefix)) return false;
         if (!Objects.equals(sslVerification, that.sslVerification)) return false;
+        if (!Objects.equals(caCertificate, that.caCertificate)) return false;
         if (!Objects.equals(pushTemplates, that.pushTemplates)) return false;
         return Objects.equals(flushInterval, that.flushInterval);
 
@@ -357,6 +378,7 @@ public class Elasticsearch {
         result = 31 * result + (pathPrefix != null ? pathPrefix.hashCode() : 0);
         result = 31 * result + bulkSize;
         result = 31 * result + (flushInterval != null ? flushInterval.hashCode() : 0);
+        result = 31 * result + (caCertificate != null ? caCertificate.hashCode() : 0);
         result = 31 * result + (sslVerification? 1: 0);
         result = 31 * result + (pushTemplates? 1: 0);
         return result;
@@ -374,6 +396,7 @@ public class Elasticsearch {
                 ", pipeline='" + pipeline + '\'' +
                 ", pathPrefix='" + pathPrefix + '\'' +
                 ", sslVerification='" + sslVerification + '\'' +
+                ", caCertificatePath='" + caCertificate + '\'' +
                 ", pushTemplates='" + pushTemplates + '\'' +
                 '}';
     }


### PR DESCRIPTION
We now support both `ssl_verification` (default to `true`) and `ca_certificate` (default to `null`).

In order to ingest documents to Elasticsearch over HTTPS based connection, you obviously need to set the URL to ``https://your-server-address``. If your server is using a certificate that has been signed by a Certificate Authority, then you're good to go. For example, that's the case if you are running Elasticsearch from cloud.elastic.co.

But if you are using a self signed certificate, which is the case in development mode, you need to either ignore the ssl check (not recommended) or provide the certificate to the Elasticsearch client.

To bypass the SSL Certificate verification, you can use the `ssl_verification` option:

```yaml
name: "test"
elasticsearch:
  api_key: "VnVhQ2ZHY0JDZGJrUW0tZTVhT3g6dWkybHAyYXhUTm1zeWFrdzl0dk5udw=="
  ssl_verification: false
```

If you are running Elasticsearch from a Docker container, you can copy the self-signed certificate generated in `/usr/share/elasticsearch/config/certs/http_ca.crt` to your local machine:

```sh
docker cp CONTAINER_NAME:/usr/share/elasticsearch/config/certs/http_ca.crt /path/to/certificate
```

And then, you can specify this file in the `elasticsearch.ca_certificate` option:

```yaml
name: "test"
elasticsearch:
  api_key: "VnVhQ2ZHY0JDZGJrUW0tZTVhT3g6dWkybHAyYXhUTm1zeWFrdzl0dk5udw=="
  ca_certificate: /path/to/certificate/http_ca.crt
```

You can also import your certificate into ``<JAVA_HOME>\lib\security\cacerts``.

For example, if you have a root CA chain certificate or Elasticsearch server certificate in DER format (it's a binary format using a `.cer` extension), you need to:

1. Logon to server (or client machine) where FSCrawler is running
2. Run:

```sh
keytool -import -alias <alias name> -keystore "<JAVA_HOME>\lib\security\cacerts" -file <Path of Elasticsearch Server certificate or Root certificate>
```

It will prompt you for the password. Enter the certificate password like `changeit`.

3. Make changes to FSCrawler `_settings.json` file to connect to your Elasticsearch server over HTTPS:

```yaml
name: "test"
elasticsearch:
  api_key: "VnVhQ2ZHY0JDZGJrUW0tZTVhT3g6dWkybHAyYXhUTm1zeWFrdzl0dk5udw=="
  nodes:
  - url: "https://localhost:9243"
```

If you can not find `keytool`, it probably means that you did not add your `JAVA_HOME/bin` directory to your path.

Closes #1538.