### PR TITLE
Add --list and --create CLI options

### DIFF
--- a/cli/src/test/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCliTest.java
+++ b/cli/src/test/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCliTest.java
@@ -22,6 +22,7 @@ package fr.pilato.elasticsearch.crawler.fs.cli;
 import fr.pilato.elasticsearch.crawler.fs.beans.FsJob;
 import fr.pilato.elasticsearch.crawler.fs.beans.FsJobFileHandler;
 import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerIllegalConfigurationException;
+import fr.pilato.elasticsearch.crawler.fs.settings.Defaults;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettingsLoader;
 import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
@@ -185,5 +186,38 @@ public class FsCrawlerCliTest extends AbstractFSCrawlerTestCase {
         String[] args = { "--config_dir", metadataDir.toString(), jobName };
 
         FsCrawlerCli.main(args);
+    }
+
+    @Test
+    public void testWithNoJobName() throws Exception {
+        Path jobDir = metadataDir.resolve(Defaults.JOB_NAME_DEFAULT);
+        Files.createDirectories(jobDir);
+        Files.writeString(jobDir.resolve(SETTINGS_YAML), "");
+
+        String[] args = { "--config_dir", metadataDir.toString() };
+
+        FsCrawlerCli.main(args);
+    }
+
+    @Test
+    public void testSetupJob() throws Exception {
+        String jobName = "fscrawler_setup_job";
+        String[] args = { "--config_dir", metadataDir.toString(), "--setup", jobName };
+        FsCrawlerCli.main(args);
+
+        Path jobDir = metadataDir.resolve(jobName);
+        assertThat(Files.exists(jobDir), is(true));
+        assertThat(Files.exists(jobDir.resolve(SETTINGS_YAML)), is(true));
+    }
+
+    @Test
+    public void testListJobs() throws Exception {
+        String[] argsJob1 = { "--config_dir", metadataDir.toString(), "--setup", "fscrawler_list_jobs_1" };
+        FsCrawlerCli.main(argsJob1);
+        String[] argsJob2 = { "--config_dir", metadataDir.toString(), "--setup", "fscrawler_list_jobs_2" };
+        FsCrawlerCli.main(argsJob2);
+
+        String[] argsListJobs = { "--config_dir", metadataDir.toString(), "--list" };
+        FsCrawlerCli.main(argsListJobs);
     }
 }

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsCrawlerImpl.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsCrawlerImpl.java
@@ -114,11 +114,6 @@ public class FsCrawlerImpl implements AutoCloseable {
     }
 
     public void start() throws Exception {
-        logger.info("Starting FS crawler");
-        if (loop < 0) {
-            logger.info("FS crawler started in watch mode. It will run unless you stop it with CTRL+C.");
-        }
-
         if (loop == 0 && !rest) {
             logger.warn("Number of runs is set to 0 and rest layer has not been started. Exiting");
             return;
@@ -127,6 +122,13 @@ public class FsCrawlerImpl implements AutoCloseable {
         managementService.start();
         documentService.start();
         documentService.createSchema();
+
+        logger.info("FSCrawler is now connected to Elasticsearch version [{}]", managementService.getVersion());
+
+        logger.debug("Starting FSCrawler for job [{}]", settings.getName());
+        if (loop < 0) {
+            logger.info("FSCrawler started in watch mode. It will run unless you stop it with CTRL+C.");
+        }
 
         fsCrawlerThread.start();
     }

--- a/docs/source/admin/cli-options.rst
+++ b/docs/source/admin/cli-options.rst
@@ -3,21 +3,33 @@
 CLI options
 ===========
 
+-  ``--config_dir`` defines directory where jobs are stored instead of default ``~/.fscrawler``.
 -  ``--help`` displays help
--  ``--silent`` runs in silent mode. No output is generated on the console.
--  ``--config_dir`` defines directory where jobs are stored instead of
-   default ``~/.fscrawler``.
+-  ``--list`` lists all jobs. See `List`_.
 -  ``--loop x`` defines the number of runs we want before exiting. See `Loop`_.
 -  ``--restart`` restart a job from scratch. See `Restart`_.
 -  ``--rest`` starts the REST service. See `Rest`_.
+-  ``--setup`` creates a job configuration. See `Setup`_.
+-  ``--silent`` runs in silent mode. No output is generated on the console.
 
 Job settings can also be passed as command line arguments. For example, if you
 want to set the ``url`` of a job named ``myjob`` to ``/tmp/test``, you can run:
 
 .. code:: sh
 
-   bin/fscrawler myjob -Dfs.url=/tmp/test
+   FS_JAVA_OPTS="-Dfs.url=/tmp/test" bin/fscrawler
 
+A more complete example as follow, runs out of the box the indexation of a the directory
+``/tmp/test`` in Elasticsearch running at ``https://elastic.mycompany.com`` with ``API_KEY`` as the API key and it
+exits after the first run:
+
+.. code:: sh
+
+   FS_JAVA_OPTS="-Dfs.url=/tmp/test -Delasticsearch.nodes=https://elastic.mycompany.com -Delasticsearch.api-key=API_KEY" bin/fscrawler --loop 1
+
+..note::
+
+    You can optionally specify the job name you want to use / run. If not set, the default job name is ``fscrawler``.
 
 Loop
 ----
@@ -34,21 +46,42 @@ If you want to scan your hard drive only once, run with ``--loop 1``.
 Restart
 -------
 
-You can tell FSCrawler that it must restart from the beginning by using
-``--restart`` option:
+You can tell FSCrawler that it must restart from the beginning by using ``--restart`` option:
 
 .. code:: sh
 
-   bin/fscrawler job_name --restart
+   bin/fscrawler --restart
 
-In that case, the ``{job_name}/_status.json`` file will be removed.
+In that case, the ``~/.fscrawler/fscrawler/_status.json`` file will be removed.
 
 Rest
 ----
 
-If you want to run the :ref:`rest-service` without scanning
-your hard drive, launch with:
+If you want to run the :ref:`rest-service` without scanning your hard drive, launch with:
 
 .. code:: sh
 
    bin/fscrawler --rest --loop 0
+
+Setup
+-----
+
+If you want to setup a new job, you can use the ``--setup`` option. It will create
+a default configuration file named ``~/.fscrawler/fscrawler/_settings.yaml``:
+
+.. code:: sh
+
+   bin/fscrawler --setup
+
+..note::
+
+    You can also use ``--setup job_name`` to create a job named ``job_name`` instead of the default ``fscrawler``.
+
+List
+----
+
+If you want to list all jobs, you can use the ``--list`` option. It will list all the existing jobs in ``~/.fscrawler``:
+
+.. code:: sh
+
+   bin/fscrawler --list

--- a/docs/source/admin/fs/index.rst
+++ b/docs/source/admin/fs/index.rst
@@ -59,14 +59,14 @@ As an example, you can run:
 
    FSCRAWLER_NAME=foo \
    FSCRAWLER_FS_URL=/tmp/test \
-   FSCRAWLER_ELASTICSEARCH_API_KEY=VnVhQ2ZHY0JDZGJrUW0tZTVhT3g6dWkybHAyYXhUTm1zeWFrdzl0dk5udw== \
+   FSCRAWLER_ELASTICSEARCH_API-KEY=VnVhQ2ZHY0JDZGJrUW0tZTVhT3g6dWkybHAyYXhUTm1zeWFrdzl0dk5udw== \
    bin/fscrawler test
 
 or:
 
 .. code:: sh
 
-   FS_JAVA_OPTS="-Dname=foo -Dfs.url=/tmp/test -Delasticsearch.api_key=VnVhQ2ZHY0JDZGJrUW0tZTVhT3g6dWkybHAyYXhUTm1zeWFrdzl0dk5udw==" \
+   FS_JAVA_OPTS="-Dname=foo -Dfs.url=/tmp/test -Delasticsearch.api-key=VnVhQ2ZHY0JDZGJrUW0tZTVhT3g6dWkybHAyYXhUTm1zeWFrdzl0dk5udw==" \
    bin/fscrawler test
 
 .. note::

--- a/docs/source/admin/jvm-settings.rst
+++ b/docs/source/admin/jvm-settings.rst
@@ -12,4 +12,4 @@ You can also use the ``-D`` option to pass some jobs specific settings:
 
 .. code:: sh
 
-   FS_JAVA_OPTS="-Dfs.url=/tmp/test" bin/fscrawler job_name
+   FS_JAVA_OPTS="-Dfs.url=/tmp/test" bin/fscrawler

--- a/docs/source/admin/layout.rst
+++ b/docs/source/admin/layout.rst
@@ -44,7 +44,7 @@ As this directory is empty by default, you can also mount it when using Docker i
         -v ~/.fscrawler:/root/.fscrawler \
         -v ~/tmp:/tmp/es:ro \
         -v "$PWD/external:/usr/share/fscrawler/external" \
-        dadoonet/fscrawler fscrawler job_name
+        dadoonet/fscrawler
 
 See also :ref:`docker` and :ref:`docker-compose`.
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -60,23 +60,16 @@ You can run FSCrawler with:
    docker run -it --rm \
         -v ~/.fscrawler:/root/.fscrawler \
         -v ~/tmp:/tmp/es:ro \
-        dadoonet/fscrawler job_name
-
-On the first run, if the job does not exist yet in ``~/.fscrawler``, FSCrawler will ask you if you want to create it:
-
-::
-
-    10:16:53,880 INFO  [f.p.e.c.f.c.BootstrapChecks] Memory [Free/Total=Percent]: HEAP [67.3mb/876.5mb=7.69%], RAM [2.1gb/3.8gb=55.43%], Swap [1023.9mb/1023.9mb=100.0%].
-    10:16:53,899 WARN  [f.p.e.c.f.c.FsCrawlerCli] job [job_name] does not exist
-    10:16:53,900 INFO  [f.p.e.c.f.c.FsCrawlerCli] Do you want to create it (Y/N)?
-    y
-    10:16:56,745 INFO  [f.p.e.c.f.c.FsCrawlerCli] Settings have been created in [/root/.fscrawler/job_name/_settings.yaml]. Please review and edit before relaunch
+        dadoonet/fscrawler
 
 .. note::
 
-    The configuration file is actually stored on your machine in ``~/.fscrawler/job_name/_settings.yaml``.
+    The configuration file is expected to be stored on your machine in ``~/.fscrawler/fscrawler/_settings.yaml``.
     Remember to change the URL of your elasticsearch instance as the container won't be able to see it
     running under the default ``127.0.0.1``. You will need to use the actual IP address of the host.
+
+    Or use the ``FSCRAWLER_ELASTICSEARCH_NODES`` environment variable to set the elasticsearch URL.
+    See :ref:`docker-options` for more information.
 
 If you need to add a 3rd party library (jar) or your Tika custom jar, you can put it in a ``external`` directory and
 mount it as well:
@@ -87,7 +80,7 @@ mount it as well:
         -v ~/.fscrawler:/root/.fscrawler \
         -v ~/tmp:/tmp/es:ro \
         -v "$PWD/external:/usr/share/fscrawler/external" \
-        dadoonet/fscrawler job_name
+        dadoonet/fscrawler
 
 If you want to use the :ref:`rest-service`, don't forget to also expose the port:
 
@@ -97,7 +90,7 @@ If you want to use the :ref:`rest-service`, don't forget to also expose the port
         -v ~/.fscrawler:/root/.fscrawler \
         -v ~/tmp:/tmp/es:ro \
         -p 8080:8080 \
-        dadoonet/fscrawler job_name
+        dadoonet/fscrawler
 
 If you want to change the log level for FSCrawler, you can run:
 
@@ -108,7 +101,7 @@ If you want to change the log level for FSCrawler, you can run:
         -v ~/tmp:/tmp/es:ro \
         -v ~/logs:/root/logs \
         -e FS_JAVA_OPTS="-DLOG_LEVEL=debug -DDOC_LEVEL=debug" \
-        dadoonet/fscrawler job_name
+        dadoonet/fscrawler
 
 And you can read the logs from the ``~/logs`` directory:
 

--- a/docs/source/release/2.10.rst
+++ b/docs/source/release/2.10.rst
@@ -9,12 +9,18 @@ Breaking changes
 * The way we run docker images has changed. We don't need anymore to specify the fscrawler binary.
   So running ``docker run -it -v ~/.fscrawler:/root/.fscrawler -v /documents:/tmp/es:ro dadoonet/fscrawler job_name`` is
 enough. Thanks to dadoonet.
+* FSCrawler does not display anymore the list of existing jobs when no job name is provided.
+  You need to use the ``--list`` option to list the jobs. Thanks to dadoonet.
+* When launching for the first time FSCrawler with a job name, FSCrawler does not create anymore the job
+  configuration folder with default settings. You need to use the ``--setup`` option to create the job settings.
+  Thanks to dadoonet.
 
 New
 ---
 
 * Job settings can be defined by env variables and system properties and you can also split the configuration of
-  jobs using multiple files in the ``~/.fscrawler/job/_settings`` directory.
+  jobs using multiple files in the ``~/.fscrawler/job/_settings`` directory. Also note that the system properties
+  need to be set in the ``FS_JAVA_OPTS`` environment variable.
 * Add support for automatic semantic search when using a 8.17+ version with a trial or enterprise
   license. See :ref:`semantic_search`. **Warning**: this might slow down the ingestion process. Thanks to dadoonet.
 * Add support for Elastic cloud serverless. Thanks to dadoonet.
@@ -30,6 +36,7 @@ New
   to the FSCrawler JVM. For example, you could provide your own Custom Tika Parser code. See :ref:`layout`. Thanks to dadoonet.
 * Add temporal information in folder index. Thanks to bdauvissat
 * Add support for external metadata files while crawling, defaults to ``.meta.yml``. See :ref:`tags` Thanks to dadoonet.
+* The job name is not mandatory anymore and it will be ``fscrawler`` by default. Thanks to dadoonet.
 
 Fix
 ---

--- a/docs/source/user/getting_started.rst
+++ b/docs/source/user/getting_started.rst
@@ -17,48 +17,32 @@ Start FSCrawler with:
 
 .. code:: sh
 
-   bin/fscrawler job_name
+   bin/fscrawler
 
-FSCrawler will read a local file (default to
-``~/.fscrawler/{job_name}/_settings.yaml``). If the file does not exist,
-FSCrawler will propose to create your first job.
+FSCrawler will read a local file (default to ``~/.fscrawler/fscrawler/_settings.yaml``). If the file does not exist,
+you can ask to create it using the ``--setup`` command.
 
 .. code:: sh
 
-   $ bin/fscrawler job_name
-   18:28:58,174 WARN  [f.p.e.c.f.FsCrawler] job [job_name] does not exist
-   18:28:58,177 INFO  [f.p.e.c.f.FsCrawler] Do you want to create it (Y/N)?
-   y
-   18:29:05,711 INFO  [f.p.e.c.f.FsCrawler] Settings have been created in [~/.fscrawler/job_name/_settings.yaml]. Please review and edit before relaunch
+   $ bin/fscrawler --setup
+   17:40:33,905 INFO  [f.console] You can edit the settings in [~/.fscrawler/fscrawler/_settings.yaml]. Then, you can run again fscrawler without the --setup option.
 
 Create a directory named ``/tmp/es`` or ``c:\tmp\es``, add some files
 you want to index in it and start again:
 
 .. code:: sh
 
-   $ bin/fscrawler --config_dir ./test job_name
-   18:30:34,330 INFO  [f.p.e.c.f.FsCrawlerImpl] Starting FS crawler
-   18:30:34,332 INFO  [f.p.e.c.f.FsCrawlerImpl] FS crawler started in watch mode. It will run unless you stop it with CTRL+C.
-   18:30:34,682 INFO  [f.p.e.c.f.FsCrawlerImpl] FS crawler started for [job_name] for [/tmp/es] every [15m]
-
-If you did not create the directory, FSCrawler will complain until you
-fix it:
-
-::
-
-   18:30:34,683 WARN  [f.p.e.c.f.FsCrawlerImpl] Error while indexing content from /tmp/es: /tmp/es doesn't exists.
-
-You can also run FSCrawler without arguments. It will give you the list
-of existing jobs and will allow you to choose one:
-
-::
-
    $ bin/fscrawler
-   18:33:00,624 INFO  [f.p.e.c.f.FsCrawler] No job specified. Here is the list of existing jobs:
-   18:33:00,629 INFO  [f.p.e.c.f.FsCrawler] [1] - job_name
-   18:33:00,629 INFO  [f.p.e.c.f.FsCrawler] Choose your job [1-1]...
-   1
-   18:33:06,151 INFO  [f.p.e.c.f.FsCrawlerImpl] Starting FS crawler
+   17:41:45,395 INFO  [f.p.e.c.f.FsCrawlerImpl] FSCrawler is now connected to Elasticsearch version [8.17.3]
+   17:41:45,395 INFO  [f.p.e.c.f.FsCrawlerImpl] FSCrawler started in watch mode. It will run unless you stop it with CTRL+C.
+   17:41:45,395 INFO  [f.p.e.c.f.FsParserAbstract] FS crawler started for [fscrawler] for [/tmp/es] every [15m]
+
+If you did not create the directory, FSCrawler will complain until you fix it:
+
+::
+
+   17:41:45,396 INFO  [f.p.e.c.f.FsParserAbstract] Run #1: job [fscrawler]: starting...
+   17:41:45,397 WARN  [f.p.e.c.f.FsParserAbstract] Error while crawling /tmp/es: /tmp/es doesn't exists.
 
 Searching for docs
 ^^^^^^^^^^^^^^^^^^

--- a/docs/source/user/options.rst
+++ b/docs/source/user/options.rst
@@ -21,19 +21,21 @@ option:
 
 .. code:: sh
 
-   $ bin/fscrawler job_name --loop 1
-   18:47:37,487 INFO  [f.p.e.c.f.FsCrawlerImpl] Starting FS crawler
-   18:47:37,854 INFO  [f.p.e.c.f.FsCrawlerImpl] FS crawler started for [job_name] for [/tmp/es] every [15m]
+   $ bin/fscrawler --loop 1
+   17:41:45,395 INFO  [f.p.e.c.f.FsCrawlerImpl] FSCrawler is now connected to Elasticsearch version [8.17.3]
+   17:41:45,395 INFO  [f.p.e.c.f.FsCrawlerImpl] FSCrawler started in watch mode. It will run unless you stop it with CTRL+C.
+   17:41:45,395 INFO  [f.p.e.c.f.FsParserAbstract] FS crawler started for [fscrawler] for [/tmp/es] every [15m]
+   17:44:57,865 INFO  [f.p.e.c.f.FsParserAbstract] Run #1: job [fscrawler]: starting...
    ...
-   18:47:37,855 INFO  [f.p.e.c.f.FsCrawlerImpl] FS crawler is stopping after 1 run
-   18:47:37,959 INFO  [f.p.e.c.f.FsCrawlerImpl] FS crawler [job_name] stopped
+   17:44:57,866 INFO  [f.p.e.c.f.FsParserAbstract] FS crawler is stopping after 1 run
+   17:44:57,972 INFO  [f.p.e.c.f.FsCrawlerImpl] FS crawler [fscrawler] stopped
 
-If you have already ran FSCrawler and want to restart (which means
-reindex existing documents), use the ``--restart`` option:
+If you have already ran FSCrawler and want to restart (which means reindex existing documents),
+use the ``--restart`` option:
 
 .. code:: sh
 
-   $ bin/fscrawler job_name --loop 1 --restart
+   $ bin/fscrawler --loop 1 --restart
 
 You will find more information about settings in the following sections:
 

--- a/docs/source/user/rest.rst
+++ b/docs/source/user/rest.rst
@@ -14,7 +14,7 @@ local files but only listen to incoming REST requests:
 
 .. code:: sh
 
-   $ bin/fscrawler job_name --loop 0 --rest
+   $ bin/fscrawler --loop 0 --rest
    18:55:37,851 INFO  [f.p.e.c.f.FsCrawlerImpl] Starting FS Crawler
    18:55:39,237 INFO  [f.p.e.c.f.FsCrawlerImpl] FS crawler Rest service started on [http://127.0.0.1:8080/fscrawler]
 

--- a/docs/source/user/tips.rst
+++ b/docs/source/user/tips.rst
@@ -43,10 +43,8 @@ Indexing from HDFS drive
 ------------------------
 
 There is no specific support for HDFS in FSCrawler. But you can `mount
-your HDFS on your
-machine <https://wiki.apache.org/hadoop/MountableHDFS>`__ and run FS
-crawler on this mount point. You can also read details about `HDFS NFS
-Gateway <http://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/HdfsNfsGateway.html>`__.
+your HDFS on your machine <https://wiki.apache.org/hadoop/MountableHDFS>`__ and run FS crawler on this mount point.
+You can also read details about `HDFS NFS Gateway <http://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/HdfsNfsGateway.html>`__.
 
 Using docker
 ------------

--- a/docs/source/user/tutorial.rst
+++ b/docs/source/user/tutorial.rst
@@ -31,11 +31,11 @@ Start FSCrawler
 .. code:: sh
 
    # On Linux/Mac
-   bin/fscrawler resumes
+   bin/fscrawler --setup resumes
    # On Windows
-   .\bin\fscrawler resumes
+   .\bin\fscrawler --setup resumes
 
-* It will ask "Do you want to create it (Y/N)?". Answer ``Y``.
+* It will create a sample configuration file.
 * Go to the FSCrawler configuration folder to edit the job configuration. The FSCrawler configuration folder named
   ``.fscrawler`` is by default in the user home directory, like ``C:\Users\myuser`` on Windows platform or
   ``~`` on Linux/MacOS. In this folder, you will find another folder named ``resumes``. Enter this folder:

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -170,7 +170,7 @@ public class ElasticsearchClient implements IElasticsearchClient {
 
         try {
             String esVersion = getVersion();
-            logger.info("Elasticsearch Client connected to a node running version {}", esVersion);
+            logger.debug("Elasticsearch Client connected to a node running version {}", esVersion);
         } catch (Exception e) {
             logger.warn("Failed to create elasticsearch client on {}. Message: {}.",
                     settings.getElasticsearch().toString(),

--- a/plugin/src/main/java/fr/pilato/elasticsearch/crawler/plugins/FsCrawlerPlugin.java
+++ b/plugin/src/main/java/fr/pilato/elasticsearch/crawler/plugins/FsCrawlerPlugin.java
@@ -33,11 +33,11 @@ public abstract class FsCrawlerPlugin extends Plugin {
 
     @Override
     public void start() {
-        logger.info("Starting FsCrawler plugin [{}]", this.getName());
+        logger.debug("Starting FsCrawler plugin [{}]", this.getName());
     }
 
     @Override
     public void stop() {
-        logger.info("Stopping FsCrawler plugin [{}]", this.getName());
+        logger.debug("Stopping FsCrawler plugin [{}]", this.getName());
     }
 }

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Defaults.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Defaults.java
@@ -27,7 +27,8 @@ public class Defaults {
     public static final List<String> DEFAULT_EXCLUDED = Collections.singletonList("*/~*");
     public static final ServerUrl NODE_DEFAULT = new ServerUrl("https://127.0.0.1:9200");
     public static final String DEFAULT_META_FILENAME = ".meta.yml";
-    public static final String URL_DEFAULT = "http://127.0.0.1:8080/fscrawler";
+    public static final String REST_URL_DEFAULT = "http://127.0.0.1:8080/fscrawler";
+    public static final String JOB_NAME_DEFAULT = "fscrawler";
 
     // To make sur we don't create an instance of this class
     private Defaults() {}

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsLoader.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsLoader.java
@@ -76,7 +76,7 @@ public class FsSettingsLoader extends MetaFileHandler {
         if (Files.exists(configDir)) {
             return load(readDir(configDir).toArray(new Path[0]));
         }
-        logger.warn("Can not read settings from [{}] with either /_settings.yaml, /_settings.json, /_settings/*." +
+        logger.debug("Can not read settings from [{}] with either /_settings.yaml, /_settings.json, /_settings/*." +
                         " Falling back to default settings.", root.resolve(jobName).toAbsolutePath());
         return load();
     }

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Rest.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Rest.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 
 public class Rest {
 
-    @Config(defaultVal = Defaults.URL_DEFAULT)
+    @Config(defaultVal = Defaults.REST_URL_DEFAULT)
     private String url;
     @Config(defaultVal = "false")
     private boolean enableCors;

--- a/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/settings/fscrawler-default.properties
+++ b/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/settings/fscrawler-default.properties
@@ -36,15 +36,15 @@ server.port=0
 server.protocol=local
 
 # elasticsearch object
-elasticsearch.index=${FSCRAWLER_ES_INDEX:=${name}}
-elasticsearch.index_folder=${FSCRAWLER_ES_INDEX_FOLDER:=${name}_folder}
+elasticsearch.index=${FSCRAWLER_ELASTICSEARCH_INDEX:=${name}}
+elasticsearch.index_folder=${FSCRAWLER_ELASTICSEARCH_INDEX-FOLDER:=${name}_folder}
 elasticsearch.push_templates=true
 elasticsearch.bulk_size=100
 elasticsearch.flush_interval=5s
 elasticsearch.byte_size=10mb
 elasticsearch.semantic_search=true
-elasticsearch.nodes[0].url=${FSCRAWLER_ES_NODE:=https://127.0.0.1:9200}
-elasticsearch.api_key=${FSCRAWLER_ES_API_KEY:=}@{secret}
+elasticsearch.nodes[0].url=${FSCRAWLER_ELASTICSEARCH_NODE:=https://127.0.0.1:9200}
+elasticsearch.api_key=${FSCRAWLER_ELASTICSEARCH_API-KEY:=}@{secret}
 elasticsearch.ssl_verification=true
 
 # rest object


### PR DESCRIPTION
This PR adds 2 new CLI options.
It removes the dialog between FSCrawler and the user and assumes that a job setting file exists prior to the run. Which can be created using the new `--setup` option.

## Setup

If you want to setup a new job, you can use the `--setup` option. It will create
a default configuration file named `~/.fscrawler/fscrawler/_settings.yaml`:

```sh
bin/fscrawler --setup
```

You can also use `--setup job_name` to create a job named `job_name` instead of the default `fscrawler`.

## List

If you want to list all jobs, you can use the `--list` option. It will list all the existing jobs in `~/.fscrawler`:

```sh
bin/fscrawler --list
```

Related to https://github.com/dadoonet/fscrawler/discussions/2071