### PR TITLE
Fix exclusion folder check for subdirectories and for Windows

### DIFF
--- a/docs/source/admin/fs/local-fs.rst
+++ b/docs/source/admin/fs/local-fs.rst
@@ -171,6 +171,15 @@ If you define the following ``fs.excludes`` property in your
 Then all files but the ones in ``/folderB/subfolderA``, ``/folderB/subfolderB`` and
 ``/folderB/subfolderC`` will be indexed.
 
+If you want to exclude a specific folder, you need to use a wildcard character at the end of the folder name, like:
+
+.. code:: yaml
+
+   name: "test"
+   fs:
+     excludes:
+     - "/folderB/subfolderB/*"
+
 Since the includes and excludes work on the entire *path of the file* you must consider that when using wildcards. Below are some includes and excludes pattern to help convey the idea better.
 
 +--------------------+------------------------------------------------+------------------------------------------------+

--- a/docs/source/release/2.10.rst
+++ b/docs/source/release/2.10.rst
@@ -1,6 +1,12 @@
 Version 2.10
 ============
 
+Breaking changes
+----------------
+
+* If you want to exclude a specific folder, you need to use a wildcard character at the end of the folder name.
+  For example, to exclude the folder ``/tmp/foo``, you need to use ``/tmp/foo/*``. Thanks to dadoonet.
+
 New
 ---
 

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/FsMatchFilesTest.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/FsMatchFilesTest.java
@@ -146,4 +146,20 @@ public class FsMatchFilesTest extends AbstractFSCrawlerTestCase {
         assertThat(isMatching("/filter test/should-not-exclude.docx", Collections.singletonList("*~*"), "exclusion"), is(false));
         assertThat(isMatching("/filter test/should-not-exclude.docx.exclude", Collections.singletonList("*.exclude"), "exclusion"), is(true));
     }
+
+    /**
+     * Testing with windows separator
+     * See <a href="https://github.com/dadoonet/fscrawler/issues/1974>#1974</a>
+     */
+    @Test
+    public void windowsSeparator() {
+        // We test with the Linux separator
+        assertThat(isIndexable(true, "/arbets", new ArrayList<>(), Collections.singletonList("*/arbets/*")), is(false));
+        assertThat(isIndexable(true, "/foo/arbets", new ArrayList<>(), Collections.singletonList("*/arbets/*")), is(false));
+        assertThat(isIndexable(true, "/foo", new ArrayList<>(), Collections.singletonList("*/arbets/*")), is(true));
+        // We test with the Windows separator
+        assertThat(isIndexable(true, "\\arbets", new ArrayList<>(), Collections.singletonList("*/arbets/*")), is(false));
+        assertThat(isIndexable(true, "\\foo\\arbets", new ArrayList<>(), Collections.singletonList("*/arbets/*")), is(false));
+        assertThat(isIndexable(true, "\\foo", new ArrayList<>(), Collections.singletonList("*/arbets/*")), is(true));
+    }
 }

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/FsMatchFilesTest.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/FsMatchFilesTest.java
@@ -102,21 +102,21 @@ public class FsMatchFilesTest extends AbstractFSCrawlerTestCase {
         assertThat(isIndexable(true, "/subfolderA", new ArrayList<>(), Collections.singletonList("/folderB/subfolder*")), is(true));
         assertThat(isIndexable(true, "/subfolderB", new ArrayList<>(), Collections.singletonList("/folderB/subfolder*")), is(true));
         assertThat(isIndexable(true, "/subfolderC", new ArrayList<>(), Collections.singletonList("/folderB/subfolder*")), is(true));
-        assertThat(isIndexable(true, "/folderA", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB")), is(true));
-        assertThat(isIndexable(true, "/folderA/subfolderA", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB")), is(true));
-        assertThat(isIndexable(true, "/folderA/subfolderB", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB")), is(true));
-        assertThat(isIndexable(true, "/folderA/subfolderC", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB")), is(true));
-        assertThat(isIndexable(true, "/folderB", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB")), is(true));
-        assertThat(isIndexable(true, "/folderB/subfolderA", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB")), is(true));
-        assertThat(isIndexable(true, "/folderB/subfolderB", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB")), is(false));
-        assertThat(isIndexable(true, "/folderB/subfolderC", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB")), is(true));
-        assertThat(isIndexable(true, "/folderC", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB")), is(true));
-        assertThat(isIndexable(true, "/folderC/subfolderA", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB")), is(true));
-        assertThat(isIndexable(true, "/folderC/subfolderB", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB")), is(true));
-        assertThat(isIndexable(true, "/folderC/subfolderC", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB")), is(true));
-        assertThat(isIndexable(true, "/subfolderA", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB")), is(true));
-        assertThat(isIndexable(true, "/subfolderB", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB")), is(true));
-        assertThat(isIndexable(true, "/subfolderC", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB")), is(true));
+        assertThat(isIndexable(true, "/folderA", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB/*")), is(true));
+        assertThat(isIndexable(true, "/folderA/subfolderA", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB/*")), is(true));
+        assertThat(isIndexable(true, "/folderA/subfolderB", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB/*")), is(true));
+        assertThat(isIndexable(true, "/folderA/subfolderC", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB/*")), is(true));
+        assertThat(isIndexable(true, "/folderB", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB/*")), is(true));
+        assertThat(isIndexable(true, "/folderB/subfolderA", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB/*")), is(true));
+        assertThat(isIndexable(true, "/folderB/subfolderB", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB/*")), is(false));
+        assertThat(isIndexable(true, "/folderB/subfolderC", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB/*")), is(true));
+        assertThat(isIndexable(true, "/folderC", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB/*")), is(true));
+        assertThat(isIndexable(true, "/folderC/subfolderA", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB/*")), is(true));
+        assertThat(isIndexable(true, "/folderC/subfolderB", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB/*")), is(true));
+        assertThat(isIndexable(true, "/folderC/subfolderC", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB/*")), is(true));
+        assertThat(isIndexable(true, "/subfolderA", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB/*")), is(true));
+        assertThat(isIndexable(true, "/subfolderB", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB/*")), is(true));
+        assertThat(isIndexable(true, "/subfolderC", new ArrayList<>(), Collections.singletonList("/folderB/subfolderB/*")), is(true));
     }
 
     /**

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestIncludesIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestIncludesIT.java
@@ -51,12 +51,12 @@ public class FsCrawlerTestIncludesIT extends AbstractFsCrawlerITCase {
     @Test
     public void test_ignore_dir() throws Exception {
         Fs fs = startCrawlerDefinition()
-                .addExclude("*/\\.ignore")
+                .addExclude("*/\\.ignore/")
                 .addExclude("/subdir/sub*")
                 .build();
         crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
-        // We expect to have one file
+        // We expect to have two files: subdir/notsub/roottxtfile.txt and subdir/roottxtfile.txt
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 2L, null);
     }
 


### PR DESCRIPTION
There were 2 issues here:

* We are comparing a folder name like `*/foo/*` with a virtual dir name which is something like `/foo` or `/bar/foo`. It's missing the `/` at the end when it's a directory.
* On windows, the exclusion for a dir named `\foo\arbets` does not match the exclusion `*/arbets/*` because of the `/` vs `\` mismatch

This commit fixes this behavior.

Closes #1974.