### PR TITLE
Fix race condition in SSH test on Windows

### DIFF
--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestSshIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestSshIT.java
@@ -162,14 +162,13 @@ public class FsCrawlerTestSshIT extends AbstractFsCrawlerITCase {
      */
     @Test
     public void dir_with_space_at_the_end() throws Exception {
-        try {
-            // We need to do a small hack here and rename the test directory as this could not work on Windows
-            Path dirWithSpace = currentTestResourceDir.resolve("with_space ");
-            Files.move(currentTestResourceDir.resolve("with_space"), dirWithSpace);
-        } catch (InvalidPathException e) {
-            logger.warn("Cannot rename directory to have a space at the end on Windows. Ignoring the test.", e);
-            assumeFalse("We can not run this test on Windows", OsValidator.WINDOWS);
-        }
+        // Skip early on Windows to avoid race condition with SSHD async threads during shutdown
+        // Windows does not support trailing spaces in path names
+        assumeFalse("This test cannot run on Windows (trailing spaces not supported in paths)", OsValidator.WINDOWS);
+
+        // We need to do a small hack here and rename the test directory as this could not work on Windows
+        Path dirWithSpace = currentTestResourceDir.resolve("with_space ");
+        Files.move(currentTestResourceDir.resolve("with_space"), dirWithSpace);
 
         FsSettings fsSettings = createTestSettings();
         fsSettings.getFs().setUrl("/");


### PR DESCRIPTION
## Summary

- Skip the `dir_with_space_at_the_end` test early on Windows to avoid a race condition with SSHD async threads during shutdown
- Previously, the test would catch `InvalidPathException` and then call `assumeFalse`, but the SSHD server's async threads could throw `IllegalStateException` when the executor was shut down, causing the test to fail instead of being skipped

## Test plan

- [x] Run the test on Windows to verify it is properly skipped
- [x] Run the test on Linux/macOS to verify it still works as expected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that alters Windows execution by skipping a known-unsupported path case, reducing flakiness from SSHD shutdown races.
> 
> **Overview**
> Updates `FsCrawlerTestSshIT.dir_with_space_at_the_end` to **skip immediately on Windows** (where trailing spaces in paths are unsupported) instead of attempting the rename and catching `InvalidPathException`.
> 
> This prevents the SSH integration test from starting/tearing down `sshd` on Windows, avoiding intermittent failures from async SSHD threads during shutdown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23435b726f2ca28ced0dd2407bbac4f9a3a997ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->