### PR TITLE
FIX: Make JsonUtilTest platform-independent

### DIFF
--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/JsonUtilTest.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/JsonUtilTest.java
@@ -152,6 +152,8 @@ public class JsonUtilTest extends AbstractFSCrawlerTestCase {
 
         String generated = mapper.writeValueAsString(country);
         logger.debug(generated);
-        assertThat(generated).isEqualTo(input);
+		/*automatically convert all \r\n (Windows) and \n (Unix) to a single \n before comparing the strings, making the test platform-independent.
+		*/
+		assertThat(generated).isEqualToNormalizingNewlines(input);
     }
 }


### PR DESCRIPTION
**Recent versions of fscrawler fail on windows - mvn clean package**
Passes with this change

Suggested by Gemini

Open: fscrawler\framework\src\test\java\fr\pilato\elasticsearch\crawler\fs\framework\JsonUtilTest.java

Go to: The mapperTester method (at the bottom).

Change this line:

Java

assertThat(generated).isEqualTo(input);
To this:

Java

assertThat(generated).isEqualToNormalizingNewlines(input);