### PR TITLE
Fix detection of files and directories for removal on Windows

### DIFF
--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParserAbstract.java
@@ -645,7 +645,7 @@ public abstract class FsParserAbstract extends FsParser {
         Collection<String> listFile = getFileDirectory(path);
 
         for (String esfile : listFile) {
-            esDelete(managementService, fsSettings.getElasticsearch().getIndex(), SignTool.sign(path.concat(pathSeparator).concat(esfile)));
+            esDelete(managementService, fsSettings.getElasticsearch().getIndex(), generateIdFromFilename(esfile, path));
             stats.removeFile();
         }
 

--- a/docs/source/release/2.10.rst
+++ b/docs/source/release/2.10.rst
@@ -55,6 +55,7 @@ Fix
 * Fix duration parsing for the day unit ``d``. Thanks to dadoonet.
 * Image raw metadata extraction was not working. Thanks to dadoonet.
 * Fix issue when using crawling over SSH when the directory ends with a space. Thanks to dadoonet.
+* On windows, files and directories to be removed were not properly detected. Thanks to newschapmj1.
 
 Deprecated
 ----------

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRemoveDeletedIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRemoveDeletedIT.java
@@ -21,7 +21,6 @@ package fr.pilato.elasticsearch.crawler.fs.test.integration.elasticsearch;
 
 import fr.pilato.elasticsearch.crawler.fs.client.ESSearchRequest;
 import fr.pilato.elasticsearch.crawler.fs.client.ESTermQuery;
-import fr.pilato.elasticsearch.crawler.fs.framework.OsValidator;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
 import fr.pilato.elasticsearch.crawler.fs.test.integration.AbstractFsCrawlerITCase;
 import org.apache.logging.log4j.Level;
@@ -96,15 +95,7 @@ public class FsCrawlerTestRemoveDeletedIT extends AbstractFsCrawlerITCase {
 
         logContentOfDir(currentTestResourceDir, Level.DEBUG);
 
-        if (OsValidator.WINDOWS) {
-            // On windows the deletion does not work as expected
-            // TODO this needs to be fixed (see https://github.com/dadoonet/fscrawler/issues/2019)
-            logger.warn("On Windows we don't detect properly the recursive removal of directories. So we skip the validation of this test");
-            countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 7L, currentTestResourceDir);
-        } else {
-            // We expect to have 4 docs now
-            countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 4L, currentTestResourceDir);
-        }
+        countTestHelper(new ESSearchRequest().withIndex(getCrawlerName()), 4L, currentTestResourceDir);
     }
 
     /**

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestSubDirsIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestSubDirsIT.java
@@ -219,13 +219,6 @@ public class FsCrawlerTestSubDirsIT extends AbstractFsCrawlerITCase {
                 .withSort("path.virtual"));
         assertThat(response.getTotalHits()).isEqualTo(subdirs + 2);
 
-        if (OsValidator.WINDOWS) {
-            // On windows the deletion does not work as expected
-            // TODO this needs to be fixed
-            logger.warn("On Windows we don't detect properly the recursive removal of directories. So we skip the validation of this test");
-            return;
-        }
-
         // Let's remove the main subdir and wait...
         logger.debug("  --> Removing all dirs from [{}]", mainDir);
         deleteRecursively(mainDir);


### PR DESCRIPTION
From the original work #2204.

Closes #2019, #2204

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch deletion to `generateIdFromFilename` in recursive folder removal to properly detect/remove files on Windows; update tests and release notes.
> 
> - **Core**:
>   - Use `generateIdFromFilename` when deleting files in `removeEsDirectoryRecursively` within `FsParserAbstract`, ensuring correct ID computation (not OS-dependent).
> - **Tests**:
>   - Remove Windows-specific skips and assert proper deletions in `FsCrawlerTestRemoveDeletedIT` and `FsCrawlerTestSubDirsIT` (very deep tree case).
> - **Docs**:
>   - Update `docs/source/release/2.10.rst` with a fix note for Windows removal detection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cd234d7d31850b9abbe0838dc7a803e5a03ac5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->