### PR TITLE
Refactor code to use JDK 17 language features

### DIFF
--- a/elasticsearch-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClientIT.java
+++ b/elasticsearch-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClientIT.java
@@ -236,25 +236,26 @@ public class ElasticsearchClientIT extends AbstractFSCrawlerTestCase {
     }
 
     private void createSearchDataset() throws Exception {
-        createIndex("{\n" +
-                "  \"mappings\": {\n" +
-                "    \"properties\": {\n" +
-                "      \"foo\": {\n" +
-                "        \"properties\": {\n" +
-                "          \"bar\": {\n" +
-                "            \"type\": \"text\",\n" +
-                "            \"store\": true,\n" +
-                "            \"fields\": {\n" +
-                "              \"raw\": { \n" +
-                "                \"type\":  \"keyword\"\n" +
-                "              }\n" +
-                "            }\n" +
-                "          }\n" +
-                "        }\n" +
-                "      }\n" +
-                "    }\n" +
-                "  }\n" +
-                "}");
+        createIndex("""
+                {
+                  "mappings": {
+                    "properties": {
+                      "foo": {
+                        "properties": {
+                          "bar": {
+                            "type": "text",
+                            "store": true,
+                            "fields": {
+                              "raw": {
+                                "type":  "keyword"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }""");
 
         esClient.indexSingle(getCrawlerName() + INDEX_SUFFIX_DOCS, "1", "{ \"foo\": { \"bar\": \"bar\" } }", null);
         esClient.indexSingle(getCrawlerName() + INDEX_SUFFIX_DOCS, "2", "{ \"foo\": { \"bar\": \"baz\" } }", null);
@@ -492,26 +493,27 @@ public class ElasticsearchClientIT extends AbstractFSCrawlerTestCase {
         String crawlerName = getCrawlerName();
 
         // Create an empty ingest pipeline
-        String pipeline = "{\n" +
-                "  \"description\": \"Testing Grok on PDF upload\",\n" +
-                "  \"processors\": [\n" +
-                "    {\n" +
-                "      \"gsub\": {\n" +
-                "        \"field\": \"content\",\n" +
-                "        \"pattern\": \"\\n\",\n" +
-                "        \"replacement\": \"-\"\n" +
-                "      }\n" +
-                "    },\n" +
-                "    {\n" +
-                "      \"grok\": {\n" +
-                "        \"field\": \"content\",\n" +
-                "        \"patterns\": [\n" +
-                "          \"%{DATA}%{IP:ip_addr} %{GREEDYDATA}\"\n" +
-                "        ]\n" +
-                "      }\n" +
-                "    }\n" +
-                "  ]\n" +
-                "}";
+        String pipeline = """
+                {
+                  "description": "Testing Grok on PDF upload",
+                  "processors": [
+                    {
+                      "gsub": {
+                        "field": "content",
+                        "pattern": "\\n",
+                        "replacement": "-"
+                      }
+                    },
+                    {
+                      "grok": {
+                        "field": "content",
+                        "patterns": [
+                          "%{DATA}%{IP:ip_addr} %{GREEDYDATA}"
+                        ]
+                      }
+                    }
+                  ]
+                }""";
         esClient.performLowLevelRequest("PUT", "/_ingest/pipeline/" + crawlerName, pipeline);
 
         assertThat(esClient.isExistingPipeline(crawlerName)).isTrue();
@@ -579,11 +581,12 @@ public class ElasticsearchClientIT extends AbstractFSCrawlerTestCase {
                 bulkRequest.add(new ElasticsearchIndexOperation(getCrawlerName() + INDEX_SUFFIX_DOCS,
                         "" + i,
                         null,
-                        "{\n" +
-                                "          \"foo\" : {\n" +
-                                "            \"bar\" : \"baz\"\n" +
-                                "          }\n" +
-                                "        }"));
+                        """
+                                {
+                                  "foo" : {
+                                    "bar" : "baz"
+                                  }
+                                }"""));
             }
 
             ElasticsearchEngine engine = new ElasticsearchEngine(esClient);
@@ -596,19 +599,20 @@ public class ElasticsearchClientIT extends AbstractFSCrawlerTestCase {
         }
         {
             esClient.deleteIndex(getCrawlerName() + INDEX_SUFFIX_DOCS);
-            String indexSettings = "{\n" +
-                    "  \"mappings\": {\n" +
-                    "    \"properties\": {\n" +
-                    "      \"foo\": {\n" +
-                    "        \"properties\": {\n" +
-                    "          \"number\": {\n" +
-                    "            \"type\": \"long\"\n" +
-                    "          }\n" +
-                    "        }\n" +
-                    "      }\n" +
-                    "    }\n" +
-                    "  }\n" +
-                    "}";
+            String indexSettings = """
+                    {
+                      "mappings": {
+                        "properties": {
+                          "foo": {
+                            "properties": {
+                              "number": {
+                                "type": "long"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }""";
 
             createIndex(indexSettings);
 
@@ -844,15 +848,16 @@ public class ElasticsearchClientIT extends AbstractFSCrawlerTestCase {
         assertThat(esClient.isExistingComponentTemplate(crawlerName)).isFalse();
 
         // Create a simple component template
-        String componentTemplate = "{\n" +
-                "  \"template\": {\n" +
-                "    \"mappings\": {\n" +
-                "      \"properties\": {\n" +
-                "        \"foo\": { \"type\": \"keyword\" }\n" +
-                "      }\n" +
-                "    }\n" +
-                "  }\n" +
-                "}";
+        String componentTemplate = """
+                {
+                  "template": {
+                    "mappings": {
+                      "properties": {
+                        "foo": { "type": "keyword" }
+                      }
+                    }
+                  }
+                }""";
         esClient.pushComponentTemplate(crawlerName, componentTemplate);
 
         assertThat(esClient.isExistingComponentTemplate(crawlerName)).isTrue();

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/ByteSizeValueTest.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/ByteSizeValueTest.java
@@ -41,27 +41,14 @@ public class ByteSizeValueTest extends AbstractFSCrawlerTestCase {
         // Test 500 random values
         for (int i = 0; i < 500; i++) {
             int unitNumber = randomIntBetween(0, 5);
-            ByteSizeUnit unit;
-            switch (unitNumber) {
-                case 1:
-                    unit = ByteSizeUnit.KB;
-                    break;
-                case 2:
-                    unit = ByteSizeUnit.MB;
-                    break;
-                case 3:
-                    unit = ByteSizeUnit.GB;
-                    break;
-                case 4:
-                    unit = ByteSizeUnit.TB;
-                    break;
-                case 5:
-                    unit = ByteSizeUnit.PB;
-                    break;
-                default:
-                    unit = ByteSizeUnit.BYTES;
-                    break;
-            }
+            ByteSizeUnit unit = switch (unitNumber) {
+                case 1 -> ByteSizeUnit.KB;
+                case 2 -> ByteSizeUnit.MB;
+                case 3 -> ByteSizeUnit.GB;
+                case 4 -> ByteSizeUnit.TB;
+                case 5 -> ByteSizeUnit.PB;
+                default -> ByteSizeUnit.BYTES;
+            };
 
             long value = randomLongBetween(1, 999);
             String randomByteSize = value + unit.getSuffix();

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerRestIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerRestIT.java
@@ -343,24 +343,28 @@ public class FsCrawlerRestIT extends AbstractRestITCase {
         }
 
         // We try with a document that does not exist
-        String json = "{\n" +
-                "  \"type\": \"local\",\n" +
-                "  \"local\": {\n" +
-                "    \"url\": \"" + fileDoesNotExist.toString().replace("\\", "\\\\") + "\"\n" +
-                "  }\n" +
-                "}";
+        String json = """
+                {
+                  "type": "local",
+                  "local": {
+                    "url": "%s"
+                  }
+                }
+                """.formatted(fileDoesNotExist.toString().replace("\\", "\\\\"));
         UploadResponse uploadResponse = post(target, "/_document", json, UploadResponse.class);
         assertThat(uploadResponse.isOk()).isFalse();
         assertThat(uploadResponse.getMessage()).contains("FsCrawlerIllegalConfigurationException");
         assertThat(uploadResponse.getMessage()).contains(fileDoesNotExist.toString());
 
         // We try with an existing document which is not part of the crawler fs.url
-        json = "{\n" +
-                "  \"type\": \"local\",\n" +
-                "  \"local\": {\n" +
-                "    \"url\": \"" + fileOutsideWatchedDir.toString().replace("\\", "\\\\") + "\"\n" +
-                "  }\n" +
-                "}";
+        json = """
+                {
+                  "type": "local",
+                  "local": {
+                    "url": "%s"
+                  }
+                }
+                """.formatted(fileOutsideWatchedDir.toString().replace("\\", "\\\\"));
         uploadResponse = post(target, "/_document", json, UploadResponse.class);
         assertThat(uploadResponse.isOk()).isFalse();
         assertThat(uploadResponse.getMessage())
@@ -369,12 +373,14 @@ public class FsCrawlerRestIT extends AbstractRestITCase {
                 .contains(fileOutsideWatchedDir.toString());
 
         // We try with an existing document which is part of the crawler fs.url
-        json = "{\n" +
-                "  \"type\": \"local\",\n" +
-                "  \"local\": {\n" +
-                "    \"url\": \"" + correctFile.toString().replace("\\", "\\\\") + "\"\n" +
-                "  }\n" +
-                "}";
+        json = """
+                {
+                  "type": "local",
+                  "local": {
+                    "url": "%s"
+                  }
+                }
+                """.formatted(correctFile.toString().replace("\\", "\\\\"));
         uploadResponse = post(target, "/_document", json, UploadResponse.class);
         assertThat(uploadResponse.isOk()).isTrue();
 
@@ -423,16 +429,18 @@ public class FsCrawlerRestIT extends AbstractRestITCase {
             }
 
             // We try with a document that does not exist
-            String json = "{\n" +
-                    "  \"type\": \"s3\",\n" +
-                    "  \"s3\": {\n" +
-                    "    \"url\": \"" + s3Url +"\",\n" +
-                    "    \"bucket\": \"documents\",\n" +
-                    "    \"object\": \"foobar/foobar.txt\",\n" +
-                    "    \"access_key\": \"" + s3Username + "\",\n" +
-                    "    \"secret_key\": \"" + s3Password + "\" \n" +
-                    "  }\n" +
-                    "}";
+            String json = """
+                    {
+                      "type": "s3",
+                      "s3": {
+                        "url": "%s",
+                        "bucket": "documents",
+                        "object": "foobar/foobar.txt",
+                        "access_key": "%s",
+                        "secret_key": "%s"
+                      }
+                    }
+                    """.formatted(s3Url, s3Username, s3Password);
 
             UploadResponse uploadResponse = post(target, "/_document", json, UploadResponse.class);
             assertThat(uploadResponse.isOk()).isFalse();
@@ -440,16 +448,18 @@ public class FsCrawlerRestIT extends AbstractRestITCase {
             assertThat(uploadResponse.getMessage()).contains("The specified key does not exist");
 
             // We try with an existing document
-            json = "{\n" +
-                    "  \"type\": \"s3\",\n" +
-                    "  \"s3\": {\n" +
-                    "    \"url\": \"" + s3Url +"\",\n" +
-                    "    \"bucket\": \"documents\",\n" +
-                    "    \"object\": \"roottxtfile.txt\",\n" +
-                    "    \"access_key\": \"" + s3Username + "\",\n" +
-                    "    \"secret_key\": \"" + s3Password + "\" \n" +
-                    "  }\n" +
-                    "}";
+            json = """
+                    {
+                      "type": "s3",
+                      "s3": {
+                        "url": "%s",
+                        "bucket": "documents",
+                        "object": "roottxtfile.txt",
+                        "access_key": "%s",
+                        "secret_key": "%s"
+                      }
+                    }
+                    """.formatted(s3Url, s3Username, s3Password);
             uploadResponse = post(target, "/_document", json, UploadResponse.class);
             assertThat(uploadResponse.isOk()).isTrue();
 
@@ -472,12 +482,14 @@ public class FsCrawlerRestIT extends AbstractRestITCase {
         }
 
         // We try with an existing document
-        String json = "{\n" +
-                "  \"type\": \"not_available\",\n" +
-                "  \"not_available\": {\n" +
-                "    \"url\": \"" + fromExists.toString().replace("\\", "\\\\") + "\"\n" +
-                "  }\n" +
-                "}";
+        String json = """
+                {
+                  "type": "not_available",
+                  "not_available": {
+                    "url": "%s"
+                  }
+                }
+                """.formatted(fromExists.toString().replace("\\", "\\\\"));
         UploadResponse uploadResponse = post(target, "/_document", json, UploadResponse.class);
         assertThat(uploadResponse).satisfies(response -> {
             assertThat(response.isOk()).isFalse();
@@ -545,24 +557,28 @@ public class FsCrawlerRestIT extends AbstractRestITCase {
             logger.info("Nginx started on {}.", url);
 
             // We try with a document that does not exist
-            String json = "{\n" +
-                    "  \"type\": \"http\",\n" +
-                    "  \"http\": {\n" +
-                    "    \"url\": \"" + url + "/doesnotexist.txt\"\n" +
-                    "  }\n" +
-                    "}";
+            String json = """
+                    {
+                      "type": "http",
+                      "http": {
+                        "url": "%s/doesnotexist.txt"
+                      }
+                    }
+                    """.formatted(url);
             UploadResponse uploadResponse = post(target, "/_document", json, UploadResponse.class);
             assertThat(uploadResponse.isOk()).isFalse().isFalse();
             assertThat(uploadResponse.getMessage()).contains("FileNotFoundException");
             assertThat(uploadResponse.getMessage()).contains("doesnotexist.txt");
 
             // We try with an existing document
-            json = "{\n" +
-                    "  \"type\": \"http\",\n" +
-                    "  \"http\": {\n" +
-                    "    \"url\": \"" + url + "/foo.txt\"\n" +
-                    "  }\n" +
-                    "}";
+            json = """
+                    {
+                      "type": "http",
+                      "http": {
+                        "url": "%s/foo.txt"
+                      }
+                    }
+                    """.formatted(url);
             uploadResponse = post(target, "/_document", json, UploadResponse.class);
             assertThat(uploadResponse.isOk()).isTrue();
 
@@ -573,12 +589,14 @@ public class FsCrawlerRestIT extends AbstractRestITCase {
             assertThat((String) JsonPath.read(response.getHits().get(0).getSource(), "$.content")).contains(text);
 
             // We try with an existing document running on https
-            json = "{\n" +
-                    "  \"type\": \"http\",\n" +
-                    "  \"http\": {\n" +
-                    "    \"url\": \"https://www.google.fr/robots.txt\"\n" +
-                    "  }\n" +
-                    "}";
+            json = """
+                    {
+                      "type": "http",
+                      "http": {
+                        "url": "https://www.google.fr/robots.txt"
+                      }
+                    }
+                    """;
             uploadResponse = post(target, "/_document", json, UploadResponse.class);
             assertThat(uploadResponse.getMessage()).isNull();
 

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestIngestPipelineIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestIngestPipelineIT.java
@@ -45,17 +45,18 @@ public class FsCrawlerTestIngestPipelineIT extends AbstractFsCrawlerITCase {
         String crawlerName = getCrawlerName();
 
         // Create an empty ingest pipeline
-        String pipeline = "{\n" +
-                "  \"description\" : \"describe pipeline\",\n" +
-                "  \"processors\" : [\n" +
-                "    {\n" +
-                "      \"rename\": {\n" +
-                "        \"field\": \"content\",\n" +
-                "        \"target_field\": \"my_content_field\"\n" +
-                "      }\n" +
-                "    }\n" +
-                "  ]\n" +
-                "}";
+        String pipeline = """
+                {
+                  "description" : "describe pipeline",
+                  "processors" : [
+                    {
+                      "rename": {
+                        "field": "content",
+                        "target_field": "my_content_field"
+                      }
+                    }
+                  ]
+                }""";
         client.performLowLevelRequest("PUT", "/_ingest/pipeline/" + crawlerName, pipeline);
 
         FsSettings fsSettings = createTestSettings();
@@ -82,26 +83,27 @@ public class FsCrawlerTestIngestPipelineIT extends AbstractFsCrawlerITCase {
         String crawlerName = getCrawlerName();
 
         // Create an empty ingest pipeline
-        String pipeline = "{\n" +
-                "  \"description\": \"Testing Grok on PDF upload\",\n" +
-                "  \"processors\": [\n" +
-                "    {\n" +
-                "      \"gsub\": {\n" +
-                "        \"field\": \"content\",\n" +
-                "        \"pattern\": \"\\n\",\n" +
-                "        \"replacement\": \"-\"\n" +
-                "      }\n" +
-                "    },\n" +
-                "    {\n" +
-                "      \"grok\": {\n" +
-                "        \"field\": \"content\",\n" +
-                "        \"patterns\": [\n" +
-                "          \"%{DATA}%{IP:ip_addr} %{GREEDYDATA}\"\n" +
-                "        ]\n" +
-                "      }\n" +
-                "    }\n" +
-                "  ]\n" +
-                "}";
+        String pipeline = """
+                {
+                  "description": "Testing Grok on PDF upload",
+                  "processors": [
+                    {
+                      "gsub": {
+                        "field": "content",
+                        "pattern": "\\n",
+                        "replacement": "-"
+                      }
+                    },
+                    {
+                      "grok": {
+                        "field": "content",
+                        "patterns": [
+                          "%{DATA}%{IP:ip_addr} %{GREEDYDATA}"
+                        ]
+                      }
+                    }
+                  ]
+                }""";
         client.performLowLevelRequest("PUT", "/_ingest/pipeline/" + crawlerName, pipeline);
 
         FsSettings fsSettings = createTestSettings();


### PR DESCRIPTION
## Summary

- Replace String concatenations with **Text Blocks** (`"""..."""`) for JSON literals
- Convert switch statement to **switch expression** in `ByteSizeValueTest`
- Use **`String.formatted()`** for text blocks with variable interpolation

## Files modified

| File | Changes |
|------|---------|
| `FsCrawlerTestIngestPipelineIT.java` | 2 JSON pipelines → text blocks |
| `ElasticsearchClientIT.java` | 5 JSON literals → text blocks |
| `ByteSizeValueTest.java` | switch statement → switch expression |
| `FsCrawlerRestIT.java` | 9 JSON payloads → text blocks with `.formatted()` |

## Benefits
- Improved code readability
- Better maintainability for JSON structures
- Takes advantage of modern Java 17 language features

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test code and are primarily string literal/syntax refactors with no behavioral changes expected beyond potential formatting differences in request bodies.
> 
> **Overview**
> Refactors test code to modern Java 17 syntax: replaces multi-line JSON string concatenations with `"""` text blocks (and `String.formatted()` where interpolation is needed) across Elasticsearch client and integration tests.
> 
> Also converts a `switch` statement to a Java 17 `switch` expression in `ByteSizeValueTest` to simplify random `ByteSizeUnit` selection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9bf6e937c98e8bd196789cbdef02f1fa2caae64f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->