### PR TITLE
Force protobuf-java to 3.25.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -613,6 +613,13 @@
                 <version>2.12.7</version>
             </dependency>
 
+            <!-- Because of CVE-2024-7254 - this comes from Tika 2.9.2 -->
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>3.25.5</version>
+            </dependency>
+
             <!-- For Language detection -->
             <dependency>
                 <groupId>org.apache.tika</groupId>


### PR DESCRIPTION
Because of CVE-2024-7254.
The dependency comes from Tika 2.9.2.