### PR TITLE
Set the docker image ENTRYPOINT

### DIFF
--- a/contrib/docker-compose-example-elasticsearch/.env
+++ b/contrib/docker-compose-example-elasticsearch/.env
@@ -4,6 +4,9 @@
 FSCRAWLER_VERSION=2.10-SNAPSHOT
 FSCRAWLER_PORT=8080
 
+# Optionally, you can change the log level settings
+FS_JAVA_OPTS="-DLOG_LEVEL=debug -DDOC_LEVEL=debug"
+
 # Password for the 'elastic' user (at least 6 characters)
 ELASTIC_PASSWORD=changeme
 

--- a/contrib/docker-compose-example-elasticsearch/docker-compose.yml
+++ b/contrib/docker-compose-example-elasticsearch/docker-compose.yml
@@ -123,9 +123,11 @@ services:
 
   # FSCrawler
   fscrawler:
-    image: dadoonet/fscrawler:$FSCRAWLER_VERSION
+    image: dadoonet/fscrawler:${FSCRAWLER_VERSION}
     container_name: fscrawler
     restart: always
+    environment:
+      - FS_JAVA_OPTS=${FS_JAVA_OPTS}
     volumes:
       - ../../test-documents/src/main/resources/documents/:/tmp/es:ro
       - ${PWD}/config:/root/.fscrawler
@@ -136,7 +138,7 @@ services:
         condition: service_healthy
     ports:
       - ${FSCRAWLER_PORT}:8080
-    command: fscrawler idx --restart --rest
+    command: idx --restart --rest
 
 volumes:
   certs:

--- a/contrib/docker-compose-example-fscrawler/.env
+++ b/contrib/docker-compose-example-fscrawler/.env
@@ -3,3 +3,6 @@
 # FSCrawler Settings
 FSCRAWLER_VERSION=2.10-SNAPSHOT
 FSCRAWLER_PORT=8080
+
+# Optionally, you can change the log level settings
+FS_JAVA_OPTS="-DLOG_LEVEL=debug -DDOC_LEVEL=debug"

--- a/contrib/docker-compose-example-fscrawler/docker-compose.yml
+++ b/contrib/docker-compose-example-fscrawler/docker-compose.yml
@@ -3,8 +3,10 @@ version: "2.2"
 
 services:
   fscrawler:
-    image: dadoonet/fscrawler:$FSCRAWLER_VERSION
+    image: dadoonet/fscrawler:${FSCRAWLER_VERSION}
     container_name: fscrawler
+    environment:
+      - FS_JAVA_OPTS=${FS_JAVA_OPTS}
     volumes:
       - ../../test-documents/src/main/resources/documents/:/tmp/es:ro
       - ${PWD}/config:/root/.fscrawler
@@ -12,5 +14,5 @@ services:
       - ${PWD}/external:/usr/share/fscrawler/external
     ports:
       - ${FSCRAWLER_PORT}:8080
-    command: fscrawler idx --rest
+    command: idx --rest
 

--- a/contrib/src/main/resources/docker-compose-example-elasticsearch/.env
+++ b/contrib/src/main/resources/docker-compose-example-elasticsearch/.env
@@ -4,6 +4,9 @@
 FSCRAWLER_VERSION=${project.version}
 FSCRAWLER_PORT=8080
 
+# Optionally, you can change the log level settings
+FS_JAVA_OPTS="-DLOG_LEVEL=debug -DDOC_LEVEL=debug"
+
 # Password for the 'elastic' user (at least 6 characters)
 ELASTIC_PASSWORD=changeme
 

--- a/contrib/src/main/resources/docker-compose-example-fscrawler/.env
+++ b/contrib/src/main/resources/docker-compose-example-fscrawler/.env
@@ -3,3 +3,6 @@
 # FSCrawler Settings
 FSCRAWLER_VERSION=${project.version}
 FSCRAWLER_PORT=8080
+
+# Optionally, you can change the log level settings
+FS_JAVA_OPTS="-DLOG_LEVEL=debug -DDOC_LEVEL=debug"

--- a/distribution/src/main/docker/Dockerfile
+++ b/distribution/src/main/docker/Dockerfile
@@ -13,7 +13,4 @@ RUN set -ex \
     && rm -rf /var/lib/apt/lists/*
 
 COPY maven /usr/share/fscrawler
-RUN set -ex \
-    && ln -sn /usr/share/fscrawler/bin/fscrawler /usr/bin/
-
-WORKDIR /usr/share/fscrawler
+ENTRYPOINT [ "/usr/share/fscrawler/bin/fscrawler" ]

--- a/docs/source/admin/fs/index.rst
+++ b/docs/source/admin/fs/index.rst
@@ -11,7 +11,7 @@ The job file (``~/.fscrawler/test/_settings.yaml``) for the job name ``test`` mu
    # required
    fs:
 
-     # define a "local" file path crawler, if running inside a docker container this must be the path INSIDE the container
+     # define a "local" file path crawler, if running inside a docker container this must be the path INSIDE the container (/tmp/es)
      url: "/path/to/docs"
      follow_symlink: false
      remove_deleted: true
@@ -89,19 +89,14 @@ The job file (``~/.fscrawler/test/_settings.yaml``) for the job name ``test`` mu
    # required
    elasticsearch:
      nodes:
-     # With Cloud ID
-     - cloud_id: "CLOUD_ID"
-     # With URL
-     - url: "http://127.0.0.1:9200"
+     - url: "https://127.0.0.1:9200"
      bulk_size: 1000
      flush_interval: "5s"
      byte_size: "10mb"
-     # choose one of the 3 following options:
-     # 1 - Using access token
-     access_token: "dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ=="
-     # 2 - Using Api Key
+     # choose one of the 2 following options:
+     # 1 - Using Api Key
      api_key: "VnVhQ2ZHY0JDZGJrUW0tZTVhT3g6dWkybHAyYXhUTm1zeWFrdzl0dk5udw=="
-     # 3 - Using username/password (not recommended / deprecated)
+     # 2 - Using username/password (not recommended / deprecated)
      username: "elastic"
      password: "password"
      # optional, defaults to ``name``-property

--- a/docs/source/admin/logger.rst
+++ b/docs/source/admin/logger.rst
@@ -41,3 +41,36 @@ Please read `Log4J2 documentation <https://logging.apache.org/log4j/2.x/manual/i
 
     FSCrawler detects automatically on Linux machines when it's running in background or foreground.
     When in background, the logger configuration file used is ``config/log4j2-file.xml``.
+
+In the Docker context, you can modify the logs level by setting the ``FS_JAVA_OPTS`` environment variable:
+
+.. code:: sh
+
+   docker run -it --rm \
+        -v ~/.fscrawler:/root/.fscrawler \
+        -v ~/tmp:/tmp/es:ro \
+        -v ~/logs:/root/logs \
+        -e FS_JAVA_OPTS="-DLOG_LEVEL=debug -DDOC_LEVEL=debug" \
+        dadoonet/fscrawler job_name
+
+Then the logs will be readable from the ``~/logs`` directory.
+
+Read :ref:`docker` for more information.
+
+Same for Docker Compose, you can modify your ``docker-compose.yml`` file:
+
+.. code:: yaml
+
+   version: '3'
+   services:
+     fscrawler:
+       image: dadoonet/fscrawler
+       volumes:
+         - ~/.fscrawler:/root/.fscrawler
+         - ~/tmp:/tmp/es:ro
+         - ~/logs:/root/logs
+       environment:
+         - FS_JAVA_OPTS=-DLOG_LEVEL=debug -DDOC_LEVEL=debug
+       command: job_name
+
+Read :ref:`docker-compose` for more information.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -60,7 +60,7 @@ You can run FSCrawler with:
    docker run -it --rm \
         -v ~/.fscrawler:/root/.fscrawler \
         -v ~/tmp:/tmp/es:ro \
-        dadoonet/fscrawler fscrawler job_name
+        dadoonet/fscrawler job_name
 
 On the first run, if the job does not exist yet in ``~/.fscrawler``, FSCrawler will ask you if you want to create it:
 
@@ -87,7 +87,7 @@ mount it as well:
         -v ~/.fscrawler:/root/.fscrawler \
         -v ~/tmp:/tmp/es:ro \
         -v "$PWD/external:/usr/share/fscrawler/external" \
-        dadoonet/fscrawler fscrawler job_name
+        dadoonet/fscrawler job_name
 
 If you want to use the :ref:`rest-service`, don't forget to also expose the port:
 
@@ -97,7 +97,36 @@ If you want to use the :ref:`rest-service`, don't forget to also expose the port
         -v ~/.fscrawler:/root/.fscrawler \
         -v ~/tmp:/tmp/es:ro \
         -p 8080:8080 \
-        dadoonet/fscrawler fscrawler job_name
+        dadoonet/fscrawler job_name
+
+If you want to change the log level for FSCrawler, you can run:
+
+.. code:: sh
+
+   docker run -it --rm \
+        -v ~/.fscrawler:/root/.fscrawler \
+        -v ~/tmp:/tmp/es:ro \
+        -v ~/logs:/root/logs \
+        -e FS_JAVA_OPTS="-DLOG_LEVEL=debug -DDOC_LEVEL=debug" \
+        dadoonet/fscrawler job_name
+
+And you can read the logs from the ``~/logs`` directory:
+
+.. code:: sh
+
+   tail -f ~/logs/documents.log
+
+You can pass all the CLI options to the docker container as well:
+
+.. code:: sh
+
+   docker run -it --rm \
+        -v ~/.fscrawler:/root/.fscrawler \
+        -v ~/tmp:/tmp/es:ro \
+        dadoonet/fscrawler job_name --restart --loop 1
+
+See :ref:`cli-options` for more information.
+
 
 .. _docker-compose:
 
@@ -151,6 +180,28 @@ with docker compose:
 
     The configuration shown above is also meant to start the REST interface. It also activates the full indexation of
     documents, lang detection and ocr using english. You can adapt this example for your needs.
+
+Prepare a ``.env`` file with the following content:
+
+.. code:: sh
+
+    # Chenge the FSCRAWLER_VERSION if needed
+    FSCRAWLER_VERSION=2.10-SNAPSHOT
+    FSCRAWLER_PORT=8080
+    # Optionally, you can change the log level settings
+    FS_JAVA_OPTS="-DLOG_LEVEL=debug -DDOC_LEVEL=debug"
+
+    # Chenge the STACK_VERSION if needed
+    STACK_VERSION=8.17.3
+    ELASTIC_PASSWORD=changeme
+    KIBANA_PASSWORD=changeme
+    CLUSTER_NAME=docker-cluster
+    LICENSE=trial
+    ES_PORT=9200
+    KIBANA_PORT=5601
+    MEM_LIMIT=4294967296
+    COMPOSE_PROJECT_NAME=fscrawler
+
 
 And, prepare the following ``docker-compose.yml``. You will find this example in the
 ``contrib/docker-compose-example-elasticsearch`` project directory.
@@ -283,9 +334,11 @@ And, prepare the following ``docker-compose.yml``. You will find this example in
 
       # FSCrawler
       fscrawler:
-        image: dadoonet/fscrawler:$FSCRAWLER_VERSION
+        image: dadoonet/fscrawler:${FSCRAWLER_VERSION}
         container_name: fscrawler
         restart: always
+        environment:
+          - FS_JAVA_OPTS=${FS_JAVA_OPTS}
         volumes:
           - ../../test-documents/src/main/resources/documents/:/tmp/es:ro
           - ${PWD}/config:/root/.fscrawler
@@ -296,7 +349,7 @@ And, prepare the following ``docker-compose.yml``. You will find this example in
             condition: service_healthy
         ports:
           - ${FSCRAWLER_PORT}:8080
-        command: fscrawler idx --restart --rest
+        command: idx --restart --rest
 
     volumes:
       certs:
@@ -316,255 +369,17 @@ Then, you can run the full stack, including FSCrawler.
 
     docker-compose up -d
 
-With Enterprise Search (Workplace Search)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Here is a typical ``_settings.yaml``, you can use to connect FSCrawler with Workplace Search when running
-with docker compose:
-
-.. code:: yaml
-
-    ---
-    name: "idx"
-    fs:
-      indexed_chars: 100%
-      lang_detect: true
-      continue_on_error: true
-      ocr:
-        language: "eng"
-        enabled: true
-        pdf_strategy: "ocr_and_text"
-    elasticsearch:
-      nodes:
-        - url: "https://elasticsearch:9200"
-      username: "elastic"
-      password: "changeme"
-      ssl_verification: false
-    workplace_search:
-      server: "http://enterprisesearch:3002"
-
-And, prepare the following ``docker-compose.yml``. You will find this example in the
-``contrib/docker-compose-example-workplace`` project directory.
-
-.. code:: yaml
-
-    ---
-    version: "2.2"
-
-    services:
-      setup:
-        image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}
-        volumes:
-          - certs:/usr/share/elasticsearch/config/certs
-        user: "0"
-        command: >
-          bash -c '
-            if [ x${ELASTIC_PASSWORD} == x ]; then
-              echo "Set the ELASTIC_PASSWORD environment variable in the .env file";
-              exit 1;
-            elif [ x${KIBANA_PASSWORD} == x ]; then
-              echo "Set the KIBANA_PASSWORD environment variable in the .env file";
-              exit 1;
-            fi;
-            if [ ! -f certs/ca.zip ]; then
-              echo "Creating CA";
-              bin/elasticsearch-certutil ca --silent --pem -out config/certs/ca.zip;
-              unzip config/certs/ca.zip -d config/certs;
-            fi;
-            if [ ! -f certs/certs.zip ]; then
-              echo "Creating certs";
-              echo -ne \
-              "instances:\n"\
-              "  - name: elasticsearch\n"\
-              "    dns:\n"\
-              "      - elasticsearch\n"\
-              "      - localhost\n"\
-              "    ip:\n"\
-              "      - 127.0.0.1\n"\
-              > config/certs/instances.yml;
-              bin/elasticsearch-certutil cert --silent --pem -out config/certs/certs.zip --in config/certs/instances.yml --ca-cert config/certs/ca/ca.crt --ca-key config/certs/ca/ca.key;
-              unzip config/certs/certs.zip -d config/certs;
-            fi;
-            echo "Setting file permissions"
-            chown -R root:root config/certs;
-            find . -type d -exec chmod 750 \{\} \;;
-            find . -type f -exec chmod 640 \{\} \;;
-            echo "Waiting for Elasticsearch availability";
-            until curl -s --cacert config/certs/ca/ca.crt https://elasticsearch:9200 | grep -q "missing authentication credentials"; do sleep 30; done;
-            echo "Setting kibana_system password";
-            until curl -s -X POST --cacert config/certs/ca/ca.crt -u elastic:${ELASTIC_PASSWORD} -H "Content-Type: application/json" https://elasticsearch:9200/_security/user/kibana_system/_password -d "{\"password\":\"${KIBANA_PASSWORD}\"}" | grep -q "^{}"; do sleep 10; done;
-            echo "All done!";
-          '
-        healthcheck:
-          test: ["CMD-SHELL", "[ -f config/certs/elasticsearch/elasticsearch.crt ]"]
-          interval: 1s
-          timeout: 5s
-          retries: 120
-
-      elasticsearch:
-        depends_on:
-          setup:
-            condition: service_healthy
-        image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}
-        volumes:
-          - certs:/usr/share/elasticsearch/config/certs
-          - esdata:/usr/share/elasticsearch/data
-        ports:
-          - ${ES_PORT}:9200
-        environment:
-          - node.name=elasticsearch
-          - cluster.name=${CLUSTER_NAME}
-          - cluster.initial_master_nodes=elasticsearch
-          - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
-          - bootstrap.memory_lock=true
-          - xpack.security.enabled=true
-          - xpack.security.http.ssl.enabled=true
-          - xpack.security.http.ssl.key=certs/elasticsearch/elasticsearch.key
-          - xpack.security.http.ssl.certificate=certs/elasticsearch/elasticsearch.crt
-          - xpack.security.http.ssl.certificate_authorities=certs/ca/ca.crt
-          - xpack.security.http.ssl.verification_mode=certificate
-          - xpack.security.transport.ssl.enabled=true
-          - xpack.security.transport.ssl.key=certs/elasticsearch/elasticsearch.key
-          - xpack.security.transport.ssl.certificate=certs/elasticsearch/elasticsearch.crt
-          - xpack.security.transport.ssl.certificate_authorities=certs/ca/ca.crt
-          - xpack.security.transport.ssl.verification_mode=certificate
-          - xpack.license.self_generated.type=${LICENSE}
-        mem_limit: ${MEM_LIMIT}
-        ulimits:
-          memlock:
-            soft: -1
-            hard: -1
-        healthcheck:
-          test:
-            [
-              "CMD-SHELL",
-              "curl -s --cacert config/certs/ca/ca.crt https://localhost:9200 | grep -q 'missing authentication credentials'",
-            ]
-          interval: 10s
-          timeout: 10s
-          retries: 120
-
-      kibana:
-        depends_on:
-          elasticsearch:
-            condition: service_healthy
-        image: docker.elastic.co/kibana/kibana:${STACK_VERSION}
-        volumes:
-          - certs:/usr/share/kibana/config/certs
-          - kibanadata:/usr/share/kibana/data
-        ports:
-          - ${KIBANA_PORT}:5601
-        environment:
-          - SERVERNAME=kibana
-          - ELASTICSEARCH_HOSTS=https://elasticsearch:9200
-          - ELASTICSEARCH_USERNAME=kibana_system
-          - ELASTICSEARCH_PASSWORD=${KIBANA_PASSWORD}
-          - ELASTICSEARCH_SSL_CERTIFICATEAUTHORITIES=config/certs/ca/ca.crt
-          - ENTERPRISESEARCH_HOST=http://enterprisesearch:${ENTERPRISE_SEARCH_PORT}
-        mem_limit: ${MEM_LIMIT}
-        healthcheck:
-          test:
-            [
-              "CMD-SHELL",
-              "curl -s -I http://localhost:5601 | grep -q 'HTTP/1.1 302 Found'",
-            ]
-          interval: 10s
-          timeout: 10s
-          retries: 120
-
-      enterprisesearch:
-        depends_on:
-          elasticsearch:
-            condition: service_healthy
-          kibana:
-            condition: service_healthy
-        image: docker.elastic.co/enterprise-search/enterprise-search:${STACK_VERSION}
-        volumes:
-          - certs:/usr/share/enterprise-search/config/certs
-          - enterprisesearchdata:/usr/share/enterprise-search/config
-        ports:
-          - ${ENTERPRISE_SEARCH_PORT}:3002
-        environment:
-          - SERVERNAME=enterprisesearch
-          - secret_management.encryption_keys=[${ENCRYPTION_KEYS}]
-          - allow_es_settings_modification=true
-          - elasticsearch.host=https://elasticsearch:9200
-          - elasticsearch.username=elastic
-          - elasticsearch.password=${ELASTIC_PASSWORD}
-          - elasticsearch.ssl.enabled=true
-          - elasticsearch.ssl.certificate_authority=/usr/share/enterprise-search/config/certs/ca/ca.crt
-          - kibana.external_url=http://kibana:5601
-        mem_limit: ${MEM_LIMIT}
-        healthcheck:
-          test:
-            [
-              "CMD-SHELL",
-              "curl -s -I http://localhost:3002 | grep -q 'HTTP/1.1 302 Found'",
-            ]
-          interval: 10s
-          timeout: 10s
-          retries: 120
-
-      # Apache Httpd service (to serve local files)
-      httpd:
-        image: httpd:2.4
-        restart: on-failure
-        volumes:
-          - ../../test-documents/src/main/resources/documents/:/usr/local/apache2/htdocs/:ro
-        ports:
-          - 80:80
-        healthcheck:
-          test:
-            [
-              "CMD-SHELL",
-              "curl -s -I http://localhost | grep -q 'HTTP/1.1 302 Found'",
-            ]
-          interval: 10s
-          timeout: 10s
-          retries: 120
-
-      # FSCrawler
-      fscrawler:
-        image: dadoonet/fscrawler:$FSCRAWLER_VERSION
-        container_name: fscrawler
-        restart: on-failure
-        volumes:
-          - ../../test-documents/src/main/resources/documents/:/tmp/es:ro
-          - ${PWD}/config:/root/.fscrawler
-          - ${PWD}/logs:/usr/share/fscrawler/logs
-          - ${PWD}/external:/usr/share/fscrawler/external
-        depends_on:
-          enterprisesearch:
-            condition: service_healthy
-        command: fscrawler idx --restart
-
-    volumes:
-      certs:
-        driver: local
-      enterprisesearchdata:
-        driver: local
-      esdata:
-        driver: local
-      kibanadata:
-        driver: local
-
-.. note::
-
-    The configuration shown above is also meant to start a local HTTP server which will serve your local files when you
-    click on a result from the Workplace Search interface.
-
-Then, you can run the full stack, including FSCrawler and the HTTP Web Server.
+Then if you need to read the logs from FSCrawler, you can run:
 
 .. code:: sh
 
-    docker-compose up -d
+    docker-compose logs -f fscrawler
 
-FSCrawler will index all the documents and then exit.
+Or just go in the ``logs`` directory to read the logs:
 
-When the FSCrawler container has stopped, you can just open `the search interface <http://0.0.0.0:3002/ws/search/>`__
-and start to search for your local documents. You might need to be authenticated first in Kibana.
-You can also open `Kibana to access the Workplace Search configuration <http://0.0.0.0:5601/app/enterprise_search/workplace_search/sources>`__
-and modify the source which has been created by FSCrawler.
+.. code:: sh
+
+    tail -f logs/documents.log
 
 Running as a Service on Windows
 -------------------------------

--- a/docs/source/release/2.10.rst
+++ b/docs/source/release/2.10.rst
@@ -6,6 +6,9 @@ Breaking changes
 
 * If you want to exclude a specific folder, you need to use a wildcard character at the end of the folder name.
   For example, to exclude the folder ``/tmp/foo``, you need to use ``/tmp/foo/*``. Thanks to dadoonet.
+* The way we run docker images has changed. We don't need anymore to specify the fscrawler binary.
+So running ``docker run -it -v ~/.fscrawler:/root/.fscrawler -v /documents:/tmp/es:ro dadoonet/fscrawler job_name`` is
+enough. Thanks to dadoonet.
 
 New
 ---

--- a/docs/source/user/tips.rst
+++ b/docs/source/user/tips.rst
@@ -48,41 +48,7 @@ machine <https://wiki.apache.org/hadoop/MountableHDFS>`__ and run FS
 crawler on this mount point. You can also read details about `HDFS NFS
 Gateway <http://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/HdfsNfsGateway.html>`__.
 
-Using docker with FSCrawler REST
---------------------------------
+Using docker
+------------
 
-To use the REST service available from 2.2 you can add the ``--rest`` flag to the FSCrawler docker container ``command:``. Note that you must expose the same ports that the REST service opens on in the docker container. For example, if your REST service starts on ``127.0.0.1:8080`` then expose the same ports in your FSCrawler docker-compose image:
-
-.. code:: yaml
-
-    fscrawler:
-      context: ${PWD}
-      dockerfile: Dockerfile-fscrawler
-    container_name: fscrawler
-    restart: always
-    ...
-    ports:
-      - "8080:8080"
-    ...
-
-Then expose the docker container you've created by changing the IP of the REST URL in your ``settings.yaml`` to the docker-compose container name:
-
-.. code:: yaml
-
-    rest :
-      url: "http://fscrawler:8080"
-
-
-Pull the Docker image:
-
-.. code:: sh
-
-   docker pull dadoonet/fscrawler
-
-Run it:
-
-.. code:: sh
-
-   docker run dadoonet/fscrawler job
-
-
+See :ref:`docker`.


### PR DESCRIPTION
**This is a breaking change!**

The way we run docker images has changed. We don't need anymore to specify the `fscrawler` binary.

So running `docker run -it -v ~/.fscrawler:/root/.fscrawler -v /documents:/tmp/es:ro dadoonet/fscrawler job_name` is enough.

This makes our life much easier as we can also pass parameters like:

```sh
docker run -it -v ~/.fscrawler:/root/.fscrawler -v /documents:/tmp/es:ro dadoonet/fscrawler job_name --restart --loop 1
```

Also we document how to change the log levels with Docker or docker compose:

```sh
docker run -it --rm \
  -v ~/.fscrawler:/root/.fscrawler \
  -v ~/tmp:/tmp/es:ro \
  -v ~/logs:/root/logs \
  -e FS_JAVA_OPTS="-DLOG_LEVEL=debug -DDOC_LEVEL=debug" \
  dadoonet/fscrawler job_name
```

Then you can read the logs from `~/logs` dir:

```sh
tail -f ~/logs/documents.log
```

Closes #1667.
