### PR TITLE
Remove Jansi lib

### DIFF
--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -96,9 +96,5 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-jul</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.fusesource.jansi</groupId>
-            <artifactId>jansi</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,6 @@
         <jackson.version>2.19.0</jackson.version>
         <jsonpath.version>2.9.0</jsonpath.version>
         <log4j.version>2.24.3</log4j.version>
-        <jansi.version>2.4.1</jansi.version>
         <jersey.version>3.1.10</jersey.version>
 
         <!-- Non Apache2 Compatible licenses -->
@@ -801,12 +800,6 @@
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-iostreams</artifactId>
                 <version>${log4j.version}</version>
-                <optional>true</optional>
-            </dependency>
-            <dependency>
-                <groupId>org.fusesource.jansi</groupId>
-                <artifactId>jansi</artifactId>
-                <version>${jansi.version}</version>
                 <optional>true</optional>
             </dependency>
             <!--

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -39,10 +39,6 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-jul</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.fusesource.jansi</groupId>
-            <artifactId>jansi</artifactId>
-        </dependency>
 
         <!-- Test containers -->
         <dependency>


### PR DESCRIPTION
Apparently, based on https://github.com/fusesource/jansi/releases/tag/jansi-2.4.2, Jansi will not be updated anymore.
It's replaced by https://github.com/jline/jline3.

But according to the PR https://github.com/apache/logging-log4j2/pull/2916, jline class has been copied to the log4j project, so there's no need to add another lib anymore.

Closes #2077.