### PR TITLE
Add support for external tags

### DIFF
--- a/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/DocUtils.java
+++ b/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/DocUtils.java
@@ -1,19 +1,66 @@
 package fr.pilato.elasticsearch.crawler.fs.beans;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerIllegalConfigurationException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.Iterator;
 
+import static fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil.*;
 import static fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil.mapper;
 
 public class DocUtils {
 
     private static final Logger logger = LogManager.getLogger(DocUtils.class);
+
+    /**
+     * Merge a json document with tags coming from a file
+     * @param doc       The document to merge
+     * @param filename  The filename to read
+     * @return The merged document
+     * @throws FsCrawlerIllegalConfigurationException If the tags can not be parsed
+     */
+    public static Doc getMergedDoc(Doc doc, Path filename) throws FsCrawlerIllegalConfigurationException {
+        if (filename == null) {
+            return doc;
+        }
+
+        try (InputStream tags = Files.newInputStream(filename, StandardOpenOption.READ)) {
+            return getMergedDoc(doc, filename.getFileName().toString(), tags);
+        } catch (IOException e) {
+            logger.error("Error parsing tags", e);
+            throw new FsCrawlerIllegalConfigurationException("Error parsing tags: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Merge a json document with tags coming from a file
+     * @param doc       The document to merge
+     * @param filename  The filename to read
+     * @return The merged document
+     * @throws FsCrawlerIllegalConfigurationException If the tags can not be parsed
+     */
+    public static Doc getMergedDoc(Doc doc, String filename, InputStream tags) throws FsCrawlerIllegalConfigurationException {
+        if (filename == null) {
+            return doc;
+        }
+        logger.trace("Reading tags from {}", filename);
+        // We test if the extension is .json or .yml/.yaml
+        if (filename.endsWith(".json")) {
+            return getMergedDoc(doc, tags, prettyMapper);
+        } else {
+            return getMergedDoc(doc, tags, ymlMapper);
+        }
+    }
 
     /**
      * Merge a json document with tags
@@ -23,6 +70,17 @@ public class DocUtils {
      * @throws FsCrawlerIllegalConfigurationException If the tags can not be parsed
      */
     public static Doc getMergedJsonDoc(Doc doc, InputStream tags) throws FsCrawlerIllegalConfigurationException {
+        return getMergedDoc(doc, tags, mapper);
+    }
+
+    /**
+     * Merge a json document with tags
+     * @param doc   The document to merge
+     * @param tags  The tags to merge
+     * @return The merged document
+     * @throws FsCrawlerIllegalConfigurationException If the tags can not be parsed
+     */
+    public static Doc getMergedDoc(Doc doc, InputStream tags, ObjectMapper mapper) throws FsCrawlerIllegalConfigurationException {
         if (tags == null) {
             return doc;
         }
@@ -69,5 +127,14 @@ public class DocUtils {
         }
 
         return mainNode;
+    }
+
+    public static String prettyPrint(Doc doc) {
+        try {
+            return prettyMapper.writeValueAsString(doc);
+        } catch (JsonProcessingException e) {
+            logger.warn("Can not pretty print the document as json", e);
+            return null;
+        }
     }
 }

--- a/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/DocUtils.java
+++ b/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/DocUtils.java
@@ -1,0 +1,73 @@
+package fr.pilato.elasticsearch.crawler.fs.beans;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerIllegalConfigurationException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.InputStream;
+import java.util.Iterator;
+
+import static fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil.mapper;
+
+public class DocUtils {
+
+    private static final Logger logger = LogManager.getLogger(DocUtils.class);
+
+    /**
+     * Merge a json document with tags
+     * @param doc   The document to merge
+     * @param tags  The tags to merge
+     * @return The merged document
+     * @throws FsCrawlerIllegalConfigurationException If the tags can not be parsed
+     */
+    public static Doc getMergedJsonDoc(Doc doc, InputStream tags) throws FsCrawlerIllegalConfigurationException {
+        if (tags == null) {
+            return doc;
+        }
+
+        try {
+            JsonNode tagsNode = mapper.readTree(tags);
+            JsonNode docNode = mapper.convertValue(doc, JsonNode.class);
+            JsonNode mergedNode = merge(tagsNode, docNode);
+            return mapper.treeToValue(mergedNode, Doc.class);
+        } catch (Exception e) {
+            logger.error("Error parsing tags", e);
+            throw new FsCrawlerIllegalConfigurationException("Error parsing tags: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Merges two json nodes into one. Main node overwrites the update node's values in the case if both nodes have the same key.
+     * @param mainNode Json node that rules over update node
+     * @param updateNode Json node that is subordinate to main node
+     * @return the merged nodes
+     */
+    private static JsonNode merge(JsonNode mainNode, JsonNode updateNode) {
+        Iterator<String> fieldNames = updateNode.fieldNames();
+
+        while (fieldNames.hasNext()) {
+            String fieldName = fieldNames.next();
+            JsonNode jsonNode = mainNode.get(fieldName);
+
+            if (jsonNode != null) {
+                if (jsonNode.isObject()) {
+                    merge(jsonNode, updateNode.get(fieldName));
+                } else if (jsonNode.isArray()) {
+                    for (int i = 0; i < jsonNode.size(); i++) {
+                        merge(jsonNode.get(i), updateNode.get(fieldName).get(i));
+                    }
+                }
+            } else {
+                if (mainNode instanceof ObjectNode) {
+                    // Overwrite field
+                    JsonNode value = updateNode.get(fieldName);
+                    ((ObjectNode) mainNode).set(fieldName, value);
+                }
+            }
+        }
+
+        return mainNode;
+    }
+}

--- a/beans/src/test/java/fr/pilato/elasticsearch/crawler/fs/beans/DocUtilsTest.java
+++ b/beans/src/test/java/fr/pilato/elasticsearch/crawler/fs/beans/DocUtilsTest.java
@@ -1,0 +1,66 @@
+package fr.pilato.elasticsearch.crawler.fs.beans;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.nio.file.Path;
+
+import static fr.pilato.elasticsearch.crawler.fs.beans.DocUtils.prettyPrint;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class DocUtilsTest {
+    private static final Logger logger = LogManager.getLogger(DocUtilsTest.class);
+
+    // Get the tags path from resources
+    Path path = Path.of(DocUtilsTest.class.getResource("/tags").getPath());
+
+    @Test
+    public void testMergeDocsWithNothing() {
+        Doc mergedDoc = DocUtils.getMergedJsonDoc(getDocSample(), (InputStream) null);
+        logger.trace("Merged doc: {}", prettyPrint(mergedDoc));
+
+        assertThat(mergedDoc.getContent(), is("This is a test"));
+        assertThat(mergedDoc.getFile().getFilename(), is("foo.txt"));
+        assertThat(mergedDoc.getMeta(), notNullValue());
+        assertThat(mergedDoc.getPath(), notNullValue());
+        assertThat(mergedDoc.getAttachment(), nullValue());
+        assertThat(mergedDoc.getExternal(), nullValue());
+        assertThat(mergedDoc.getAttributes(), nullValue());
+    }
+
+    @Test
+    public void testMergeDocsWithAJsonFile() {
+        testMergeDocsWithAFile(path.resolve("meta-as-json.json"));
+    }
+
+    @Test
+    public void testMergeDocsWithAYamlFile() {
+        testMergeDocsWithAFile(path.resolve(".meta.yml"));
+    }
+
+    private void testMergeDocsWithAFile(Path file) {
+        Doc mergedDoc = DocUtils.getMergedDoc(getDocSample(), file);
+        logger.trace("Merged doc: {}", prettyPrint(mergedDoc));
+
+        assertThat(mergedDoc.getContent(), is("This is a test"));
+        assertThat(mergedDoc.getFile().getFilename(), is("foo.txt"));
+        assertThat(mergedDoc.getMeta(), notNullValue());
+        assertThat(mergedDoc.getPath(), notNullValue());
+        assertThat(mergedDoc.getExternal(), notNullValue());
+        assertThat(mergedDoc.getExternal().get("tenantId"), is(23));
+        assertThat(mergedDoc.getAttachment(), nullValue());
+        assertThat(mergedDoc.getAttributes(), nullValue());
+    }
+
+    private Doc getDocSample() {
+        File file = new File();
+        file.setFilename("foo.txt");
+        Doc doc = new Doc();
+        doc.setFile(file);
+        doc.setContent("This is a test");
+        return doc;
+    }
+}

--- a/beans/src/test/resources/tags/.meta.yml
+++ b/beans/src/test/resources/tags/.meta.yml
@@ -1,0 +1,18 @@
+external:
+  tenantId: 23
+  company: "shoe company"
+  projectId: 34
+  project: "business development"
+  daysOpen:
+    - "Mon"
+    - "Tue"
+    - "Wed"
+    - "Thu"
+    - "Fri"
+  products:
+    - brand: "nike"
+      size: 41
+      sub: "Air MAX"
+    - brand: "reebok"
+      size: 43
+      sub: "Pump"

--- a/beans/src/test/resources/tags/meta-as-json.json
+++ b/beans/src/test/resources/tags/meta-as-json.json
@@ -1,0 +1,27 @@
+{
+  "external": {
+    "tenantId" : 23,
+    "company": "shoe company",
+    "projectId": 34,
+    "project": "business development",
+    "daysOpen": [
+      "Mon",
+      "Tue",
+      "Wed",
+      "Thu",
+      "Fri"
+    ],
+    "products": [
+      {
+        "brand": "nike",
+        "size": 41,
+        "sub": "Air MAX"
+      },
+      {
+        "brand": "reebok",
+        "size": 43,
+        "sub": "Pump"
+      }
+    ]
+  }
+}

--- a/docs/source/admin/fs/index.rst
+++ b/docs/source/admin/fs/index.rst
@@ -73,6 +73,10 @@ The job file (``~/.fscrawler/test/_settings.yaml``) for the job name ``test`` mu
      #  path: "/path/to/tesseract/if/not/available/in/PATH"
      #  data_path: "/path/to/tesseract/tessdata/if/needed"
 
+   # optional: only needed if you want to change the default settings
+    tags:
+      metaFilename: "meta_tags.json" # default is ".meta.yml"
+
    # optional: only required if you want to SSH to another server to index documents from there
    server:
      hostname: "localhost"
@@ -120,6 +124,8 @@ Here is a list of existing top level settings:
 | ``name`` (mandatory field)        | :ref:`simple_crawler`         |
 +-----------------------------------+-------------------------------+
 | ``fs``                            | :ref:`local-fs-settings`      |
++-----------------------------------+-------------------------------+
+| ``tags``                          | :ref:`tags`                   |
 +-----------------------------------+-------------------------------+
 | ``elasticsearch``                 | :ref:`elasticsearch-settings` |
 +-----------------------------------+-------------------------------+

--- a/docs/source/admin/fs/tags.rst
+++ b/docs/source/admin/fs/tags.rst
@@ -1,0 +1,85 @@
+.. _tags:
+
+External Tags
+-------------
+
+.. contents:: :backlinks: entry
+
+.. versionadded:: 2.10
+
+The goal of this feature is to allow users to provide additional metadata when
+crawling files. Whenever a directory is crawled, FSCrawler checks if a file named
+``.meta.yml`` is present in the directory. If it is, the content of this file is
+used to enrich the document.
+
+For example, if you have a file named ``.meta.yml`` in the directory
+``/path/to/data/dir``:
+
+.. code:: yaml
+
+   external:
+     myTitle: "My document title"
+
+Then the document indexed will have a new field named ``external.myTitle`` with the value
+``My document title``.
+
+Only supported fields can be added to the document. If you try to add a field
+which is not supported, it will be ignored.
+
+For example, if you have the ``.meta.yml`` file contains:
+
+.. code:: yaml
+
+   foo: "bar"
+   external:
+     myTitle: "My document title"
+
+The document indexed will have a new field named ``external.myTitle`` with the value
+``My document title``. The field ``foo`` will be ignored.
+
+If you really want to add a field named ``foo``, you need to add it first as an external tag:
+
+.. code:: yaml
+
+   external:
+     foo: "bar"
+     myTitle: "My document title"
+
+and then use an ingest pipeline to rename the ``external.foo`` field to ``foo``. See :ref:`ingest_node`.
+
+The ``.meta.yml`` file can also overwrite existing fields. For example, if you have the following
+``.meta.yml`` file:
+
+.. code:: yaml
+
+   content: "HIDDEN"
+
+Then the ``content`` field will be replaced by ``HIDDEN`` even though something else is extracted.
+
+.. note::
+
+    The ``.meta.yml`` file is not indexed. It is only used to enrich the document.
+
+
+Here is a list of Tags settings (under ``tags.`` prefix)`:
+
++----------------------------+-----------------------+---------------------------------+
+| Name                       | Default value         | Documentation                   |
++============================+=======================+=================================+
+| ``tags.metaFilename``      | ``".meta.yml"``       | `Meta Filename`_                |
++----------------------------+-----------------------+---------------------------------+
+
+Meta Filename
+^^^^^^^^^^^^^
+
+You can use another filename for the external tags file. For example, if you want to use
+``meta_tags.json`` instead of ``.meta.yml``, you can set:
+
+.. code:: yaml
+
+   tags:
+     metaFilename: "meta_tags.json"
+
+.. note::
+
+    Only json and yaml files are supported.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -57,6 +57,7 @@ This crawler helps to index binary documents such as PDF, Open Office, MS Office
    admin/fs/index
    admin/fs/simple
    admin/fs/local-fs
+   admin/fs/tags
    admin/fs/ssh
    admin/fs/ftp
    admin/fs/elasticsearch

--- a/docs/source/release/2.10.rst
+++ b/docs/source/release/2.10.rst
@@ -5,7 +5,7 @@ New
 ---
 
 * Add support for automatic semantic search when using a 8.17+ version with a trial or enterprise
-  license. See :ref:`semantic_search`. Thanks to dadoonet.
+  license. See :ref:`semantic_search`. **Warning**: this might slow down the ingestion process. Thanks to dadoonet.
 * Using the REST API ``_document``, you can now fetch a document from the local dir, from an http website
   or from an S3 bucket. See :ref:`rest-service`. Thanks to dadoonet.
 * You can now remove a document in Elasticsearch using FSCrawler ``_document`` endpoint. See :ref:`rest-service`. Thanks to dadoonet.
@@ -17,6 +17,7 @@ New
 * Allow loading external jars. This adds a new ``external`` directory from where jars can be loaded
   to the FSCrawler JVM. For example, you could provide your own Custom Tika Parser code. See :ref:`layout`. Thanks to dadoonet.
 * Add temporal information in folder index. Thanks to bdauvissat
+* Add support for external metadata files while crawling, defaults to ``.meta.yml``. See :ref:`tags` Thanks to dadoonet.
 
 Fix
 ---

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -605,11 +605,17 @@ public class ElasticsearchClient implements IElasticsearchClient {
 
     public void deleteIndexTemplate(String indexTemplate) throws ElasticsearchClientException {
         logger.debug("delete index template [{}]", indexTemplate);
-        String url = "_index_template/" + indexTemplate;
-        try {
-            httpDelete(url, null);
-        } catch (NotFoundException e) {
-            logger.trace("Index template [{}] does not exist", indexTemplate);
+
+        // Component templates are only available since 7.8
+        if (majorVersion > 7 || (majorVersion == 7 && minorVersion >= 8)) {
+            String url = "_index_template/" + indexTemplate;
+            try {
+                httpDelete(url, null);
+            } catch (NotFoundException e) {
+                logger.trace("Index template [{}] does not exist", indexTemplate);
+            }
+        } else {
+            logger.debug("Index templates are not available on this version [{}] of Elasticsearch", version);
         }
     }
 

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -603,6 +603,16 @@ public class ElasticsearchClient implements IElasticsearchClient {
         pushIndexTemplate(name + "_" + index, json);
     }
 
+    public void deleteIndexTemplate(String indexTemplate) throws ElasticsearchClientException {
+        logger.debug("delete index template [{}]", indexTemplate);
+        String url = "_index_template/" + indexTemplate;
+        try {
+            httpDelete(url, null);
+        } catch (NotFoundException e) {
+            logger.trace("Index template [{}] does not exist", indexTemplate);
+        }
+    }
+
     /**
      * Reads a resource file from the classpath or from a JAR.
      * @param source The target

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/IElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/IElasticsearchClient.java
@@ -162,6 +162,13 @@ public interface IElasticsearchClient extends Closeable {
     void createIndexAndComponentTemplates() throws Exception;
 
     /**
+     * Delete an index template (only needed for tests)
+     * @param indexTemplate Index template name
+     * @throws ElasticsearchClientException in case of error
+     */
+    void deleteIndexTemplate(String indexTemplate) throws ElasticsearchClientException;
+
+    /**
      * Run a search
      * @param request Search Request
      * @return A search response object

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/FsCrawlerUtil.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/FsCrawlerUtil.java
@@ -18,8 +18,6 @@
  */
 package fr.pilato.elasticsearch.crawler.fs.framework;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.logging.log4j.LogManager;
@@ -107,39 +105,6 @@ public class FsCrawlerUtil {
             // We fall back to default mappings in config dir
             return readDefaultJsonVersionedFile(config, version, filename);
         }
-    }
-
-    /**
-     * Merges two json nodes into one. Main node overwrites the update node's values in the case if both nodes have the same key.
-     * @param mainNode Json node that rules over update node
-     * @param updateNode Json node that is subordinate to main node
-     * @return the merged nodes
-     */
-    public static JsonNode merge(JsonNode mainNode, JsonNode updateNode) {
-        Iterator<String> fieldNames = updateNode.fieldNames();
-
-        while (fieldNames.hasNext()) {
-            String fieldName = fieldNames.next();
-            JsonNode jsonNode = mainNode.get(fieldName);
-
-            if (jsonNode != null) {
-                if (jsonNode.isObject()) {
-                    merge(jsonNode, updateNode.get(fieldName));
-                } else if (jsonNode.isArray()) {
-                    for (int i = 0; i < jsonNode.size(); i++) {
-                        merge(jsonNode.get(i), updateNode.get(fieldName).get(i));
-                    }
-                }
-            } else {
-                if (mainNode instanceof ObjectNode) {
-                    // Overwrite field
-                    JsonNode value = updateNode.get(fieldName);
-                    ((ObjectNode) mainNode).set(fieldName, value);
-                }
-            }
-        }
-
-        return mainNode;
     }
 
     /**

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractFsCrawlerITCase.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractFsCrawlerITCase.java
@@ -83,7 +83,7 @@ public abstract class AbstractFsCrawlerITCase extends AbstractITCase {
     }
 
     private Elasticsearch endCrawlerDefinition(String indexDocName, String indexFolderName) {
-        return generateElasticsearchConfig(indexDocName, indexFolderName, 1, null, null, false);
+        return generateElasticsearchConfig(indexDocName, indexFolderName, 1, null, null, false, false);
     }
 
     protected FsCrawlerImpl startCrawler() throws Exception {

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
@@ -414,6 +414,8 @@ public abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
 
         builder.setSslVerification(false);
 
+        builder.setSemanticSearch(false);
+
         return builder.build();
     }
 

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
@@ -386,7 +386,7 @@ public abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
 
     protected static Elasticsearch generateElasticsearchConfig(String indexName, String indexFolderName, int bulkSize,
                                                                TimeValue timeValue, ByteSizeValue byteSize,
-                                                               boolean useLoginPassword) {
+                                                               boolean useLoginPassword, boolean useSemantic) {
         Elasticsearch.Builder builder = Elasticsearch.builder()
                 .setNodes(Collections.singletonList(new ServerUrl(testClusterUrl)))
                 .setBulkSize(bulkSize);
@@ -414,7 +414,7 @@ public abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
 
         builder.setSslVerification(false);
 
-        builder.setSemanticSearch(false);
+        builder.setSemanticSearch(useSemantic);
 
         return builder.build();
     }

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerImplAllDocumentsIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerImplAllDocumentsIT.java
@@ -89,7 +89,7 @@ public class FsCrawlerImplAllDocumentsIT extends AbstractFsCrawlerITCase {
                 FsSettings.builder("fscrawler_test_all_documents")
                         .setElasticsearch(generateElasticsearchConfig(
                                 "fscrawler_test_all_documents", "fscrawler_test_all_documents_folder",
-                                5, TimeValue.timeValueSeconds(1), null, true))
+                                5, TimeValue.timeValueSeconds(1), null, true, false))
                         .setFs(Fs.builder()
                                 .setUrl(testResourceTarget.toString())
                                 .setLangDetect(true)

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestAttributesIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestAttributesIT.java
@@ -41,7 +41,7 @@ public class FsCrawlerTestAttributesIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .setAttributesSupport(true)
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
         ESSearchResponse searchResponse = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
         for (ESSearchHit hit : searchResponse.getHits()) {
             DocumentContext document = parseJsonAsDocumentContext(hit.getSource());

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestChecksumIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestChecksumIT.java
@@ -50,7 +50,7 @@ public class FsCrawlerTestChecksumIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .setChecksum("MD5")
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
         ESSearchResponse searchResponse = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
         for (ESSearchHit hit : searchResponse.getHits()) {
             assertThat(JsonPath.read(hit.getSource(), "$.file.checksum"), is("caa71e1914ecbcf5ae4f46cf85de8648"));
@@ -68,7 +68,7 @@ public class FsCrawlerTestChecksumIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .setChecksum("SHA-1")
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
         ESSearchResponse searchResponse = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
         for (ESSearchHit hit : searchResponse.getHits()) {
             assertThat(JsonPath.read(hit.getSource(), "$.file.checksum"), is("81bf7dba781a1efbea6d9f2ad638ffe772ba4eab"));

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestExternalMetadataIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestExternalMetadataIT.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package fr.pilato.elasticsearch.crawler.fs.test.integration.elasticsearch;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.PathNotFoundException;
+import fr.pilato.elasticsearch.crawler.fs.client.*;
+import fr.pilato.elasticsearch.crawler.fs.settings.Fs;
+import fr.pilato.elasticsearch.crawler.fs.settings.Tags;
+import fr.pilato.elasticsearch.crawler.fs.test.integration.AbstractFsCrawlerITCase;
+import org.junit.Test;
+
+import static fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil.parseJsonAsDocumentContext;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Test crawler with external metadata files
+ */
+public class FsCrawlerTestExternalMetadataIT extends AbstractFsCrawlerITCase {
+
+    @Test
+    public void test_external_metadata_default() throws Exception {
+        crawler = startCrawler();
+
+        // We expect to have 3 files
+        ESSearchResponse searchResponse = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 3L, null);
+        for (ESSearchHit hit : searchResponse.getHits()) {
+            DocumentContext document = parseJsonAsDocumentContext(hit.getSource());
+            String filename = document.read("$.file.filename");
+            assertThat(filename, isOneOf("root_dir.txt", "with_meta.txt", "without_meta.txt"));
+
+            switch (filename) {
+                case "root_dir.txt":
+                    checkHit(document, filename, true, "This file contains some words.");
+                    break;
+                case "with_meta.txt":
+                    checkHit(document, filename, true, "the content should be altered.");
+                    break;
+                case "without_meta.txt":
+                    checkHit(document, filename, false, "it does not have a metadata file.");
+                    break;
+            }
+        }
+    }
+
+    @Test
+    public void test_external_metadata_yaml() throws Exception {
+        crawler = startCrawler(getCrawlerName(),
+                startCrawlerDefinition().build(),
+                endCrawlerDefinition(getCrawlerName()),
+                null,
+                Tags.builder().setMetaFilename("meta-as-yaml.yaml").build());
+
+        // We expect to have 3 files
+        ESSearchResponse searchResponse = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 3L, null);
+        for (ESSearchHit hit : searchResponse.getHits()) {
+            DocumentContext document = parseJsonAsDocumentContext(hit.getSource());
+            String filename = document.read("$.file.filename");
+            assertThat(filename, isOneOf("root_dir.txt", "with_meta.txt", "without_meta.txt"));
+
+            switch (filename) {
+                case "root_dir.txt":
+                    checkHit(document, filename, true, "This file contains some words.");
+                    break;
+                case "with_meta.txt":
+                    checkHit(document, filename, true, "the content should be altered.");
+                    break;
+                case "without_meta.txt":
+                    checkHit(document, filename, false, "it does not have a metadata file.");
+                    break;
+            }
+        }
+    }
+
+    @Test
+    public void test_external_metadata_json() throws Exception {
+        crawler = startCrawler(getCrawlerName(),
+                startCrawlerDefinition().build(),
+                endCrawlerDefinition(getCrawlerName()),
+                null,
+                Tags.builder().setMetaFilename("meta-as-json.json").build());
+
+        // We expect to have 3 files
+        ESSearchResponse searchResponse = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 3L, null);
+        for (ESSearchHit hit : searchResponse.getHits()) {
+            DocumentContext document = parseJsonAsDocumentContext(hit.getSource());
+            String filename = document.read("$.file.filename");
+            assertThat(filename, isOneOf("root_dir.txt", "with_meta.txt", "without_meta.txt"));
+
+            switch (filename) {
+                case "root_dir.txt":
+                    checkHit(document, filename, true, "This file contains some words.");
+                    break;
+                case "with_meta.txt":
+                    checkHit(document, filename, true, "the content should be altered.");
+                    break;
+                case "without_meta.txt":
+                    checkHit(document, filename, false, "it does not have a metadata file.");
+                    break;
+            }
+        }
+    }
+
+    @Test
+    public void test_external_metadata_overwrite() throws Exception {
+        crawler = startCrawler(getCrawlerName(),
+                startCrawlerDefinition().build(),
+                endCrawlerDefinition(getCrawlerName()),
+                null,
+                Tags.DEFAULT);
+
+        // We expect to have 3 files
+        ESSearchResponse searchResponse = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 3L, null);
+        for (ESSearchHit hit : searchResponse.getHits()) {
+            DocumentContext document = parseJsonAsDocumentContext(hit.getSource());
+            String filename = document.read("$.file.filename");
+            assertThat(filename, isOneOf("root_dir.txt", "with_meta.txt", "without_meta.txt"));
+
+            switch (filename) {
+                case "root_dir.txt":
+                    checkHit(document, filename, false, "This file contains some words.");
+                    break;
+                case "with_meta.txt":
+                    checkHit(document, filename, true, "This is a new content which is overwritten.");
+                    break;
+                case "without_meta.txt":
+                    checkHit(document, filename, false, "it does not have a metadata file.");
+                    break;
+            }
+        }
+    }
+
+    private void checkHit(DocumentContext document, String filename, boolean hasExternal, String expectedContent) {
+        assertThat(document.read("$.content"), containsString(expectedContent));
+        assertThat(document.read("$.file.filename"), is(filename));
+        if (hasExternal) {
+            assertThat(document.read("$.external.tenantId"), is(23));
+        } else {
+            expectThrows(PathNotFoundException.class, () -> document.read("$.external"));
+        }
+    }
+}

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestFTPIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestFTPIT.java
@@ -76,7 +76,7 @@ public class FsCrawlerTestFTPIT extends AbstractFsCrawlerITCase {
                 .setProtocol(Server.PROTOCOL.FTP)
                 .setPort(port)
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), server);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), server, null);
 
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
     }
@@ -91,7 +91,7 @@ public class FsCrawlerTestFTPIT extends AbstractFsCrawlerITCase {
                 .setProtocol(Server.PROTOCOL.FTP)
                 .setPort(port)
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), server);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), server, null);
 
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
     }

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestFilenameAsIdIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestFilenameAsIdIT.java
@@ -47,7 +47,7 @@ public class FsCrawlerTestFilenameAsIdIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .setFilenameAsId(true)
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
         assertThat("Document should exists with [roottxtfile.txt] id...", awaitBusy(() -> {
             try {
@@ -67,7 +67,7 @@ public class FsCrawlerTestFilenameAsIdIT extends AbstractFsCrawlerITCase {
                 .setRemoveDeleted(true)
                 .setFilenameAsId(true)
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
         // We should have two docs first
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 2L, currentTestResourceDir);

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestFilesizeIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestFilesizeIT.java
@@ -51,7 +51,7 @@ public class FsCrawlerTestFilesizeIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .setIndexedChars(new Percentage(7))
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
         ESSearchResponse searchResponse = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
         for (ESSearchHit hit : searchResponse.getHits()) {
@@ -68,7 +68,7 @@ public class FsCrawlerTestFilesizeIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .setIndexedChars(Percentage.parse("0.1%"))
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
         ESSearchResponse searchResponse = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
         for (ESSearchHit hit : searchResponse.getHits()) {
@@ -85,7 +85,7 @@ public class FsCrawlerTestFilesizeIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .setIndexedChars(new Percentage(-1))
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
         ESSearchResponse searchResponse = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
         for (ESSearchHit hit : searchResponse.getHits()) {
@@ -112,7 +112,7 @@ public class FsCrawlerTestFilesizeIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .setAddFilesize(false)
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
         ESSearchResponse searchResponse = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
         for (ESSearchHit hit : searchResponse.getHits()) {
@@ -128,7 +128,7 @@ public class FsCrawlerTestFilesizeIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .setIgnoreAbove(ByteSizeValue.parseBytesSizeValue("10kb"))
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
     }

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestFiltersIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestFiltersIT.java
@@ -33,7 +33,7 @@ public class FsCrawlerTestFiltersIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .addFilter(".*foo.*")
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 2L, null);
     }
 
@@ -42,7 +42,7 @@ public class FsCrawlerTestFiltersIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .addFilter("^4\\d{3}([\\ \\-]?)\\d{4}\\1\\d{4}\\1\\d{4}$")
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 2L, null);
     }
 
@@ -52,7 +52,7 @@ public class FsCrawlerTestFiltersIT extends AbstractFsCrawlerITCase {
                 .addFilter("^4\\d{3}([\\ \\-]?)\\d{4}\\1\\d{4}\\1\\d{4}$")
                 .addFilter(".*foo.*")
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
     }
 }

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestFollowSymlinksIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestFollowSymlinksIT.java
@@ -42,7 +42,7 @@ public class FsCrawlerTestFollowSymlinksIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .setFollowSymlinks(false)
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
         // We should have two docs first
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, currentTestResourceDir);
@@ -58,7 +58,7 @@ public class FsCrawlerTestFollowSymlinksIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .setFollowSymlinks(true)
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
         // We should have two docs first
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 2L, currentTestResourceDir);

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestIgnoreFoldersIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestIgnoreFoldersIT.java
@@ -26,12 +26,9 @@ import fr.pilato.elasticsearch.crawler.fs.settings.Fs;
 import fr.pilato.elasticsearch.crawler.fs.test.integration.AbstractFsCrawlerITCase;
 import org.junit.Test;
 
-import java.io.IOException;
-
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.INDEX_SUFFIX_FOLDER;
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.extractMajorVersion;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.fail;
 
@@ -48,7 +45,7 @@ public class FsCrawlerTestIgnoreFoldersIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .setIndexFolders(false)
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
         // We expect to have two files
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 2L, null);

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestIncludesIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestIncludesIT.java
@@ -33,7 +33,7 @@ public class FsCrawlerTestIncludesIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .addInclude("*/*_include\\.txt")
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
     }
 
@@ -42,7 +42,7 @@ public class FsCrawlerTestIncludesIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .addInclude("*/*\\.txt")
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
         // We expect to have seven files
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 7L, null);
@@ -54,7 +54,7 @@ public class FsCrawlerTestIncludesIT extends AbstractFsCrawlerITCase {
                 .addExclude("*/\\.ignore")
                 .addExclude("/subdir/sub*")
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
         // We expect to have one file
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 2L, null);

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestIndexContentIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestIndexContentIT.java
@@ -39,7 +39,7 @@ public class FsCrawlerTestIndexContentIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .setIndexContent(false)
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
         // We expect to have one file
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestIngestPipelineIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestIngestPipelineIT.java
@@ -62,7 +62,7 @@ public class FsCrawlerTestIngestPipelineIT extends AbstractFsCrawlerITCase {
         Elasticsearch elasticsearch = endCrawlerDefinition(crawlerName);
         elasticsearch.setPipeline(crawlerName);
 
-        crawler = startCrawler(crawlerName, startCrawlerDefinition().build(), elasticsearch, null);
+        crawler = startCrawler(crawlerName, startCrawlerDefinition().build(), elasticsearch, null, null);
 
         // We expect to have one file
         countTestHelper(new ESSearchRequest()
@@ -107,7 +107,7 @@ public class FsCrawlerTestIngestPipelineIT extends AbstractFsCrawlerITCase {
         Elasticsearch elasticsearch = endCrawlerDefinition(crawlerName);
         elasticsearch.setPipeline(crawlerName);
 
-        crawler = startCrawler(crawlerName, startCrawlerDefinition().build(), elasticsearch, null);
+        crawler = startCrawler(crawlerName, startCrawlerDefinition().build(), elasticsearch, null, null);
 
         // We expect to have one file
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName())
@@ -125,7 +125,7 @@ public class FsCrawlerTestIngestPipelineIT extends AbstractFsCrawlerITCase {
         elasticsearch.setPipeline(crawlerName);
 
         try {
-            crawler = startCrawler(crawlerName, startCrawlerDefinition().build(), elasticsearch, null);
+            crawler = startCrawler(crawlerName, startCrawlerDefinition().build(), elasticsearch, null, null);
             fail("We should have caught a RuntimeException");
         } catch (RuntimeException e) {
             assertThat(e.getMessage(), containsString("You defined pipeline:" + crawlerName + ", but it does not exist."));

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestJsonSupportIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestJsonSupportIT.java
@@ -48,7 +48,7 @@ public class FsCrawlerTestJsonSupportIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .setJsonSupport(true)
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
         assertThat("We should have 2 doc for tweet in text field...", awaitBusy(() -> {
             try {
@@ -71,7 +71,7 @@ public class FsCrawlerTestJsonSupportIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .setJsonSupport(false)
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
         assertThat("We should have 0 doc for tweet in text field...", awaitBusy(() -> {
             try {
@@ -107,7 +107,7 @@ public class FsCrawlerTestJsonSupportIT extends AbstractFsCrawlerITCase {
                 .setJsonSupport(true)
                 .setAddAsInnerObject(true)
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
         assertThat("We should have 2 doc for tweet in object.text field...", awaitBusy(() -> {
             try {
@@ -130,7 +130,7 @@ public class FsCrawlerTestJsonSupportIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .setJsonSupport(true)
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
         assertThat("We should have 2 docs only...", awaitBusy(() -> {
             try {

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestMultipleCrawlersIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestMultipleCrawlersIT.java
@@ -46,8 +46,8 @@ public class FsCrawlerTestMultipleCrawlersIT extends AbstractFsCrawlerITCase {
     public void test_multiple_crawlers() throws Exception {
         Fs fs1 = startCrawlerDefinition(currentTestResourceDir.resolve("crawler1").toString()).build();
         Fs fs2 = startCrawlerDefinition(currentTestResourceDir.resolve("crawler2").toString()).build();
-        FsCrawlerImpl crawler1 = startCrawler(getCrawlerName() + "_1", fs1, endCrawlerDefinition(getCrawlerName() + "_1"), null);
-        FsCrawlerImpl crawler2 = startCrawler(getCrawlerName() + "_2", fs2, endCrawlerDefinition(getCrawlerName() + "_2"), null);
+        FsCrawlerImpl crawler1 = startCrawler(getCrawlerName() + "_1", fs1, endCrawlerDefinition(getCrawlerName() + "_1"), null, null);
+        FsCrawlerImpl crawler2 = startCrawler(getCrawlerName() + "_2", fs2, endCrawlerDefinition(getCrawlerName() + "_2"), null, null);
         // We should have one doc in index 1...
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName() + "_1"), 1L, null);
         // We should have one doc in index 2...

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestOcrIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestOcrIT.java
@@ -86,7 +86,7 @@ public class FsCrawlerTestOcrIT extends AbstractFsCrawlerITCase {
                             .build())
                     .build();
 
-            crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+            crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
             // We expect to have one file
             ESSearchResponse searchResponse = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 2L, null);
@@ -111,7 +111,7 @@ public class FsCrawlerTestOcrIT extends AbstractFsCrawlerITCase {
                             .build())
                     .build();
 
-            crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+            crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
             // We expect to have one file
             ESSearchResponse searchResponse = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 2L, null);

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRawIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRawIT.java
@@ -79,7 +79,7 @@ public class FsCrawlerTestRawIT extends AbstractFsCrawlerITCase {
             // Sometimes we explicitly disable it but this is also the default value
             builder.setRawMetadata(false);
         }
-        crawler = startCrawler(getCrawlerName(), builder.build(), endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), builder.build(), endCrawlerDefinition(getCrawlerName()), null, null);
         ESSearchResponse searchResponse = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
         for (ESSearchHit hit : searchResponse.getHits()) {
             expectThrows(PathNotFoundException.class, () -> JsonPath.read(hit.getSource(), "$.meta.raw"));
@@ -91,7 +91,7 @@ public class FsCrawlerTestRawIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .setRawMetadata(true)
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
         ESSearchResponse searchResponse = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
         for (ESSearchHit hit : searchResponse.getHits()) {
             assertThat(JsonPath.read(hit.getSource(), "$.meta.raw"), notNullValue());

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRemoveDeletedIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRemoveDeletedIT.java
@@ -54,7 +54,7 @@ public class FsCrawlerTestRemoveDeletedIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .setRemoveDeleted(true)
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
         // We should have two docs first
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 2L, currentTestResourceDir);
@@ -72,7 +72,7 @@ public class FsCrawlerTestRemoveDeletedIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .setRemoveDeleted(false)
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
         // We should have two docs first
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 2L, currentTestResourceDir);
@@ -93,7 +93,7 @@ public class FsCrawlerTestRemoveDeletedIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .setRemoveDeleted(true)
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
         // We should have 7 docs first
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 7L, currentTestResourceDir);

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestSemanticIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestSemanticIT.java
@@ -24,6 +24,7 @@ import fr.pilato.elasticsearch.crawler.fs.client.*;
 import fr.pilato.elasticsearch.crawler.fs.test.integration.AbstractFsCrawlerITCase;
 import org.junit.Test;
 
+import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.INDEX_SUFFIX_FOLDER;
 import static fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil.parseJsonAsDocumentContext;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -44,7 +45,12 @@ public class FsCrawlerTestSemanticIT extends AbstractFsCrawlerITCase {
         assumeTrue("We don't run this test when semantic search is not available",
                 managementService.getClient().isSemanticSupported());
 
-        crawler = startCrawler();
+        crawler = startCrawler(getCrawlerName(),
+                startCrawlerDefinition().build(),
+                generateElasticsearchConfig(getCrawlerName(), getCrawlerName() + INDEX_SUFFIX_FOLDER,
+                        1, null, null, false, true),
+                null,
+                null);
 
         // We expect to have 3 files
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 3L, null);

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestSettingsIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestSettingsIT.java
@@ -39,7 +39,7 @@ public class FsCrawlerTestSettingsIT extends AbstractFsCrawlerITCase {
     @Test
     public void test_time_value() throws Exception {
         Fs fs = startCrawlerDefinition(TimeValue.timeValueHours(1)).build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
         // We expect to have one file
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
@@ -50,7 +50,7 @@ public class FsCrawlerTestSettingsIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition().build();
         crawler = startCrawler(getCrawlerName(), fs,
                 generateElasticsearchConfig(getCrawlerName(), getCrawlerName() + INDEX_SUFFIX_FOLDER,
-                        100, TimeValue.timeValueSeconds(2), ByteSizeValue.parseBytesSizeValue("100b"), false), null);
+                        100, TimeValue.timeValueSeconds(2), ByteSizeValue.parseBytesSizeValue("100b"), false), null, null);
 
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
     }

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestSettingsIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestSettingsIT.java
@@ -50,7 +50,7 @@ public class FsCrawlerTestSettingsIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition().build();
         crawler = startCrawler(getCrawlerName(), fs,
                 generateElasticsearchConfig(getCrawlerName(), getCrawlerName() + INDEX_SUFFIX_FOLDER,
-                        100, TimeValue.timeValueSeconds(2), ByteSizeValue.parseBytesSizeValue("100b"), false), null, null);
+                        100, TimeValue.timeValueSeconds(2), ByteSizeValue.parseBytesSizeValue("100b"), false, false), null, null);
 
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
     }

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestSshIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestSshIT.java
@@ -122,7 +122,7 @@ public class FsCrawlerTestSshIT extends AbstractFsCrawlerITCase {
                 .setPassword(SSH_PASSWORD)
                 .setProtocol(Server.PROTOCOL.SSH)
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), server);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), server, null);
 
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 2L, null);
     }
@@ -137,7 +137,7 @@ public class FsCrawlerTestSshIT extends AbstractFsCrawlerITCase {
                 .setPemPath(rootTmpDir.resolve("private.key").toFile().getAbsolutePath())
                 .setProtocol(Server.PROTOCOL.SSH)
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), server);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), server, null);
 
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
     }

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestStoreSourceIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestStoreSourceIT.java
@@ -41,7 +41,7 @@ public class FsCrawlerTestStoreSourceIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .setStoreSource(true)
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
         ESSearchResponse searchResponse = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
         for (ESSearchHit hit : searchResponse.getHits()) {
@@ -69,7 +69,7 @@ public class FsCrawlerTestStoreSourceIT extends AbstractFsCrawlerITCase {
                 .setStoreSource(true)
                 .setIndexContent(false)
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
         ESSearchResponse searchResponse = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
         for (ESSearchHit hit : searchResponse.getHits()) {

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestTikaConfigPathIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestTikaConfigPathIT.java
@@ -39,7 +39,7 @@ public class FsCrawlerTestTikaConfigPathIT extends AbstractFsCrawlerITCase {
         .setTikaConfigPath(currentTestResourceDir.resolve("config/tikaConfig.xml").toString())
         .addExclude("/config/*")
         .build();
-    crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+    crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
     countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 2L, null);
     countTestHelper(new ESSearchRequest()

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestUnparsableIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestUnparsableIT.java
@@ -71,7 +71,7 @@ public class FsCrawlerTestUnparsableIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .setIndexContent(false)
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
 
         // We should have one doc first
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, currentTestResourceDir);

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestXmlSupportIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestXmlSupportIT.java
@@ -44,7 +44,7 @@ public class FsCrawlerTestXmlSupportIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .setXmlSupport(true)
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
         ESSearchResponse response = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 3L, null);
 
         countTestHelper(new ESSearchRequest()
@@ -70,7 +70,7 @@ public class FsCrawlerTestXmlSupportIT extends AbstractFsCrawlerITCase {
         Fs fs = startCrawlerDefinition()
                 .setXmlSupport(true)
                 .build();
-        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null);
+        crawler = startCrawler(getCrawlerName(), fs, endCrawlerDefinition(getCrawlerName()), null, null);
         ESSearchResponse response = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);
 
         countTestHelper(new ESSearchRequest()

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestZipFilesIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestZipFilesIT.java
@@ -36,7 +36,7 @@ public class FsCrawlerTestZipFilesIT extends AbstractFsCrawlerITCase {
     @Test
     public void test_zip() throws Exception {
         crawler = startCrawler(getCrawlerName(), startCrawlerDefinition().build(), endCrawlerDefinition(getCrawlerName()), null, null,
-                TimeValue.timeValueMinutes(2));
+                null, TimeValue.timeValueMinutes(2));
 
         // We expect to have one file
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, null);

--- a/integration-tests/src/test/resources-binary/samples/test_external_metadata_default/.meta.yml
+++ b/integration-tests/src/test/resources-binary/samples/test_external_metadata_default/.meta.yml
@@ -1,0 +1,18 @@
+external:
+  tenantId: 23
+  company: "shoe company"
+  projectId: 34
+  project: "business development"
+  daysOpen:
+    - "Mon"
+    - "Tue"
+    - "Wed"
+    - "Thu"
+    - "Fri"
+  products:
+    - brand: "nike"
+      size: 41
+      sub: "Air MAX"
+    - brand: "reebok"
+      size: 43
+      sub: "Pump"

--- a/integration-tests/src/test/resources-binary/samples/test_external_metadata_default/root_dir.txt
+++ b/integration-tests/src/test/resources-binary/samples/test_external_metadata_default/root_dir.txt
@@ -1,0 +1,1 @@
+This file contains some words.

--- a/integration-tests/src/test/resources-binary/samples/test_external_metadata_default/subdir_no_meta/without_meta.txt
+++ b/integration-tests/src/test/resources-binary/samples/test_external_metadata_default/subdir_no_meta/without_meta.txt
@@ -1,0 +1,1 @@
+This file is in a sub folder of the test_external_metadata directory, but it does not have a metadata file.

--- a/integration-tests/src/test/resources-binary/samples/test_external_metadata_default/subdir_with_meta/.meta.yml
+++ b/integration-tests/src/test/resources-binary/samples/test_external_metadata_default/subdir_with_meta/.meta.yml
@@ -1,0 +1,18 @@
+external:
+  tenantId: 23
+  company: "shoe company"
+  projectId: 34
+  project: "business development"
+  daysOpen:
+    - "Mon"
+    - "Tue"
+    - "Wed"
+    - "Thu"
+    - "Fri"
+  products:
+    - brand: "nike"
+      size: 41
+      sub: "Air MAX"
+    - brand: "reebok"
+      size: 43
+      sub: "Pump"

--- a/integration-tests/src/test/resources-binary/samples/test_external_metadata_default/subdir_with_meta/with_meta.txt
+++ b/integration-tests/src/test/resources-binary/samples/test_external_metadata_default/subdir_with_meta/with_meta.txt
@@ -1,0 +1,2 @@
+This file is in a sub folder of the test_external_metadata directory and it does have a metadata file
+so the content should be altered.

--- a/integration-tests/src/test/resources-binary/samples/test_external_metadata_json/meta-as-json.json
+++ b/integration-tests/src/test/resources-binary/samples/test_external_metadata_json/meta-as-json.json
@@ -1,0 +1,27 @@
+{
+  "external": {
+    "tenantId" : 23,
+    "company": "shoe company",
+    "projectId": 34,
+    "project": "business development",
+    "daysOpen": [
+      "Mon",
+      "Tue",
+      "Wed",
+      "Thu",
+      "Fri"
+    ],
+    "products": [
+      {
+        "brand": "nike",
+        "size": 41,
+        "sub": "Air MAX"
+      },
+      {
+        "brand": "reebok",
+        "size": 43,
+        "sub": "Pump"
+      }
+    ]
+  }
+}

--- a/integration-tests/src/test/resources-binary/samples/test_external_metadata_json/root_dir.txt
+++ b/integration-tests/src/test/resources-binary/samples/test_external_metadata_json/root_dir.txt
@@ -1,0 +1,1 @@
+This file contains some words.

--- a/integration-tests/src/test/resources-binary/samples/test_external_metadata_json/subdir_no_meta/without_meta.txt
+++ b/integration-tests/src/test/resources-binary/samples/test_external_metadata_json/subdir_no_meta/without_meta.txt
@@ -1,0 +1,1 @@
+This file is in a sub folder of the test_external_metadata directory, but it does not have a metadata file.

--- a/integration-tests/src/test/resources-binary/samples/test_external_metadata_json/subdir_with_meta/meta-as-json.json
+++ b/integration-tests/src/test/resources-binary/samples/test_external_metadata_json/subdir_with_meta/meta-as-json.json
@@ -1,0 +1,27 @@
+{
+  "external": {
+    "tenantId" : 23,
+    "company": "shoe company",
+    "projectId": 34,
+    "project": "business development",
+    "daysOpen": [
+      "Mon",
+      "Tue",
+      "Wed",
+      "Thu",
+      "Fri"
+    ],
+    "products": [
+      {
+        "brand": "nike",
+        "size": 41,
+        "sub": "Air MAX"
+      },
+      {
+        "brand": "reebok",
+        "size": 43,
+        "sub": "Pump"
+      }
+    ]
+  }
+}

--- a/integration-tests/src/test/resources-binary/samples/test_external_metadata_json/subdir_with_meta/with_meta.txt
+++ b/integration-tests/src/test/resources-binary/samples/test_external_metadata_json/subdir_with_meta/with_meta.txt
@@ -1,0 +1,2 @@
+This file is in a sub folder of the test_external_metadata directory and it does have a metadata file
+so the content should be altered.

--- a/integration-tests/src/test/resources-binary/samples/test_external_metadata_overwrite/root_dir.txt
+++ b/integration-tests/src/test/resources-binary/samples/test_external_metadata_overwrite/root_dir.txt
@@ -1,0 +1,1 @@
+This file contains some words.

--- a/integration-tests/src/test/resources-binary/samples/test_external_metadata_overwrite/subdir_no_meta/without_meta.txt
+++ b/integration-tests/src/test/resources-binary/samples/test_external_metadata_overwrite/subdir_no_meta/without_meta.txt
@@ -1,0 +1,1 @@
+This file is in a sub folder of the test_external_metadata directory, but it does not have a metadata file.

--- a/integration-tests/src/test/resources-binary/samples/test_external_metadata_overwrite/subdir_with_meta/.meta.yml
+++ b/integration-tests/src/test/resources-binary/samples/test_external_metadata_overwrite/subdir_with_meta/.meta.yml
@@ -1,0 +1,19 @@
+content: "This is a new content which is overwritten."
+external:
+  tenantId: 23
+  company: "shoe company"
+  projectId: 34
+  project: "business development"
+  daysOpen:
+    - "Mon"
+    - "Tue"
+    - "Wed"
+    - "Thu"
+    - "Fri"
+  products:
+    - brand: "nike"
+      size: 41
+      sub: "Air MAX"
+    - brand: "reebok"
+      size: 43
+      sub: "Pump"

--- a/integration-tests/src/test/resources-binary/samples/test_external_metadata_overwrite/subdir_with_meta/with_meta.txt
+++ b/integration-tests/src/test/resources-binary/samples/test_external_metadata_overwrite/subdir_with_meta/with_meta.txt
@@ -1,0 +1,2 @@
+This file is in a sub folder of the test_external_metadata directory and it does have a metadata file
+so the content should be altered.

--- a/integration-tests/src/test/resources-binary/samples/test_external_metadata_yaml/meta-as-yaml.yaml
+++ b/integration-tests/src/test/resources-binary/samples/test_external_metadata_yaml/meta-as-yaml.yaml
@@ -1,0 +1,18 @@
+external:
+  tenantId: 23
+  company: "shoe company"
+  projectId: 34
+  project: "business development"
+  daysOpen:
+    - "Mon"
+    - "Tue"
+    - "Wed"
+    - "Thu"
+    - "Fri"
+  products:
+    - brand: "nike"
+      size: 41
+      sub: "Air MAX"
+    - brand: "reebok"
+      size: 43
+      sub: "Pump"

--- a/integration-tests/src/test/resources-binary/samples/test_external_metadata_yaml/root_dir.txt
+++ b/integration-tests/src/test/resources-binary/samples/test_external_metadata_yaml/root_dir.txt
@@ -1,0 +1,1 @@
+This file contains some words.

--- a/integration-tests/src/test/resources-binary/samples/test_external_metadata_yaml/subdir_no_meta/without_meta.txt
+++ b/integration-tests/src/test/resources-binary/samples/test_external_metadata_yaml/subdir_no_meta/without_meta.txt
@@ -1,0 +1,1 @@
+This file is in a sub folder of the test_external_metadata directory, but it does not have a metadata file.

--- a/integration-tests/src/test/resources-binary/samples/test_external_metadata_yaml/subdir_with_meta/meta-as-yaml.yaml
+++ b/integration-tests/src/test/resources-binary/samples/test_external_metadata_yaml/subdir_with_meta/meta-as-yaml.yaml
@@ -1,0 +1,18 @@
+external:
+  tenantId: 23
+  company: "shoe company"
+  projectId: 34
+  project: "business development"
+  daysOpen:
+    - "Mon"
+    - "Tue"
+    - "Wed"
+    - "Thu"
+    - "Fri"
+  products:
+    - brand: "nike"
+      size: 41
+      sub: "Air MAX"
+    - brand: "reebok"
+      size: 43
+      sub: "Pump"

--- a/integration-tests/src/test/resources-binary/samples/test_external_metadata_yaml/subdir_with_meta/with_meta.txt
+++ b/integration-tests/src/test/resources-binary/samples/test_external_metadata_yaml/subdir_with_meta/with_meta.txt
@@ -1,0 +1,2 @@
+This file is in a sub folder of the test_external_metadata directory and it does have a metadata file
+so the content should be altered.

--- a/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/DocumentApi.java
+++ b/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/DocumentApi.java
@@ -47,6 +47,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
 
+import static fr.pilato.elasticsearch.crawler.fs.beans.DocUtils.getMergedJsonDoc;
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.localDateTimeToDate;
 import static fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil.mapper;
 import static fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil.parseJsonAsDocumentContext;
@@ -255,7 +256,7 @@ public class DocumentApi extends RestApi {
         // Elasticsearch entity coordinates (we use the first node address)
         ServerUrl node = settings.getElasticsearch().getNodes().get(0);
         String url = node.getUrl() + "/" + index + "/_doc/" + id;
-        final Doc mergedDoc = this.getMergedJsonDoc(doc, tags);
+        final Doc mergedDoc = getMergedJsonDoc(doc, tags);
         if (Boolean.parseBoolean(simulate)) {
             logger.debug("Simulate mode is on, so we skip sending document [{}] to elasticsearch at [{}].", filename, url);
         } else {
@@ -313,23 +314,5 @@ public class DocumentApi extends RestApi {
         }
 
         return response;
-    }
-
-    private Doc getMergedJsonDoc(Doc doc, InputStream tags) throws BadRequestException {
-        if (tags == null) {
-            return doc;
-        }
-
-        try {
-            JsonNode tagsNode = mapper.readTree(tags);
-            JsonNode docNode = mapper.convertValue(doc, JsonNode.class);
-
-            JsonNode mergedNode = FsCrawlerUtil.merge(tagsNode, docNode);
-
-            return mapper.treeToValue(mergedNode, Doc.class);
-        } catch (Exception e) {
-            logger.error("Error parsing tags", e);
-            throw new BadRequestException("Error parsing tags", e);
-        }
     }
 }

--- a/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/DocumentApi.java
+++ b/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/DocumentApi.java
@@ -19,10 +19,8 @@
 
 package fr.pilato.elasticsearch.crawler.fs.rest;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.jayway.jsonpath.DocumentContext;
 import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
-import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil;
 import fr.pilato.elasticsearch.crawler.fs.framework.SignTool;
 import fr.pilato.elasticsearch.crawler.fs.service.FsCrawlerDocumentService;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
@@ -49,7 +47,6 @@ import java.time.LocalDateTime;
 
 import static fr.pilato.elasticsearch.crawler.fs.beans.DocUtils.getMergedJsonDoc;
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.localDateTimeToDate;
-import static fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil.mapper;
 import static fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil.parseJsonAsDocumentContext;
 
 @Path("/_document")

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettings.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettings.java
@@ -29,17 +29,19 @@ public class FsSettings {
     private Server server;
     private Elasticsearch elasticsearch;
     private Rest rest;
+    private Tags tags;
 
     public FsSettings() {
 
     }
 
-    private FsSettings(String name, Fs fs, Server server, Elasticsearch elasticsearch, Rest rest) {
+    private FsSettings(String name, Fs fs, Server server, Elasticsearch elasticsearch, Rest rest, Tags tags) {
         this.name = name;
         this.fs = fs;
         this.server = server;
         this.elasticsearch = elasticsearch;
         this.rest = rest;
+        this.tags = tags;
     }
 
     public static Builder builder(String name) {
@@ -52,6 +54,7 @@ public class FsSettings {
         private Server server = null;
         private Elasticsearch elasticsearch = Elasticsearch.DEFAULT();
         private Rest rest = null;
+        private Tags tags = Tags.DEFAULT;
 
         private Builder setName(String name) {
             this.name = name;
@@ -78,8 +81,13 @@ public class FsSettings {
             return this;
         }
 
+        public Builder setTags(Tags tags) {
+            this.tags = tags;
+            return this;
+        }
+
         public FsSettings build() {
-            return new FsSettings(name, fs, server, elasticsearch, rest);
+            return new FsSettings(name, fs, server, elasticsearch, rest, tags);
         }
     }
 
@@ -123,6 +131,14 @@ public class FsSettings {
         this.rest = rest;
     }
 
+    public Tags getTags() {
+        return tags;
+    }
+
+    public void setTags(Tags tags) {
+        this.tags = tags;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -134,6 +150,7 @@ public class FsSettings {
         if (!Objects.equals(fs, that.fs)) return false;
         if (!Objects.equals(server, that.server)) return false;
         if (!Objects.equals(rest, that.rest)) return false;
+        if (!Objects.equals(tags, that.tags)) return false;
         return Objects.equals(elasticsearch, that.elasticsearch);
 
     }
@@ -144,6 +161,7 @@ public class FsSettings {
         result = 31 * result + (fs != null ? fs.hashCode() : 0);
         result = 31 * result + (server != null ? server.hashCode() : 0);
         result = 31 * result + (rest != null ? rest.hashCode() : 0);
+        result = 31 * result + (tags != null ? tags.hashCode() : 0);
         result = 31 * result + (elasticsearch != null ? elasticsearch.hashCode() : 0);
         return result;
     }
@@ -155,6 +173,7 @@ public class FsSettings {
                 ", server=" + server +
                 ", elasticsearch=" + elasticsearch +
                 ", rest=" + rest +
+                ", tags=" + tags +
                 '}';
     }
 }

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Tags.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Tags.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package fr.pilato.elasticsearch.crawler.fs.settings;
+
+import java.util.Objects;
+
+@SuppressWarnings("SameParameterValue")
+public class Tags {
+    public static final String DEFAULT_META_FILENAME = ".meta.yml";
+    public static final Tags DEFAULT = Tags.builder().build();
+
+    private String metaFilename;
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String metaFilename = DEFAULT_META_FILENAME;
+
+        public Builder setMetaFilename(String metaFilename) {
+            this.metaFilename = metaFilename;
+            return this;
+        }
+
+        public Tags build() {
+            return new Tags(metaFilename);
+        }
+    }
+
+    public Tags() {
+
+    }
+
+    public Tags(String metaFilename) {
+        this.metaFilename = metaFilename;
+    }
+
+    public String getMetaFilename() {
+        return metaFilename;
+    }
+
+    public void setMetaFilename(String metaFilename) {
+        this.metaFilename = metaFilename;
+    }
+
+    @Override
+    public String toString() {
+        return "Tags{" +
+                "metaFilename='" + metaFilename + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        Tags tags = (Tags) o;
+        return Objects.equals(metaFilename, tags.metaFilename);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(metaFilename);
+    }
+}

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsParserTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsParserTest.java
@@ -83,6 +83,8 @@ public class FsSettingsParserTest extends AbstractFSCrawlerTestCase {
 
         logger.info("-> testing settings: [{}]", yaml);
         FsSettings generated = FsSettingsParser.fromYaml(yaml);
+
+        logger.info("-> comparing with settings: [{}]", FsSettingsParser.toYaml(generated));
         assertThat(generated, is(source));
     }
 


### PR DESCRIPTION
The goal of this feature is to allow users to provide additional metadata when crawling files. Whenever a directory is crawled, FSCrawler checks if a file named `.meta.yml` is present in the directory. If it is, the content of this file is used to enrich the document.

## Example

For example, if you have a file named `.meta.yml` in the directory `/path/to/data/dir`:

```yaml
external:
  myTitle: "My document title"
```

Then the document indexed will have a new field named `external.myTitle` with the value `My document title`.

## Supported Fields

Only supported fields can be added to the document. If you try to add a field which is not supported, it will be ignored.

For example, if you have the `.meta.yml` file contains:

```yaml
foo: "bar"
external:
  myTitle: "My document title"
```

The document indexed will have a new field named `external.myTitle` with the value `My document title`. The field `foo` will be ignored.

If you really want to add a field named `foo`, you need to add it first as an external tag:

```yaml
external:
  foo: "bar"
  myTitle: "My document title"
```

and then use an ingest pipeline to rename the `external.foo` field to `foo`.

## Overwriting Fields

The `.meta.yml` file can also overwrite existing fields. For example, if you have the following `.meta.yml` file:

```yaml
content: "HIDDEN"
```

Then the `content` field will be replaced by `HIDDEN` even though something else is extracted.

> **Note:** The `.meta.yml` file is not indexed. It is only used to enrich the document.

## Tags Settings

Here is a list of Tags settings (under `tags.` prefix):

| Name                  | Default value   | Documentation       |
|-----------------------|-----------------|---------------------|
| `tags.metaFilename`   | `.meta.yml`     | [Meta Filename](#meta-filename) |

### Meta Filename

You can use another filename for the external tags file. For example, if you want to use `meta_tags.json` instead of `.meta.yml`, you can set:

```yaml
tags:
  metaFilename: "meta_tags.json"
```

> **Note:** Only json and yaml files are supported.

Closes #1984.

