### PR TITLE
IT: Fix size of robots.txt

### DIFF
--- a/.run/Template JUnit.run.xml
+++ b/.run/Template JUnit.run.xml
@@ -3,7 +3,7 @@
     <option name="MAIN_CLASS_NAME" value="" />
     <option name="METHOD_NAME" value="" />
     <option name="TEST_OBJECT" value="class" />
-    <option name="VM_PARAMETERS" value="-ea -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager" />
+    <option name="VM_PARAMETERS" value="-ea -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager -Dtests.cluster.check_ssl=false" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/plugins/fs-http-plugin/src/test/java/fr/pilato/elasticsearch/crawler/plugins/fs/http/FsHttpPluginIT.java
+++ b/plugins/fs-http-plugin/src/test/java/fr/pilato/elasticsearch/crawler/plugins/fs/http/FsHttpPluginIT.java
@@ -103,7 +103,7 @@ public class FsHttpPluginIT extends AbstractFSCrawlerTestCase {
             assertThat(object).contains("User-agent: *");
             Doc doc = provider.createDocument();
             assertThat(doc.getFile().getFilename()).isEqualTo("robots.txt");
-            assertThat(doc.getFile().getFilesize()).isEqualTo(13L);
+            assertThat(doc.getFile().getFilesize()).isEqualTo(14L);
         }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates test expectation and run configuration.
> 
> - Adjusts `FsHttpPluginIT` to expect `doc.file.filesize` of `14` for `robots.txt`
> - Adds `-Dtests.cluster.check_ssl=false` to JUnit VM parameters in `.run/Template JUnit.run.xml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68b55fde9d9fa06c77a62457197a758363612ffc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->