### PR TITLE
Bundle fs-ftp and fs-ssh plugins as built-in

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -54,6 +54,14 @@
             <groupId>fr.pilato.elasticsearch.crawler</groupId>
             <artifactId>fscrawler-fs-http-plugin</artifactId>
         </dependency>
+        <dependency>
+            <groupId>fr.pilato.elasticsearch.crawler</groupId>
+            <artifactId>fscrawler-fs-ftp-plugin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>fr.pilato.elasticsearch.crawler</groupId>
+            <artifactId>fscrawler-fs-ssh-plugin</artifactId>
+        </dependency>
 
     </dependencies>
 


### PR DESCRIPTION
## Summary
- The docs list `ftp` and `ssh` as valid `fs.provider` values, but their plugin jars (`fscrawler-fs-ftp-plugin`, `fscrawler-fs-ssh-plugin`) were never added as built-in dependencies of `cli`, so they were missing from both the ZIP distribution and the Docker image (only `local`, `s3`, `http` were bundled).
- Adds the two missing dependencies to `cli/pom.xml`, alongside the existing built-in plugins, so they flow transitively into the `distribution` module's assembly and Docker image.

Closes #2417.

## Test plan
- [x] `mvn clean install -DskipTests -Dossindex.skip`
- [x] Verified `fscrawler-fs-ftp-plugin` and `fscrawler-fs-ssh-plugin` jars are present in `distribution/target/fscrawler-distribution-2.10-SNAPSHOT.zip` under `lib/`
- [x] Verified both jars are present in the rebuilt `dadoonet/fscrawler:2.10-SNAPSHOT` Docker image under `/usr/share/fscrawler/lib`
- [x] `mvn spotless:check` passes