### PR TITLE
Retry root endpoint on 404 during client bootstrap

### DIFF
--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -106,6 +106,13 @@ public class ElasticsearchClient implements IElasticsearchClient {
     private static final Duration RETRY_429_INITIAL_DELAY = Duration.ofSeconds(1);
     private static final Duration RETRY_429_MAX_DELAY = Duration.ofSeconds(30);
 
+    // Retry configuration for the root endpoint during bootstrap. On Elastic Cloud hosted deployments, the Cloud proxy
+    // can answer 404 on GET / while the cluster is still "cold" (waking up, rolling restart, resize...) and no backing
+    // node is routable yet. A healthy Elasticsearch always answers 200 on the root, so this 404 is transient.
+    private static final Duration BOOTSTRAP_RETRY_MAX_DURATION = Duration.ofMinutes(1);
+    private static final Duration BOOTSTRAP_RETRY_INITIAL_DELAY = Duration.ofSeconds(1);
+    private static final Duration BOOTSTRAP_RETRY_MAX_DELAY = Duration.ofSeconds(10);
+
     private Client client = null;
     private FsCrawlerBulkProcessor<ElasticsearchOperation, ElasticsearchBulkRequest, ElasticsearchBulkResponse>
             bulkProcessor = null;
@@ -304,6 +311,34 @@ public class ElasticsearchClient implements IElasticsearchClient {
         if (version != null) {
             return version;
         }
+
+        // On Elastic Cloud hosted deployments, the Cloud proxy may answer 404 on the root endpoint while the cluster
+        // is still "cold" (waking up, rolling restart, resize...). A healthy Elasticsearch always answers 200 on the
+        // root, so we retry on NotFoundException here, mirroring getLicense(). This is scoped to the root endpoint:
+        // 404 on regular endpoints stays non-retryable (see executeWithRetry and testNoRetryOn4xxErrors).
+        try {
+            return Awaitility.await()
+                    .atMost(BOOTSTRAP_RETRY_MAX_DURATION)
+                    .pollInterval(ExponentialBackoffPollInterval.exponential(
+                            BOOTSTRAP_RETRY_INITIAL_DELAY, BOOTSTRAP_RETRY_MAX_DELAY))
+                    .until(
+                            () -> {
+                                try {
+                                    return getVersionInternal();
+                                } catch (NotFoundException e) {
+                                    logger.warn(
+                                            "Root endpoint answered 404. The cluster might still be cold. Retrying...");
+                                    return null;
+                                }
+                            },
+                            Objects::nonNull);
+        } catch (ConditionTimeoutException e) {
+            throw new ElasticsearchClientException(
+                    "Root endpoint is still not ready (404) after " + BOOTSTRAP_RETRY_MAX_DURATION);
+        }
+    }
+
+    private String getVersionInternal() throws ElasticsearchClientException {
         logger.trace("get version");
         String response = httpGet(null);
         // We parse the response

--- a/elasticsearch-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClientRetryTest.java
+++ b/elasticsearch-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClientRetryTest.java
@@ -201,6 +201,52 @@ class ElasticsearchClientRetryTest extends AbstractFSCrawlerTestCase {
     }
 
     /**
+     * Test that a "cold" hosted deployment is retried during bootstrap. On Elastic Cloud hosted deployments, the Cloud
+     * proxy can answer 404 on the root endpoint (GET /) while no backing node is routable yet (cluster waking up,
+     * rolling restart, resize...). A healthy Elasticsearch always answers 200 on the root, so this 404 is transient and
+     * must be retried during start(), unlike 404 on regular endpoints (see {@link #testNoRetryOn4xxErrors()}).
+     */
+    @Test
+    void testRetryOnRootNotFoundDuringBootstrap() throws IOException, ElasticsearchClientException {
+        wireMockServer.resetAll();
+
+        // Simulate: 404 -> 404 -> Success (cluster becomes routable on the third call)
+        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/"))
+                .inScenario("Cold Cluster")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(WireMock.aResponse()
+                        .withStatus(404)
+                        .withBody("{\"ok\":false,\"message\":\"Unknown deployment.\"}"))
+                .willSetStateTo("First 404"));
+
+        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/"))
+                .inScenario("Cold Cluster")
+                .whenScenarioStateIs("First 404")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(404)
+                        .withBody("{\"ok\":false,\"message\":\"Unknown deployment.\"}"))
+                .willSetStateTo("Second 404"));
+
+        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/"))
+                .inScenario("Cold Cluster")
+                .whenScenarioStateIs("Second 404")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"version\": {\"number\": \"" + elasticsearchVersion + "\"}}")));
+
+        try (ElasticsearchClient client = createClient()) {
+            // start() calls getVersion() internally, which must retry on the transient 404
+            client.start();
+            Assertions.assertThat(client.getVersion()).isEqualTo(elasticsearchVersion);
+        }
+
+        // Verify that 3 requests were made (2 x 404 + 1 success)
+        WireMock.verify(3, WireMock.getRequestedFor(WireMock.urlEqualTo("/")));
+        logger.info("Test passed: bootstrap retried on cold-cluster 404 and eventually succeeded");
+    }
+
+    /**
      * Test that 429 (Too Many Requests) errors trigger retry. This is important for handling Elasticsearch rate
      * limiting. See: https://github.com/dadoonet/fscrawler/issues/2119
      */


### PR DESCRIPTION
## Problem

CI intermittently fails when connecting to a **hosted** Elastic Cloud deployment (never on Serverless) with:

```
jakarta.ws.rs.NotFoundException: HTTP 404 Not Found
  at ElasticsearchClient.httpCall(ElasticsearchClient.java:1497)
  ... in @BeforeAll startServices → start() → getVersion()
```

The failure happens during client bootstrap on a plain `GET /` (the info endpoint). A healthy Elasticsearch always answers `200` on the root, and the 404 carries no ES JSON error body, so it comes from the **Cloud proxy in front of the deployment**, not from Elasticsearch. When the cluster is "cold" (waking up, rolling restart, resize, master not yet elected), the proxy can't route to a live node and returns `404`.

`getVersion()` (`GET /`) only retries on `5xx`/`429`; a `4xx` is thrown immediately, so a single transient blip fails the whole test class. It's flaky by nature — a re-run passes.

## Fix

- `getVersion()` now retries on `NotFoundException` during bootstrap, mirroring the existing `getLicense()` pattern (exponential backoff 1s→10s, capped at 1 minute), then throws a clear `ElasticsearchClientException` if still not ready.
- **Scoped to the root endpoint only**: `404` on regular endpoints (e.g. `isExistingIndex`) stays non-retryable — guarded by the existing `testNoRetryOn4xxErrors`.

## Test plan

- 🔴→🟢 New `testRetryOnRootNotFoundDuringBootstrap` (WireMock `404 → 404 → 200`) — failed with `HTTP 404` before the fix, passes after.
- Full `ElasticsearchClientRetryTest`: `9/9` green, including `testNoRetryOn4xxErrors` and `testRetryExhausted`.
- `mvn spotless:check` OK.

## Notes

- No user-visible config/CLI change → no `docs/source/` update.
- The "404 forever → exhausted" path is intentionally not unit-tested (it would wait the full 1-minute window), consistent with `getLicense()` which has no exhausted test either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)