### PR TITLE
Add `next_check` to `_status.json`

### DIFF
--- a/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/FsJob.java
+++ b/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/FsJob.java
@@ -29,15 +29,17 @@ public class FsJob {
 
     private String name;
     private LocalDateTime lastrun;
+    private LocalDateTime nextCheck;
     private long indexed;
     private long deleted;
 
     public FsJob() {
     }
 
-    public FsJob(String name, LocalDateTime lastrun, long indexed, long deleted) {
+    public FsJob(String name, LocalDateTime lastrun, LocalDateTime nextCheck, long indexed, long deleted) {
         this.name = name;
         this.lastrun = lastrun;
+        this.nextCheck = nextCheck;
         this.indexed = indexed;
         this.deleted = deleted;
     }
@@ -56,6 +58,14 @@ public class FsJob {
 
     public void setLastrun(LocalDateTime lastrun) {
         this.lastrun = lastrun;
+    }
+
+    public LocalDateTime getNextCheck() {
+        return nextCheck;
+    }
+
+    public void setNextCheck(LocalDateTime nextCheck) {
+        this.nextCheck = nextCheck;
     }
 
     public long getIndexed() {
@@ -84,6 +94,7 @@ public class FsJob {
         if (indexed != fsJob.indexed) return false;
         if (deleted != fsJob.deleted) return false;
         if (!Objects.equals(name, fsJob.name)) return false;
+        if (!Objects.equals(nextCheck, fsJob.nextCheck)) return false;
         return Objects.equals(lastrun, fsJob.lastrun);
     }
 
@@ -91,6 +102,7 @@ public class FsJob {
     public int hashCode() {
         int result = name != null ? name.hashCode() : 0;
         result = 31 * result + (lastrun != null ? lastrun.hashCode() : 0);
+        result = 31 * result + (nextCheck != null ? nextCheck.hashCode() : 0);
         result = 31 * result + Long.hashCode(indexed);
         result = 31 * result + Long.hashCode(deleted);
         return result;

--- a/beans/src/test/java/fr/pilato/elasticsearch/crawler/fs/beans/FsJobParserTest.java
+++ b/beans/src/test/java/fr/pilato/elasticsearch/crawler/fs/beans/FsJobParserTest.java
@@ -48,7 +48,7 @@ public class FsJobParserTest extends AbstractFSCrawlerTestCase {
 
     @Test
     public void parseJob() throws IOException {
-        jobTester(new FsJob(getCurrentTestName(), LocalDateTime.now(), 1000, 5));
+        jobTester(new FsJob(getCurrentTestName(), LocalDateTime.now(), LocalDateTime.now(), 1000, 5));
     }
 
     /**
@@ -58,7 +58,7 @@ public class FsJobParserTest extends AbstractFSCrawlerTestCase {
     @Test
     public void dateTimeSerialization() throws IOException {
         LocalDateTime now = LocalDateTime.now();
-        FsJob job = new FsJob(getCurrentTestName(), now, 1000, 5);
+        FsJob job = new FsJob(getCurrentTestName(), now, now, 1000, 5);
         String json = prettyMapper.writeValueAsString(job);
         FsJob generated = prettyMapper.readValue(json, FsJob.class);
         assertThat(generated.getLastrun()).isEqualTo(now);

--- a/docs/source/admin/fs/local-fs.rst
+++ b/docs/source/admin/fs/local-fs.rst
@@ -113,6 +113,13 @@ The supported units for duration are:
 * ``s`` for seconds
 * ``ms`` for milliseconds
 
+.. note::
+
+    If you don't want to wait for the next scan, you can manually edit the ``~/.fscrawler/test/_status.json`` file and
+    set ``next_check`` to the current time or to ``null``. FSCrawler will then start a new scan at most after 5 seconds.
+
+    See :ref:`status-files` for more information.
+
 .. _includes_excludes:
 
 Includes and excludes

--- a/docs/source/admin/status.rst
+++ b/docs/source/admin/status.rst
@@ -1,3 +1,5 @@
+.. _status-files:
+
 Status files
 ============
 
@@ -6,6 +8,28 @@ statistics in:
 
 -  ``~/.fscrawler/{job_name}/_status.json``
 
-It means that if you stop the job at some point, FSCrawler will restart
+It means that if you stop the job at some point (after a full run), FSCrawler will restart
 it from where it stops.
 
+The information in this file is:
+
+- ``name``: the name of the job
+- ``lastrun``: start time of the job
+- ``next_check``: next time the job will be checked for new files
+- ``indexed``: total number of files indexed on the last run
+- ``deleted``: total number of files removed on the last run
+
+For example:
+
+.. code-block:: json
+
+   {
+     "name": "fscrawler",
+     "lastrun": "2025-07-01T12:00:00Z",
+     "next_check": "2025-07-01T12:15:00Z",
+     "indexed": 100,
+     "deleted": 0
+   }
+
+If you don't want to wait for the next scan, you can manually edit the ``~/.fscrawler/test/_status.json`` file and
+set ``next_check`` to the current time or to ``null``. FSCrawler will then start a new scan at most after 5 seconds.

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestAddNewFilesIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestAddNewFilesIT.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package fr.pilato.elasticsearch.crawler.fs.test.integration.elasticsearch;
+
+import fr.pilato.elasticsearch.crawler.fs.beans.FsJob;
+import fr.pilato.elasticsearch.crawler.fs.beans.FsJobFileHandler;
+import fr.pilato.elasticsearch.crawler.fs.client.ESSearchHit;
+import fr.pilato.elasticsearch.crawler.fs.client.ESSearchRequest;
+import fr.pilato.elasticsearch.crawler.fs.client.ESSearchResponse;
+import fr.pilato.elasticsearch.crawler.fs.framework.TimeValue;
+import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
+import fr.pilato.elasticsearch.crawler.fs.test.integration.AbstractFsCrawlerITCase;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.time.LocalDateTime;
+
+import static java.lang.Thread.sleep;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test moving/removing/adding files
+ */
+public class FsCrawlerTestAddNewFilesIT extends AbstractFsCrawlerITCase {
+    private static final Logger logger = LogManager.getLogger();
+
+    @Test
+    public void add_new_files_and_force_rescan() throws Exception {
+        FsSettings fsSettings = createTestSettings();
+        // We want to wait the default wait time which is 15 minutes.
+        fsSettings.getFs().setUpdateRate(TimeValue.timeValueMinutes(15));
+        crawler = startCrawler(fsSettings);
+
+        // We should have one doc first
+        countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, currentTestResourceDir);
+
+        // We add a file
+        logger.info("  ---> Adding file new_roottxtfile.txt");
+        Files.write(currentTestResourceDir.resolve("new_roottxtfile.txt"), "This is a second file".getBytes(StandardCharsets.UTF_8));
+
+        // Forcing a rescan by modifying the next scan date
+        logger.info("  ---> changing next check date to now manually");
+        FsJobFileHandler fsJobFileHandler = new FsJobFileHandler(metadataDir);
+        FsJob fsJob = fsJobFileHandler.read(fsSettings.getName());
+        // We set the next check to now so that the crawler will rescan the directory
+        fsJob.setNextCheck(LocalDateTime.now());
+        fsJobFileHandler.write(getCrawlerName(), fsJob);
+
+        // We expect to have two files
+        countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 2L, currentTestResourceDir);
+    }
+
+    @Test
+    public void add_new_files_and_force_rescan_with_null() throws Exception {
+        FsSettings fsSettings = createTestSettings();
+        // We want to wait the default wait time which is 15 minutes.
+        fsSettings.getFs().setUpdateRate(TimeValue.timeValueMinutes(15));
+        crawler = startCrawler(fsSettings);
+
+        // We should have one doc first
+        countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, currentTestResourceDir);
+
+        // We add a file
+        logger.info("  ---> Adding file new_roottxtfile.txt");
+        Files.write(currentTestResourceDir.resolve("new_roottxtfile.txt"), "This is a second file".getBytes(StandardCharsets.UTF_8));
+
+        // Forcing a rescan by modifying the next scan date
+        logger.info("  ---> removing next check date to force a manual rescan");
+        FsJobFileHandler fsJobFileHandler = new FsJobFileHandler(metadataDir);
+        FsJob fsJob = fsJobFileHandler.read(fsSettings.getName());
+        // We set the next check to null so that the crawler will rescan the directory
+        fsJob.setNextCheck(null);
+        fsJobFileHandler.write(getCrawlerName(), fsJob);
+
+        // We expect to have two files
+        countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 2L, currentTestResourceDir);
+    }
+
+    /**
+     * Test case for issue #60: <a href="https://github.com/dadoonet/fscrawler/issues/60">https://github.com/dadoonet/fscrawler/issues/60</a> : new files are not added
+     */
+    @Test
+    public void add_new_file() throws Exception {
+        // We need to wait for 2 seconds before starting the test as the file might have just been created
+        // It's due to https://github.com/dadoonet/fscrawler/issues/82 which removes 2 seconds from the last scan date
+        sleep(2000L);
+
+        FsSettings fsSettings = createTestSettings();
+        // We change the update rate to 5 seconds because the FsParser last scan date is set to 2 seconds less than the current time
+        fsSettings.getFs().setUpdateRate(TimeValue.timeValueSeconds(5));
+        crawler = startCrawler(fsSettings);
+
+        // We should have one doc first
+        ESSearchResponse response = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, currentTestResourceDir);
+        checkDocVersions(response, 1L);
+
+        logger.info(" ---> Creating a new file new_roottxtfile.txt");
+        Files.write(currentTestResourceDir.resolve("new_roottxtfile.txt"), "This is a second file".getBytes());
+
+        // We expect to have two files
+        response = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 2L, currentTestResourceDir);
+
+        // It should be only version <= 2 for both docs
+        checkDocVersions(response, 2L);
+
+        logger.info(" ---> Creating a new file new_new_roottxtfile.txt");
+        Files.write(currentTestResourceDir.resolve("new_new_roottxtfile.txt"), "This is a third file".getBytes());
+
+        // We expect to have three files
+        response = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 3L, currentTestResourceDir);
+
+        // It should be only version <= 2 for all docs
+        checkDocVersions(response, 2L);
+    }
+
+    /**
+     * Iterate other response hits and check that _version is at most a given version
+     * @param response The search response object
+     * @param maxVersion Maximum version number we can have
+     */
+    private void checkDocVersions(ESSearchResponse response, long maxVersion) {
+        // It should be only version <= maxVersion for all docs
+       assertThat(response.getHits())
+               .isNotEmpty()
+               .allSatisfy(hit -> {
+           ESSearchHit getHit = client.get(hit.getIndex(), hit.getId());
+           assertThat(getHit.getVersion()).isLessThanOrEqualTo(maxVersion);
+       });
+    }
+}

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRemoveDeletedIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRemoveDeletedIT.java
@@ -23,7 +23,6 @@ import fr.pilato.elasticsearch.crawler.fs.client.ESSearchHit;
 import fr.pilato.elasticsearch.crawler.fs.client.ESSearchRequest;
 import fr.pilato.elasticsearch.crawler.fs.client.ESSearchResponse;
 import fr.pilato.elasticsearch.crawler.fs.client.ESTermQuery;
-import fr.pilato.elasticsearch.crawler.fs.framework.TimeValue;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
 import fr.pilato.elasticsearch.crawler.fs.test.integration.AbstractFsCrawlerITCase;
 import org.apache.logging.log4j.Level;
@@ -38,7 +37,6 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.FileTime;
 import java.time.Instant;
 
-import static java.lang.Thread.sleep;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -196,57 +194,5 @@ public class FsCrawlerTestRemoveDeletedIT extends AbstractFsCrawlerITCase {
 
         // We expect to have 2 docs now
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 2L, null);
-    }
-
-    /**
-     * Test case for issue #60: <a href="https://github.com/dadoonet/fscrawler/issues/60">https://github.com/dadoonet/fscrawler/issues/60</a> : new files are not added
-     */
-    @Test
-    public void add_new_file() throws Exception {
-        // We need to wait for 2 seconds before starting the test as the file might have just been created
-        // It's due to https://github.com/dadoonet/fscrawler/issues/82 which removes 2 seconds from the last scan date
-        sleep(2000L);
-
-        FsSettings fsSettings = createTestSettings();
-        // We change the update rate to 5 seconds because the FsParser last scan date is set to 2 seconds less than the current time
-        fsSettings.getFs().setUpdateRate(TimeValue.timeValueSeconds(5));
-        crawler = startCrawler(fsSettings);
-
-        // We should have one doc first
-        ESSearchResponse response = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 1L, currentTestResourceDir);
-        checkDocVersions(response, 1L);
-
-        logger.info(" ---> Creating a new file new_roottxtfile.txt");
-        Files.write(currentTestResourceDir.resolve("new_roottxtfile.txt"), "This is a second file".getBytes());
-
-        // We expect to have two files
-        response = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 2L, currentTestResourceDir);
-
-        // It should be only version <= 2 for both docs
-        checkDocVersions(response, 2L);
-
-        logger.info(" ---> Creating a new file new_new_roottxtfile.txt");
-        Files.write(currentTestResourceDir.resolve("new_new_roottxtfile.txt"), "This is a third file".getBytes());
-
-        // We expect to have three files
-        response = countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 3L, currentTestResourceDir);
-
-        // It should be only version <= 2 for all docs
-        checkDocVersions(response, 2L);
-    }
-
-    /**
-     * Iterate other response hits and check that _version is at most a given version
-     * @param response The search response object
-     * @param maxVersion Maximum version number we can have
-     */
-    private void checkDocVersions(ESSearchResponse response, long maxVersion) {
-        // It should be only version <= maxVersion for all docs
-       assertThat(response.getHits())
-               .isNotEmpty()
-               .allSatisfy(hit -> {
-           ESSearchHit getHit = client.get(hit.getIndex(), hit.getId());
-           assertThat(getHit.getVersion()).isLessThanOrEqualTo(maxVersion);
-       });
     }
 }


### PR DESCRIPTION
This allows FSCrawler to start a new scan after `next_check` has been reached.

Which also means that if you manually edit the `_status.json` file between 2 runs, you can trigger an immediate rescan of the filesystem without having to wait for hours.

As an example, the `_status.json` could be:

```json
{
 "name": "fscrawler",
 "lastrun": "2025-07-01T12:00:00Z",
 "next_check": "2025-07-01T12:15:00Z",
 "indexed": 100,
 "deleted": 0
}
```

This means that no other check will be done before `2025-07-01T12:15:00Z`. But if you edit the file as follows:

```json
{
 "name": "fscrawler",
 "lastrun": "2025-07-01T12:00:00Z",
 "indexed": 100,
 "deleted": 0
}
```

FSCrawler will almost immediately (at most after 5 seconds) rescan the filesystem again.

Closes #2095.
