### PR TITLE
Add tests.seed to the reproduce command line

### DIFF
--- a/test-framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/framework/AbstractFSCrawlerTestCase.java
+++ b/test-framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/framework/AbstractFSCrawlerTestCase.java
@@ -109,6 +109,9 @@ public abstract class AbstractFSCrawlerTestCase {
             return;
         }
 
+        // Expose the root seed to the reproduce-info extension so it can print -Dtests.seed on failures.
+        FsCrawlerReproduceInfoExtension.rememberRootSeed(context.getRootSeed().toString());
+
         Random random = new Random(context.getRootSeed().value());
 
         String testLocale = getSystemProperty("tests.locale", RANDOM);

--- a/test-framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/framework/FsCrawlerReproduceInfoExtension.java
+++ b/test-framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/framework/FsCrawlerReproduceInfoExtension.java
@@ -46,6 +46,28 @@ public class FsCrawlerReproduceInfoExtension
 
     private static final Logger logger = LogManager.getLogger();
 
+    /**
+     * Root seed of randomizedtesting for the current JVM fork, formatted for {@code -Dtests.seed}. It is JVM-wide (one
+     * value per surefire/failsafe fork) and captured once by {@link AbstractFSCrawlerTestCase}. Remains {@code null}
+     * until known (e.g. a {@code @BeforeAll} fails before the base class had a chance to record it).
+     */
+    private static volatile String rootSeed;
+
+    /**
+     * Records the randomizedtesting root seed of the current JVM fork so it can be added to the reproduction command
+     * line. Called once per fork by {@link AbstractFSCrawlerTestCase}.
+     *
+     * @param seed the root seed formatted for {@code -Dtests.seed}, or {@code null} if unknown
+     */
+    public static void rememberRootSeed(String seed) {
+        rootSeed = seed;
+    }
+
+    /** @return the root seed currently recorded for this JVM fork, or {@code null} if none is known yet */
+    public static String getRootSeed() {
+        return rootSeed;
+    }
+
     /** Annotation to put on test classes to inject additional system properties into the reproduction command. */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.TYPE)
@@ -123,6 +145,7 @@ public class FsCrawlerReproduceInfoExtension
             commandBuilder.append("#").append(methodName);
         }
 
+        appendOpt(commandBuilder, "tests.seed", rootSeed);
         appendOpt(commandBuilder, "tests.locale", Locale.getDefault().toLanguageTag());
         appendOpt(commandBuilder, "tests.timezone", TimeZone.getDefault().getID());
 

--- a/test-framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/framework/FsCrawlerReproduceInfoExtensionTest.java
+++ b/test-framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/framework/FsCrawlerReproduceInfoExtensionTest.java
@@ -50,6 +50,30 @@ class FsCrawlerReproduceInfoExtensionTest {
         Assertions.assertThat(command).doesNotContain("#");
     }
 
+    @Test
+    void shouldIncludeSeedWhenKnown() {
+        String previous = FsCrawlerReproduceInfoExtension.getRootSeed();
+        try {
+            FsCrawlerReproduceInfoExtension.rememberRootSeed("DEADBEEF");
+            String command = extension.buildReproduceCommand(context(PlainTest.class), "myMethod");
+            Assertions.assertThat(command).contains("-Dtests.seed=DEADBEEF");
+        } finally {
+            FsCrawlerReproduceInfoExtension.rememberRootSeed(previous);
+        }
+    }
+
+    @Test
+    void shouldOmitSeedWhenUnknown() {
+        String previous = FsCrawlerReproduceInfoExtension.getRootSeed();
+        try {
+            FsCrawlerReproduceInfoExtension.rememberRootSeed(null);
+            String command = extension.buildReproduceCommand(context(PlainTest.class), "myMethod");
+            Assertions.assertThat(command).doesNotContain("-Dtests.seed=");
+        } finally {
+            FsCrawlerReproduceInfoExtension.rememberRootSeed(previous);
+        }
+    }
+
     private static ExtensionContext context(Class<?> testClass) {
         return (ExtensionContext) Proxy.newProxyInstance(
                 ExtensionContext.class.getClassLoader(),


### PR DESCRIPTION
## Problem

When an IT (or unit) test fails, the `🐛 REPRODUCE WITH:` line printed by `FsCrawlerReproduceInfoExtension` only contained `-Dtests.locale` and `-Dtests.timezone` — **never `-Dtests.seed`**.

In JUnit 4, randomizedtesting's `ReproduceInfoPrinter` emitted the seed automatically. During the JUnit 4 → JUnit 6 migration the extension was rewritten by hand and the seed was dropped. On top of that, the extension only receives an `ExtensionContext`, while the seed lives in `RandomizedContext`, so it had to be plumbed through.

## Fix

- `FsCrawlerReproduceInfoExtension`: add a per-fork `rootSeed` holder (`rememberRootSeed` / `getRootSeed`) and append `-Dtests.seed` before locale/timezone (classic randomizedtesting order).
- `AbstractFSCrawlerTestCase.setGlobalDefaults(...)`: capture `context.getRootSeed().toString()` once per JVM fork (inside the existing `compareAndSet` block) and hand it to the extension.
- Unit coverage for the seed-present / seed-absent cases.

The **root** seed is used on purpose: the whole run derives deterministically from it, so `Class#method` reproduces exactly (locale/timezone included).

## Test plan

- Unit: `FsCrawlerReproduceInfoExtensionTest` — 4 tests green (red first: methods didn't compile).
- End-to-end via the `@Disabled` `FakeTest` fixture:
  - pinned seed → `... -Dtests.seed=CAFEBABE -Dtests.locale=... -Dtests.timezone=...`
  - random seed → `... -Dtests.seed=9D7A42CD6A238B60 ...`
  - **round-trip verified**: re-running with `-Dtests.seed=9D7A42CD6A238B60` reproduces the exact same locale/timezone.
- `mvn spotless:check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)