### PR TITLE
Remove clash when running multiple builds at the same time

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -178,7 +178,7 @@ jobs:
         shell: bash
         run: |
           echo "Running integration tests from Windows with Elastic Cloud Elasticsearch service with prefix win_${{ needs.get-pr-number.outputs.pr_number }}"
-          mvn --batch-mode integration-test -Ddocker.skip -DskipUnitTests -Dtests.leaveTemporary=false -Dtests.timeoutSuite=1200000 -Dtests.timeout=900000 -Dtests.heartbeat=30 -Dtests.cluster.apiKey=${{ secrets.ELASTIC_CLOUD_APIKEY }} -Dtests.cluster.url=${{ secrets.ELASTIC_CLOUD_URL }} -Dtests.index.prefix=win_${{ needs.get-pr-number.outputs.pr_number }}
+          mvn --batch-mode integration-test -Dtests.parallelism=1 -Ddocker.skip -DskipUnitTests -Dtests.leaveTemporary=false -Dtests.timeoutSuite=1200000 -Dtests.timeout=900000 -Dtests.heartbeat=30 -Dtests.cluster.apiKey=${{ secrets.ELASTIC_CLOUD_APIKEY }} -Dtests.cluster.url=${{ secrets.ELASTIC_CLOUD_URL }} -Dtests.index.prefix=win_${{ needs.get-pr-number.outputs.pr_number }}
 
   # We run this job in parallel after the build
   build-docker:


### PR DESCRIPTION
It was a problem when the client IT are ran at the same time as other tests. It was removing the same index/component templates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Integration tests now delete index/component templates using a crawler-specific pattern, with helpers updated to accept a template name.
> 
> - **Tests**:
>   - **Setup/Teardown**: Compute `templateName = "fscrawler_" + getCrawlerName() + "_*"` and call `removeIndexTemplates(templateName)` and `removeComponentTemplates(templateName)` instead of broad deletions.
>   - **Helpers**: `removeIndexTemplates(String)` and `removeComponentTemplates(String)` now accept a template name and DELETE `/_index_template/{name}` and `/_component_template/{name}`; refined logging for failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75c6b20a19719a4a41e813de28badaa1125f7972. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->