### PR TITLE
Fix MD5 checksum calculation for large binary files

### DIFF
--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsCrawlerImpl.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsCrawlerImpl.java
@@ -81,6 +81,13 @@ public class FsCrawlerImpl implements AutoCloseable {
             throw new RuntimeException("Can not create the job config directory", e);
         }
 
+        // Set default temp directory if not configured
+        if (settings.getFs().getTempDir() == null) {
+            Path tempDir = jobSettingsFolder.resolve("tmp");
+            settings.getFs().setTempDir(tempDir.toString());
+            logger.debug("Using default temp directory: [{}]", tempDir);
+        }
+
         // Create the fsParser instance depending on the settings
         if (loop != 0) {
             // What is the protocol used?

--- a/docs/source/admin/fs/local-fs.rst
+++ b/docs/source/admin/fs/local-fs.rst
@@ -54,6 +54,8 @@ Here is a list of Local FS settings (under ``fs.`` prefix)`:
 +----------------------------+-----------------------+---------------------------------+
 | ``fs.checksum``            | ``null``              | `File Checksum`_                |
 +----------------------------+-----------------------+---------------------------------+
+| ``fs.temp_dir``            | ``null``              | `Temporary Directory`_          |
++----------------------------+-----------------------+---------------------------------+
 | ``fs.follow_symlinks``     | ``false``             | `Follow Symlinks`_              |
 +----------------------------+-----------------------+---------------------------------+
 | ``fs.tika_config_path``    | ``null``              | `Tika Config Path`_             |
@@ -781,6 +783,34 @@ such as ``MD5`` or ``SHA-1``.
      index_content: true
      #indexed_chars: 0
      checksum: "MD5"
+
+Temporary Directory
+^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 2.10
+
+When ``checksum`` or ``store_source`` is enabled, FSCrawler may need to create
+temporary files to process large documents without loading them entirely into memory.
+By default, temporary files are created in ``~/.fscrawler/<job_name>/tmp/``.
+
+You can override this location using the ``temp_dir`` option:
+
+.. code:: yaml
+
+   name: "test"
+   fs:
+     checksum: "MD5"
+     temp_dir: "/path/to/custom/temp"
+
+.. note::
+
+    For small files (64KB or less), FSCrawler uses an in-memory buffer instead of
+    temporary files for better performance. Temporary files are only created for
+    larger files to avoid ``OutOfMemoryError``.
+
+.. note::
+
+    Temporary files are automatically deleted after processing each document.
 
 Follow Symlinks
 ^^^^^^^^^^^^^^^

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Fs.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Fs.java
@@ -86,6 +86,9 @@ public class Fs {
     @Nullable private String tikaConfigPath;
 
     @Config
+    @Nullable private String tempDir;
+
+    @Config
     @Nullable private Ocr ocr;
 
     public String getUrl() {
@@ -304,6 +307,14 @@ public class Fs {
       this.tikaConfigPath = tikaConfigPath;
     }
 
+    public String getTempDir() {
+        return tempDir;
+    }
+
+    public void setTempDir(String tempDir) {
+        this.tempDir = tempDir;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -333,14 +344,15 @@ public class Fs {
                 Objects.equals(checksum, fs.checksum) &&
                 Objects.equals(ocr, fs.ocr) &&
                 Objects.equals(ignoreAbove, fs.ignoreAbove) &&
-                Objects.equals(tikaConfigPath, fs.tikaConfigPath);
+                Objects.equals(tikaConfigPath, fs.tikaConfigPath) &&
+                Objects.equals(tempDir, fs.tempDir);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(url, updateRate, includes, excludes, filters, jsonSupport, filenameAsId, addFilesize,
                 removeDeleted, addAsInnerObject, storeSource, indexContent, indexedChars, attributesSupport, aclSupport, rawMetadata, xmlSupport,
-                checksum, indexFolders, langDetect, continueOnError, ocr, ignoreAbove, followSymlinks, tikaConfigPath);
+                checksum, indexFolders, langDetect, continueOnError, ocr, ignoreAbove, followSymlinks, tikaConfigPath, tempDir);
     }
 
     @Override
@@ -370,6 +382,7 @@ public class Fs {
                 ", ignoreAbove=" + ignoreAbove +
                 ", followSymlinks=" + followSymlinks +
                 ", tikaConfigPath='" + tikaConfigPath + '\'' +
+                ", tempDir='" + tempDir + '\'' +
                 '}';
     }
 }

--- a/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
+++ b/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
@@ -21,10 +21,10 @@ package fr.pilato.elasticsearch.crawler.fs.tika;
 
 import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
 import fr.pilato.elasticsearch.crawler.fs.framework.FSCrawlerLogger;
+import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerIllegalConfigurationException;
 import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil;
 import fr.pilato.elasticsearch.crawler.fs.framework.SignTool;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
-import org.apache.commons.io.input.TeeInputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tika.language.detect.LanguageResult;
@@ -33,9 +33,15 @@ import org.apache.tika.metadata.Office;
 import org.apache.tika.metadata.Property;
 import org.apache.tika.metadata.TikaCoreProperties;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -56,6 +62,12 @@ import static fr.pilato.elasticsearch.crawler.fs.tika.TikaInstance.langDetector;
 public class TikaDocParser {
 
     private static final Logger logger = LogManager.getLogger();
+
+    /**
+     * Threshold in bytes below which we keep the file content in memory instead of using a temp file.
+     * This avoids disk I/O overhead for small files while still protecting against OOM for large files.
+     */
+    private static final long IN_MEMORY_THRESHOLD = 64L * 1024; // 64KB
 
     private static MessageDigest findMessageDigest(FsSettings fsSettings) {
         if (fsSettings.getFs().getChecksum() != null) {
@@ -90,17 +102,64 @@ public class TikaDocParser {
 
         String parsedContent = null;
 
+        // If checksum is needed, we need to read the entire stream to compute it.
+        // Tika's internal mark/reset during content type detection would otherwise cause
+        // the DigestInputStream to only hash the bytes read during detection (typically 64KB),
+        // not the entire file.
+        // To avoid loading the entire file in memory (which could cause OOM for large files),
+        // we use a temporary file to store the content while computing the checksum.
+        // We also use a temp file when storeSource is enabled, so we can read the file twice
+        // (once for Tika, once for storing as attachment).
+        // For small files (below IN_MEMORY_THRESHOLD), we keep everything in memory to avoid disk I/O.
         MessageDigest messageDigest = findMessageDigest(fsSettings);
-        if (messageDigest != null) {
-            logger.trace("Generating hash with [{}]", messageDigest.getAlgorithm());
-            inputStream = new DigestInputStream(inputStream, messageDigest);
-        }
-
-        ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        if (fsSettings.getFs().isStoreSource()) {
-            logger.debug("Using a TeeInputStream as we need to store the source");
-            bos = new ByteArrayOutputStream();
-            inputStream = new TeeInputStream(inputStream, bos);
+        boolean needsBuffering = messageDigest != null || fsSettings.getFs().isStoreSource();
+        // Use in-memory only when we KNOW the file is small (filesize > 0 and <= threshold)
+        // When filesize is unknown (-1 or 0), use temp file to be safe and avoid OOM
+        boolean useInMemory = needsBuffering && filesize > 0 && filesize <= IN_MEMORY_THRESHOLD;
+        boolean useTempFile = needsBuffering && (filesize <= 0 || filesize > IN_MEMORY_THRESHOLD);
+        Path tempFile = null;
+        InputStream tempFileStream = null;
+        byte[] contentBuffer = null;
+        try {
+        if (useInMemory) {
+            logger.trace("Using in-memory buffer for small file (size: {}, checksum: {}, storeSource: {})",
+                    filesize, messageDigest != null, fsSettings.getFs().isStoreSource());
+            // Read entire stream into memory
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            if (messageDigest != null) {
+                try (DigestInputStream dis = new DigestInputStream(inputStream, messageDigest)) {
+                    dis.transferTo(bos);
+                }
+            } else {
+                inputStream.transferTo(bos);
+            }
+            contentBuffer = bos.toByteArray();
+            inputStream = new ByteArrayInputStream(contentBuffer);
+        } else if (useTempFile) {
+            logger.trace("Using temp file for large file (size: {}, checksum: {}, storeSource: {})",
+                    filesize, messageDigest != null, fsSettings.getFs().isStoreSource());
+            // Use configured temp directory - it should always be set by FsCrawlerImpl
+            if (fsSettings.getFs().getTempDir() == null) {
+                throw new FsCrawlerIllegalConfigurationException("tempDir must be configured when checksum or storeSource is enabled. " +
+                        "This is normally set automatically by FsCrawlerImpl.");
+            }
+            Path tempDir = Paths.get(fsSettings.getFs().getTempDir());
+            Files.createDirectories(tempDir);
+            tempFile = Files.createTempFile(tempDir, "fscrawler-", ".tmp");
+            // Copy stream to temp file, optionally computing the digest
+            if (messageDigest != null) {
+                try (DigestInputStream dis = new DigestInputStream(inputStream, messageDigest);
+                     OutputStream fos = Files.newOutputStream(tempFile)) {
+                    dis.transferTo(fos);
+                }
+            } else {
+                try (OutputStream fos = Files.newOutputStream(tempFile)) {
+                    inputStream.transferTo(fos);
+                }
+            }
+            // Now use the temp file as input for Tika
+            tempFileStream = Files.newInputStream(tempFile);
+            inputStream = tempFileStream;
         }
 
         if (fsSettings.getFs().isIndexContent()) {
@@ -226,18 +285,47 @@ public class TikaDocParser {
 
             // Doc content
             doc.setContent(parsedContent);
-        } else if (fsSettings.getFs().isStoreSource()) {
-            // We don't extract content but just store the binary file
-            // We need to create the ByteArrayOutputStream which has not been created then
-            inputStream.transferTo(bos);
         }
 
         // Doc as binary attachment
         if (fsSettings.getFs().isStoreSource()) {
-            doc.setAttachment(Base64.getEncoder().encodeToString(bos.toByteArray()));
+            logger.trace("Storing source as attachment");
+            if (contentBuffer != null) {
+                // Use in-memory buffer for small files
+                doc.setAttachment(Base64.getEncoder().encodeToString(contentBuffer));
+            } else {
+                // Stream from temp file for large files to avoid loading raw bytes into memory
+                // We use Base64.getEncoder().wrap() to encode while streaming
+                ByteArrayOutputStream base64Out = new ByteArrayOutputStream();
+                try (OutputStream encoder = Base64.getEncoder().wrap(base64Out);
+                     InputStream fileIn = Files.newInputStream(tempFile)) {
+                    fileIn.transferTo(encoder);
+                }
+                // Use explicit charset to avoid platform dependency
+                doc.setAttachment(base64Out.toString(StandardCharsets.UTF_8));
+            }
         }
         logger.trace("End document generation");
         // End of our document
+        } finally {
+            // Close the temp file stream before deleting the file
+            if (tempFileStream != null) {
+                try {
+                    tempFileStream.close();
+                } catch (IOException e) {
+                    logger.debug("Failed to close temp file stream: {}", e.getMessage());
+                }
+            }
+            // Clean up temp file if it was created
+            if (tempFile != null) {
+                try {
+                    Files.deleteIfExists(tempFile);
+                    logger.trace("Deleted temp file [{}]", tempFile);
+                } catch (IOException e) {
+                    logger.warn("Failed to delete temp file [{}]: {}", tempFile, e.getMessage());
+                }
+            }
+        }
     }
 
     private static <T> void setMeta(String filename, Metadata metadata, Property property, Consumer<T> setter, Function<String,T> transformer) {

--- a/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaInstance.java
+++ b/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaInstance.java
@@ -207,7 +207,7 @@ public class TikaInstance {
             TikaException {
         initTika(fsSettings.getFs());
         WriteOutContentHandler handler = new WriteOutContentHandler(indexedChars);
-        try (stream) {
+        try {
             parser.parse(stream, new BodyContentHandler(handler), metadata, context);
         } catch (WriteLimitReachedException e) {
             String resourceName = metadata.get("resourceName");


### PR DESCRIPTION
The checksum was incorrectly computed from only the first 64KB of binary files due to Tika's internal mark/reset during content type detection.

The fix reads the entire stream into a buffer first when checksum is needed, then computes the digest from the full content before passing the data to Tika for parsing.

Closes #2252.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Tika parsing/streaming logic and introduces temp-file buffering, which can impact memory/disk usage and stream lifecycle across indexing and REST upload paths.
> 
> **Overview**
> Fixes incorrect checksum generation for large/unknown-size uploads by **buffering input when `fs.checksum` or `fs.store_source` is enabled**: small files (<=64KB) are fully read in-memory, while larger/unknown sizes are copied to a temp file before running Tika so the digest covers the entire content.
> 
> Adds configurable `fs.temp_dir` (defaulting to `~/.fscrawler/<job>/tmp/` via `FsCrawlerImpl`), streams `store_source` Base64 encoding from the temp file, and ensures temp files/streams are cleaned up; REST `DocumentApi` now also closes upload/provider streams reliably. Docs and tests are updated to cover small/large/unknown-size checksum scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c380418b6bd4ff562169cf0ab1fcc221912b6c78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->