### PR TITLE
Remove redundant job meta file existence check in integration test

### DIFF
--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractFsCrawlerITCase.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractFsCrawlerITCase.java
@@ -20,7 +20,6 @@
 package fr.pilato.elasticsearch.crawler.fs.test.integration;
 
 import fr.pilato.elasticsearch.crawler.fs.FsCrawlerImpl;
-import fr.pilato.elasticsearch.crawler.fs.beans.FsJobFileHandler;
 import fr.pilato.elasticsearch.crawler.fs.client.ESSearchRequest;
 import fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchClientException;
 import fr.pilato.elasticsearch.crawler.fs.framework.TimeValue;
@@ -35,10 +34,8 @@ import org.junit.Before;
 import java.io.IOException;
 
 import static fr.pilato.elasticsearch.crawler.fs.FsCrawlerImpl.LOOP_INFINITE;
-import static fr.pilato.elasticsearch.crawler.fs.framework.Await.awaitBusy;
 import static fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil.INDEX_SUFFIX_FOLDER;
 import static fr.pilato.elasticsearch.crawler.fs.framework.TimeValue.MAX_WAIT_FOR_SEARCH;
-import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class AbstractFsCrawlerITCase extends AbstractITCase {
     private static final Logger logger = LogManager.getLogger();
@@ -125,21 +122,10 @@ public abstract class AbstractFsCrawlerITCase extends AbstractITCase {
         crawler = new FsCrawlerImpl(metadataDir, fsSettings, LOOP_INFINITE, false);
         crawler.start();
 
-        // We wait up to X seconds before considering a failing test
-        assertThat(awaitBusy(() -> {
-            try {
-                new FsJobFileHandler(metadataDir).read(fsSettings.getName());
-                return true;
-            } catch (IOException e) {
-                return false;
-            }
-        }, duration))
-                .as("Job meta file should exists in ~/.fscrawler...")
-                .isTrue();
-
         // Wait for the index to be healthy as we might have a race condition
         client.waitForHealthyIndex(fsSettings.getElasticsearch().getIndex());
 
+        // We check that we have at least a few documents
         countTestHelper(new ESSearchRequest().withIndex(fsSettings.getElasticsearch().getIndex()), null, null, duration);
 
         // Make sure we refresh indexed docs and folders before launching tests


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Remove the job meta file existence wait in the integration test startup, relying instead on index health and document count.
> 
> - **Tests (integration)**:
>   - Remove job meta file existence wait from `AbstractFsCrawlerITCase.startCrawler(...)` (drops `awaitBusy` + `FsJobFileHandler` check).
>   - Rely on index health (`waitForHealthyIndex`) and document presence via `countTestHelper` after starting the crawler.
>   - Clean up unused imports tied to the removed check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a10b2681fb6be1cf138e96e6f59700dcd5e06227. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->