### PR TITLE
Fix documentation snippet for tags section at the root

### DIFF
--- a/docs/source/admin/fs/tags.rst
+++ b/docs/source/admin/fs/tags.rst
@@ -92,8 +92,9 @@ You can use another filename for the external tags file. For example, if you wan
 .. code:: yaml
 
    fs:
-     tags:
-       metaFilename: "meta_tags.json"
+     url: "/path/to/docs"
+   tags:
+     metaFilename: "meta_tags.json"
 
 Static Metadata
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
Correcting the yaml configuration snippet in the documentation to correspond the change of `tags` section no longer under `fs` but directly at root.