### PR TITLE
NPE when crawling on some filesystems: "other" is null

### DIFF
--- a/crawler/crawler-fs/src/main/java/fr/pilato/elasticsearch/crawler/fs/crawler/fs/FileAbstractorFile.java
+++ b/crawler/crawler-fs/src/main/java/fr/pilato/elasticsearch/crawler/fs/crawler/fs/FileAbstractorFile.java
@@ -56,7 +56,8 @@ public class FileAbstractorFile extends FileAbstractor<File> {
     }
 
     private static final Comparator<Path> PATH_COMPARATOR = Comparator.comparing(
-            file -> getModificationOrCreationTime(file.toFile()));
+            file -> getModificationOrCreationTime(file.toFile()),
+            Comparator.nullsLast(Comparator.naturalOrder()));
 
     @Override
     public FileAbstractModel toFileAbstractModel(String path, File file) {

--- a/crawler/crawler-ftp/src/main/java/fr/pilato/elasticsearch/crawler/fs/crawler/ftp/FileAbstractorFTP.java
+++ b/crawler/crawler-ftp/src/main/java/fr/pilato/elasticsearch/crawler/fs/crawler/ftp/FileAbstractorFTP.java
@@ -56,7 +56,11 @@ public class FileAbstractorFTP extends FileAbstractor<FTPFile> {
 
     private static final String ALTERNATIVE_ENCODING = "GBK";
     private static final Comparator<FTPFile> FTP_FILE_COMPARATOR = Comparator.comparing(
-            file -> LocalDateTime.ofInstant(Instant.ofEpochMilli(file.getTimestamp().getTimeInMillis()), ZoneId.systemDefault()));
+            file -> {
+                var timestamp = file.getTimestamp();
+                return timestamp != null ? LocalDateTime.ofInstant(Instant.ofEpochMilli(timestamp.getTimeInMillis()), ZoneId.systemDefault()) : null;
+            },
+            Comparator.nullsLast(Comparator.naturalOrder()));
     private final Predicate<FTPFile> IS_SYM_LINK = file -> {
         if (fsSettings.getFs().isFollowSymlinks()) return true;
         return !file.isSymbolicLink();

--- a/crawler/crawler-ssh/src/main/java/fr/pilato/elasticsearch/crawler/fs/crawler/ssh/FileAbstractorSSH.java
+++ b/crawler/crawler-ssh/src/main/java/fr/pilato/elasticsearch/crawler/fs/crawler/ssh/FileAbstractorSSH.java
@@ -46,7 +46,12 @@ public class FileAbstractorSSH extends FileAbstractor<SftpClient.DirEntry> {
             !".".equals(file.getFilename()) &&
             !"..".equals(file.getFilename());
     private static final Comparator<SftpClient.DirEntry> SFTP_FILE_COMPARATOR = Comparator.comparing(
-            file -> LocalDateTime.ofInstant(file.getAttributes().getModifyTime().toInstant(), ZoneId.systemDefault()));
+            file -> {
+                var attributes = file.getAttributes();
+                var modifyTime = attributes != null ? attributes.getModifyTime() : null;
+                return modifyTime != null ? LocalDateTime.ofInstant(modifyTime.toInstant(), ZoneId.systemDefault()) : null;
+            },
+            Comparator.nullsLast(Comparator.naturalOrder()));
 
     public FileAbstractorSSH(FsSettings fsSettings) {
         super(fsSettings);


### PR DESCRIPTION
Add null-safe comparators to file abstractors to prevent `NullPointerException` when sorting files with unreadable or null timestamps.

The `getModificationOrCreationTime()` method can return null if file attributes (like creation or last modified time) cannot be read, for example, due to permission issues. This null value was then passed to a `Comparator`, leading to a `NullPointerException`. By using `Comparator.nullsLast()`, files with null timestamps are gracefully handled and sorted to the end of the list, allowing the crawl to proceed without errors. This fix is applied consistently across local, FTP, and SSH file abstractors.

---
<a href="https://cursor.com/background-agent?bcId=bc-32149ddc-d2fd-40f6-98f9-7b9bf37a5ec4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-32149ddc-d2fd-40f6-98f9-7b9bf37a5ec4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use null-safe comparators with nullsLast to prevent NPEs when sorting files with missing timestamps.
> 
> - **Crawlers**:
>   - **Local FS (`FileAbstractorFile`)**: Update `PATH_COMPARATOR` to use `Comparator.nullsLast(Comparator.naturalOrder())` when comparing `getModificationOrCreationTime(...)`.
>   - **FTP (`FileAbstractorFTP`)**: Make `FTP_FILE_COMPARATOR` timestamp extraction null-safe and apply `nullsLast` for ordering.
>   - **SSH (`FileAbstractorSSH`)**: Make `SFTP_FILE_COMPARATOR` handle null `attributes/modifyTime` and apply `nullsLast` for ordering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ced0d00c3760fc51228feeac2ef117c55219a0b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->