### PR TITLE
ci: warm up Elastic Cloud cluster before cloud IT jobs

### DIFF
--- a/.github/scripts/warm-up-elasticsearch.sh
+++ b/.github/scripts/warm-up-elasticsearch.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Wait until an Elasticsearch cluster answers HTTP 200 on GET / with API key auth.
+# Used in CI before cloud integration tests to wake up cold Elastic Cloud deployments.
+set -euo pipefail
+
+CLUSTER_URL="${TESTS_CLUSTER_URL:?TESTS_CLUSTER_URL is required}"
+API_KEY="${TESTS_CLUSTER_APIKEY:?TESTS_CLUSTER_APIKEY is required}"
+MAX_DURATION_SECONDS="${TESTS_CLUSTER_WARMUP_SECONDS:-300}"
+
+CLUSTER_URL="${CLUSTER_URL%/}"
+
+start_time=$(date +%s)
+delay=1
+
+echo "Warming up Elasticsearch cluster (max ${MAX_DURATION_SECONDS}s)..."
+
+while true; do
+  now=$(date +%s)
+  elapsed=$((now - start_time))
+  if [ "$elapsed" -ge "$MAX_DURATION_SECONDS" ]; then
+    echo "ERROR: Cluster root endpoint did not return HTTP 200 within ${MAX_DURATION_SECONDS}s."
+    exit 1
+  fi
+
+  http_code=$(curl -sS -o /dev/null -w "%{http_code}" \
+    -H "Authorization: ApiKey ${API_KEY}" \
+    "${CLUSTER_URL}/" 2>/dev/null || echo "000")
+
+  if [ "$http_code" = "200" ]; then
+    echo "Cluster is ready (HTTP 200) after ${elapsed}s."
+    exit 0
+  fi
+
+  echo "Root endpoint returned HTTP ${http_code}. Cluster might still be cold. Retrying in ${delay}s..."
+  sleep "$delay"
+  delay=$((delay * 2))
+  if [ "$delay" -gt 10 ]; then
+    delay=10
+  fi
+done

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -107,6 +107,12 @@ jobs:
       - name: Fetch base branch for Spotless ratchet
         if: ${{ env.ELASTIC_CLOUD_APIKEY && env.ELASTIC_CLOUD_URL }}
         run: git fetch origin master --depth=1
+      - name: Warm up Elastic Cloud cluster
+        if: ${{ env.ELASTIC_CLOUD_APIKEY && env.ELASTIC_CLOUD_URL }}
+        env:
+          TESTS_CLUSTER_URL: ${{ secrets.ELASTIC_CLOUD_URL }}
+          TESTS_CLUSTER_APIKEY: ${{ secrets.ELASTIC_CLOUD_APIKEY }}
+        run: bash .github/scripts/warm-up-elasticsearch.sh
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         if: ${{ env.ELASTIC_CLOUD_APIKEY && env.ELASTIC_CLOUD_URL }}
@@ -138,6 +144,12 @@ jobs:
       - name: Fetch base branch for Spotless ratchet
         if: ${{ env.ELASTIC_SERVERLESS_APIKEY && env.ELASTIC_SERVERLESS_URL }}
         run: git fetch origin master --depth=1
+      - name: Warm up Elastic Cloud Serverless cluster
+        if: ${{ env.ELASTIC_SERVERLESS_APIKEY && env.ELASTIC_SERVERLESS_URL }}
+        env:
+          TESTS_CLUSTER_URL: ${{ secrets.ELASTIC_SERVERLESS_URL }}
+          TESTS_CLUSTER_APIKEY: ${{ secrets.ELASTIC_SERVERLESS_APIKEY }}
+        run: bash .github/scripts/warm-up-elasticsearch.sh
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         if: ${{ env.ELASTIC_SERVERLESS_APIKEY && env.ELASTIC_SERVERLESS_URL }}
@@ -173,6 +185,13 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
+      - name: Warm up Elastic Cloud cluster
+        if: ${{ env.ELASTIC_CLOUD_APIKEY && env.ELASTIC_CLOUD_URL }}
+        shell: bash
+        env:
+          TESTS_CLUSTER_URL: ${{ secrets.ELASTIC_CLOUD_URL }}
+          TESTS_CLUSTER_APIKEY: ${{ secrets.ELASTIC_CLOUD_APIKEY }}
+        run: bash .github/scripts/warm-up-elasticsearch.sh
       - name: Run the integration tests
         if: ${{ env.ELASTIC_CLOUD_APIKEY && env.ELASTIC_CLOUD_URL }}
         shell: bash


### PR DESCRIPTION
## Summary

- Add a reusable `.github/scripts/warm-up-elasticsearch.sh` script that polls `GET /` with API key auth until the cluster returns HTTP 200.
- Run this warm-up step before Maven integration tests in the `it-cloud`, `it-serverless`, and `it-windows` CI jobs.
- Use a 5-minute timeout with exponential backoff (1s → 10s) to handle cold Elastic Cloud deployments waking up.

## Context

Cloud IT jobs were failing when the Elastic Cloud proxy answered 404 on the root endpoint for longer than the 1-minute bootstrap retry inside `ElasticsearchClient`. Warming up the cluster in CI before starting Maven should reduce these flaky failures.

## Test plan

- [x] Verify `it-cloud` job logs show the warm-up step succeeding before integration tests start
- [x] Verify `it-windows` job runs the same warm-up step under bash
- [x] Confirm integration tests pass once the cluster is warm


Made with [Cursor](https://cursor.com)