### PR TITLE
Test remove_folder_deleted_enabled on Windows should behave like Linux

### DIFF
--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRemoveDeletedIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRemoveDeletedIT.java
@@ -21,7 +21,6 @@ package fr.pilato.elasticsearch.crawler.fs.test.integration.elasticsearch;
 
 import fr.pilato.elasticsearch.crawler.fs.client.ESSearchRequest;
 import fr.pilato.elasticsearch.crawler.fs.client.ESTermQuery;
-import fr.pilato.elasticsearch.crawler.fs.framework.OsValidator;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
 import fr.pilato.elasticsearch.crawler.fs.test.integration.AbstractFsCrawlerITCase;
 import org.apache.logging.log4j.Level;
@@ -96,15 +95,8 @@ public class FsCrawlerTestRemoveDeletedIT extends AbstractFsCrawlerITCase {
 
         logContentOfDir(currentTestResourceDir, Level.DEBUG);
 
-        if (OsValidator.WINDOWS) {
-            // On windows the deletion does not work as expected
-            // TODO this needs to be fixed (see https://github.com/dadoonet/fscrawler/issues/2019)
-            logger.warn("On Windows we don't detect properly the recursive removal of directories. So we skip the validation of this test");
-            countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 7L, currentTestResourceDir);
-        } else {
-            // We expect to have 4 docs now
-            countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 4L, currentTestResourceDir);
-        }
+        // We expect to have 4 docs now
+        countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 4L, currentTestResourceDir);
     }
 
     /**


### PR DESCRIPTION
Related to #2019.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove Windows-specific skip in `remove_folder_deleted_enabled` so the test always expects 4 docs after deleting `subdir1` and drop unused `OsValidator` import.
> 
> - **Integration tests** (`integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRemoveDeletedIT.java`):
>   - **`remove_folder_deleted_enabled`**: Remove Windows-specific conditional; always assert 4 docs after deleting `subdir1`.
>   - Cleanup: Remove unused `OsValidator` import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44494bcf7c1c4378e8722c027bfdc7aea168b2c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->