### PR TITLE
fix(logging): 🐛 suppress OpenTelemetry export errors when collector unavailable

### DIFF
--- a/cli/src/main/resources/log4j2.xml
+++ b/cli/src/main/resources/log4j2.xml
@@ -85,6 +85,10 @@
          <AppenderRef ref="Console" />
          <AppenderRef ref="RollingFile" />
       </Logger>
+      <Logger name="io.opentelemetry" level="warn" additivity="false">
+         <AppenderRef ref="Console" />
+         <AppenderRef ref="RollingFile" />
+      </Logger>
 
       <Root level="warn">
          <AppenderRef ref="Console" />

--- a/cli/src/test/resources/log4j2.xml
+++ b/cli/src/test/resources/log4j2.xml
@@ -26,6 +26,9 @@
       <Logger name="org.github.gestalt" level="warn" additivity="false">
          <AppenderRef ref="CONSOLE"/>
       </Logger>
+      <Logger name="io.opentelemetry" level="warn" additivity="false">
+         <AppenderRef ref="CONSOLE"/>
+      </Logger>
       <Root level="info">
          <AppenderRef ref="CONSOLE"/>
       </Root>

--- a/distribution/src/main/scripts/fscrawler
+++ b/distribution/src/main/scripts/fscrawler
@@ -52,13 +52,18 @@ esac
 # Fix for CVE-2021-44228
 JAVA_OPTS="$JAVA_OPTS -Dlog4j2.formatMsgNoLookups=true"
 
-# Auto-load Elastic OTel javaagent if present in external/ (remove the JAR to disable APM tracing)
-# To disable: rm "$FS_HOME/external/elastic-otel-javaagent-*.jar"
+# Always route OTEL agent logs to application logger (Log4j2)
+JAVA_OPTS="$JAVA_OPTS -DOTEL_JAVAAGENT_LOGGING=application"
+
+# Load Elastic OTel javaagent only if OTEL_ENABLED=true
+# If set, will auto-load javaagent if present in external/ (remove the JAR to disable APM tracing)
 # To configure: set OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_SERVICE_NAME, etc.
 # To disable without removing: set OTEL_SDK_DISABLED=true
-OTEL_AGENT=$(ls "$FS_HOME"/external/elastic-otel-javaagent-*.jar 2>/dev/null | head -1)
-if [ -n "$OTEL_AGENT" ]; then
-    JAVA_OPTS="$JAVA_OPTS -javaagent:$OTEL_AGENT"
+if [ "$OTEL_ENABLED" = "true" ]; then
+    OTEL_AGENT=$(ls "$FS_HOME"/external/elastic-otel-javaagent-*.jar 2>/dev/null | head -1)
+    if [ -n "$OTEL_AGENT" ]; then
+        JAVA_OPTS="$JAVA_OPTS -javaagent:$OTEL_AGENT"
+    fi
 fi
 
 # If the user defined FS_JAVA_OPTS, we will use it to start the crawler

--- a/distribution/src/main/scripts/fscrawler.bat
+++ b/distribution/src/main/scripts/fscrawler.bat
@@ -34,18 +34,22 @@ set JAVA_OPTS=%JAVA_OPTS% -Dlog4j.configurationFile=%FS_HOME%/config/log4j2.xml
 REM Fix for CVE-2021-44228
 set JAVA_OPTS=%JAVA_OPTS% -Dlog4j2.formatMsgNoLookups=true
 
-REM Auto-load Elastic OTel javaagent if present in external\ (delete the JAR to disable APM tracing)
-REM To disable without deleting: set OTEL_SDK_DISABLED=true
+REM Always route OTEL agent logs to application logger (Log4j2)
+set JAVA_OPTS=%JAVA_OPTS% -DOTEL_JAVAAGENT_LOGGING=application
+
+REM Load Elastic OTel javaagent only if OTEL_ENABLED=true
 REM PUSHD is guarded so that a missing external\ directory does not unbalance the directory stack.
-IF EXIST "%FS_HOME%\external\" (
-    PUSHD "%FS_HOME%\external"
-    FOR %%I IN (elastic-otel-javaagent-*.jar) DO (
-        set OTEL_AGENT=%FS_HOME%\external\%%I
+IF "%OTEL_ENABLED%"=="true" (
+    IF EXIST "%FS_HOME%\external\" (
+        PUSHD "%FS_HOME%\external"
+        FOR %%I IN (elastic-otel-javaagent-*.jar) DO (
+            set OTEL_AGENT=%FS_HOME%\external\%%I
+        )
+        POPD
     )
-    POPD
-)
-IF DEFINED OTEL_AGENT (
-    set JAVA_OPTS=%JAVA_OPTS% -javaagent:!OTEL_AGENT!
+    IF DEFINED OTEL_AGENT (
+        set JAVA_OPTS=%JAVA_OPTS% -javaagent:!OTEL_AGENT!
+    )
 )
 
 REM If the user defined FS_JAVA_OPTS, we will use it to start the crawler

--- a/docs/source/admin/otel.rst
+++ b/docs/source/admin/otel.rst
@@ -93,8 +93,6 @@ Common variables:
      - Comma-separated ``key=value`` resource attributes
    * - ``OTEL_EXPORTER_OTLP_HEADERS``
      - Auth headers, e.g. ``Authorization=Bearer <token>``
-   * - ``OTEL_SDK_DISABLED``
-     - Set to ``true`` to disable without removing the agent
    * - ``OTEL_EXPORTER_OTLP_TIMEOUT``
      - Export timeout in ms (e.g. ``1000``); reduce if the collector is unavailable
    * - ``OTEL_METRIC_EXPORT_INTERVAL``
@@ -122,18 +120,18 @@ You can find your OTel endpoint and API key in Kibana under
 Behavior without a collector
 ------------------------------
 
-If the agent is present but no EDOT Collector is reachable, the OTLP exporter
+If OTEL_ENABLED is set and the collector is unreachable, the OTLP exporter
 will log a ``WARN`` message on each failed export attempt and retry with
 exponential back-off.  FSCrawler continues to run normally — tracing failures
 are non-blocking.
 
-To suppress the warnings when no collector is available::
+To suppress the warnings, you can:
 
-    export OTEL_SDK_DISABLED=true
-
-or reduce the export timeout::
+- Reduce the export timeout::
 
     export OTEL_EXPORTER_OTLP_TIMEOUT=1000
+
+- Or disable OTEL tracing entirely by not setting ``OTEL_ENABLED=true``
 
 Using with other OTel backends (Jaeger, Zipkin, …)
 ----------------------------------------------------

--- a/docs/source/admin/otel.rst
+++ b/docs/source/admin/otel.rst
@@ -70,6 +70,7 @@ Use standard OpenTelemetry environment variables before starting FSCrawler:
 .. code-block:: bash
 
    # Send traces to an EDOT Collector (OTLP HTTP)
+   export OTEL_ENABLED=true
    export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
    export OTEL_SERVICE_NAME=fscrawler
    export OTEL_RESOURCE_ATTRIBUTES=deployment.environment=production,service.version=2.10

--- a/docs/source/admin/otel.rst
+++ b/docs/source/admin/otel.rst
@@ -11,9 +11,8 @@ loads it on startup and exports traces to any OpenTelemetry-compatible backend
 
 .. note::
 
-   OTel tracing is **enabled by default** when using the standard FSCrawler distribution.
-   The agent JAR is bundled in ``external/``.  No configuration is required to
-   start collecting traces — just point the exporter at your EDOT Collector.
+   OTel tracing is **disabled by default** when using the standard FSCrawler distribution.
+   To enable it, set the ``OTEL_ENABLED=true`` environment variable before starting FSCrawler.
 
 How it works
 -------------
@@ -51,16 +50,16 @@ FSCrawler uses a hybrid instrumentation approach:
      - ``es.bulk.actions``
      - Elasticsearch bulk indexing request (number of operations in the batch)
 
-Disabling OTel tracing
------------------------
+Enabling OTel tracing
+----------------------
 
-Remove the agent JAR to disable tracing entirely::
+To enable OTel tracing, set the ``OTEL_ENABLED=true`` environment variable before starting FSCrawler::
 
-    rm $FS_HOME/external/elastic-otel-javaagent-*.jar
+    export OTEL_ENABLED=true
+    export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+    export OTEL_SERVICE_NAME=fscrawler
+    export OTEL_RESOURCE_ATTRIBUTES=deployment.environment=production,service.version=2.10
 
-Alternatively, keep the JAR but disable the SDK at runtime::
-
-    export OTEL_SDK_DISABLED=true
     ./bin/fscrawler
 
 Configuring the OTel exporter
@@ -110,6 +109,7 @@ Using with Elastic Cloud (managed EDOT)
 
 .. code-block:: bash
 
+   export OTEL_ENABLED=true
    export OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-otel-endpoint>:443
    export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer <api-key>"
    export OTEL_SERVICE_NAME=fscrawler
@@ -142,6 +142,7 @@ Example for Jaeger (OTLP/gRPC):
 
 .. code-block:: bash
 
+   export OTEL_ENABLED=true
    export OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger-host:4317
    export OTEL_SERVICE_NAME=fscrawler
    ./bin/fscrawler
@@ -158,21 +159,20 @@ is available under ``contrib/docker-compose-example-edot/``.
      fscrawler:
        image: dadoonet/fscrawler:latest
        environment:
+         - OTEL_ENABLED=true
          - OTEL_EXPORTER_OTLP_ENDPOINT=http://edot-collector:4318
          - OTEL_SERVICE_NAME=fscrawler
          - OTEL_RESOURCE_ATTRIBUTES=deployment.environment=docker
 
-To disable OTel tracing in Docker without rebuilding the image::
-
-    environment:
-      - OTEL_SDK_DISABLED=true
+To disable OTel tracing in Docker, simply omit the ``OTEL_ENABLED=true`` environment variable.
 
 Windows
 --------
 
-The ``bin\fscrawler.bat`` launcher applies the same auto-detection logic.
+The ``bin\fscrawler.bat`` launcher applies the same logic.
 Set environment variables in the same shell before running::
 
+    set OTEL_ENABLED=true
     set OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
     set OTEL_SERVICE_NAME=fscrawler
     bin\fscrawler.bat


### PR DESCRIPTION
- Set io.opentelemetry logger to WARN level instead of ERROR
- Prevents log spam when no OTEL endpoint is available (localhost:4318)
- Tracing failures are non-blocking per OTEL design
- Applied to both main and test configurations

Closes #2397.