### PR TITLE
Make document ID hash algorithm configurable

### DIFF
--- a/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
+++ b/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
@@ -257,7 +257,8 @@ public class FsCrawlerCli {
                     "Created job [{}] with [fs.hash_algorithm={}] in the example settings. "
                             + "Existing jobs without this setting keep MD5. "
                             + "Changing the algorithm later changes every document _id and requires a full reindex.",
-                    jobName, settings.getFs().getHashAlgorithm());
+                    jobName,
+                    settings.getFs().getHashAlgorithm());
             if (logger.isDebugEnabled()) {
                 logger.debug("Created job [{}] with settings: [{}]", jobName, FsSettingsParser.toYaml(settings));
             }

--- a/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
+++ b/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
@@ -252,11 +252,15 @@ public class FsCrawlerCli {
             logger.debug(
                     "Creating [{}] from the classloader [{}] file.", configFile, FsSettingsLoader.EXAMPLE_SETTINGS);
             FsCrawlerUtil.copyResourceFile(FsSettingsLoader.EXAMPLE_SETTINGS, configFile);
+            FsSettings settings = FsSettingsLoader.load(configFile);
             logger.info(
-                    "Created job [{}] with fs.hash_algorithm=SHA-256 in the example settings. "
+                    "Created job [{}] with [fs.hash_algorithm={}] in the example settings. "
                             + "Existing jobs without this setting keep MD5. "
                             + "Changing the algorithm later changes every document _id and requires a full reindex.",
-                    jobName);
+                    jobName, settings.getFs().getHashAlgorithm());
+            if (logger.isDebugEnabled()) {
+                logger.debug("Created job [{}] with settings: [{}]", jobName, FsSettingsParser.toYaml(settings));
+            }
         }
     }
 

--- a/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
+++ b/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
@@ -252,6 +252,11 @@ public class FsCrawlerCli {
             logger.debug(
                     "Creating [{}] from the classloader [{}] file.", configFile, FsSettingsLoader.EXAMPLE_SETTINGS);
             FsCrawlerUtil.copyResourceFile(FsSettingsLoader.EXAMPLE_SETTINGS, configFile);
+            logger.info(
+                    "Created job [{}] with fs.hash_algorithm=SHA-256 in the example settings. "
+                            + "Existing jobs without this setting keep MD5. "
+                            + "Changing the algorithm later changes every document _id and requires a full reindex.",
+                    jobName);
         }
     }
 

--- a/cli/src/test/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCliTest.java
+++ b/cli/src/test/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCliTest.java
@@ -189,6 +189,12 @@ class FsCrawlerCliTest extends AbstractFSCrawlerTestCase {
         Path jobDir = metadataDir.resolve(jobName);
         Assertions.assertThat(jobDir).exists();
         Assertions.assertThat(jobDir.resolve(FsSettingsLoader.SETTINGS_YAML)).exists();
+
+        FsSettings settings = new FsSettingsLoader(metadataDir).read(jobName);
+        Assertions.assertThat(settings.getFs().getHashAlgorithm()).isEqualTo("SHA-256");
+        Assertions.assertThat(Files.readString(jobDir.resolve(FsSettingsLoader.SETTINGS_YAML)))
+                .contains("hash_algorithm: \"SHA-256\"")
+                .containsPattern("(?m)^fs:\\s*$");
     }
 
     @Test

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParser.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParser.java
@@ -349,7 +349,7 @@ public class FsParser implements Runnable, AutoCloseable {
                         throw new RuntimeException(url + " doesn't exists.");
                     }
 
-                    String rootPathId = SignTool.sign(url);
+                    String rootPathId = sign(url);
                     stats.setRootPathId(rootPathId);
 
                     // We need to round that latest date to the lower second and remove 2 seconds.
@@ -1304,7 +1304,7 @@ public class FsParser implements Runnable, AutoCloseable {
 
                 // Path
                 // Encoded version of the dir this file belongs to
-                doc.getPath().setRoot(SignTool.sign(dirname));
+                doc.getPath().setRoot(sign(dirname));
                 // The virtual URL (not including the initial root dir)
                 doc.getPath().setVirtual(FsCrawlerUtil.computeVirtualPathName(stats.getRootPath(), fullFilename));
                 // The real and complete filename
@@ -1458,7 +1458,11 @@ public class FsParser implements Runnable, AutoCloseable {
         String idSource = filepathForId.endsWith("/")
                 ? filepathForId.concat(filenameForId)
                 : filepathForId.concat("/").concat(filenameForId);
-        return fsSettings.getFs().isFilenameAsId() ? filename : SignTool.sign(idSource);
+        return fsSettings.getFs().isFilenameAsId() ? filename : sign(idSource);
+    }
+
+    private String sign(String toSign) throws NoSuchAlgorithmException {
+        return SignTool.sign(fsSettings.getFs().getHashAlgorithm(), toSign);
     }
 
     /**
@@ -1500,7 +1504,7 @@ public class FsParser implements Runnable, AutoCloseable {
 
         Folder folder = new Folder(
                 name,
-                SignTool.sign(rootdir),
+                sign(rootdir),
                 path,
                 FsCrawlerUtil.computeVirtualPathName(rootPath, path),
                 FsCrawlerUtil.getCreationTime(folderInfo),
@@ -1532,7 +1536,7 @@ public class FsParser implements Runnable, AutoCloseable {
             }
         }
 
-        indexDirectory(SignTool.sign(path), folder);
+        indexDirectory(sign(path), folder);
     }
 
     /** Remove a full directory and sub dirs recursively */
@@ -1551,7 +1555,7 @@ public class FsParser implements Runnable, AutoCloseable {
             removeEsDirectoryRecursively(esfolder, stats);
         }
 
-        esDelete(managementService, fsSettings.getElasticsearch().getIndexFolder(), SignTool.sign(path));
+        esDelete(managementService, fsSettings.getElasticsearch().getIndexFolder(), sign(path));
     }
 
     /** Remove a document with the document service */

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerManagementServiceElasticsearchImpl.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerManagementServiceElasticsearchImpl.java
@@ -80,7 +80,9 @@ public class FsCrawlerManagementServiceElasticsearchImpl implements FsCrawlerMan
     public Collection<String> getFileDirectory(String path) throws Exception {
 
         if (logger.isTraceEnabled()) {
-            logger.trace("Querying elasticsearch for files in dir [path.root:{}]", SignTool.sign(path));
+            logger.trace(
+                    "Querying elasticsearch for files in dir [path.root:{}]",
+                    SignTool.sign(settings.getFs().getHashAlgorithm(), path));
         }
 
         Collection<String> files = new ArrayList<>();
@@ -91,7 +93,8 @@ public class FsCrawlerManagementServiceElasticsearchImpl implements FsCrawlerMan
                     .withIndex(settings.getElasticsearch().getIndex())
                     .withSize(REQUEST_SIZE)
                     .addStoredField(FILE_FILENAME_FIELD)
-                    .withESQuery(new ESTermQuery("path.root", SignTool.sign(path))));
+                    .withESQuery(new ESTermQuery(
+                            "path.root", SignTool.sign(settings.getFs().getHashAlgorithm(), path))));
 
             if (response.getHits() != null) {
                 for (ESSearchHit hit : response.getHits()) {
@@ -130,7 +133,8 @@ public class FsCrawlerManagementServiceElasticsearchImpl implements FsCrawlerMan
             ESSearchResponse response = client.search(new ESSearchRequest()
                     .withIndex(settings.getElasticsearch().getIndexFolder())
                     .withSize(REQUEST_SIZE) // TODO: WHAT? DID I REALLY WROTE THAT? :p
-                    .withESQuery(new ESTermQuery("path.root", SignTool.sign(path))));
+                    .withESQuery(new ESTermQuery(
+                            "path.root", SignTool.sign(settings.getFs().getHashAlgorithm(), path))));
 
             if (response.getHits() != null) {
                 for (ESSearchHit hit : response.getHits()) {

--- a/docs/source/admin/fs/document-ids.md
+++ b/docs/source/admin/fs/document-ids.md
@@ -1,0 +1,69 @@
+(document-ids)=
+# Document IDs
+
+```{contents}
+:backlinks: entry
+```
+
+```{versionadded} 3.0
+```
+
+By default, FSCrawler derives the Elasticsearch document `_id` by hashing the file path
+(and similarly hashes folder paths and `path.root` values used for housekeeping queries).
+You can control the digest algorithm with `fs.hash_algorithm`, or skip hashing entirely with
+`fs.filename_as_id`.
+
+See also {ref}`filename-as-id` and {ref}`rest-document-id`.
+
+## `fs.hash_algorithm`
+
+| Name                 | Environment Variable           | Default when unset | New jobs (`--setup`) |
+|----------------------|--------------------------------|--------------------|----------------------|
+| `fs.hash_algorithm`  | `FSCRAWLER_FS_HASH_ALGORITHM`  | `MD5`              | `SHA-256`            |
+
+Any algorithm supported by Java `MessageDigest` is accepted (for example `MD5`, `SHA-1`,
+`SHA-256`). Invalid names disable the crawler at startup.
+
+```yaml
+name: "test"
+fs:
+  url: "/path/to/data/dir"
+  hash_algorithm: "SHA-256"
+```
+
+### Defaults and compatibility
+
+* **Existing jobs** that do not set `fs.hash_algorithm` keep **`MD5`**, including the historical
+  encoding used for document `_id`s, so upgrading FSCrawler does not rewrite existing ids.
+* **New jobs** created with `fscrawler --setup` get an example `_settings.yaml` with
+  `hash_algorithm: "SHA-256"`.
+
+`fs.hash_algorithm` is independent from `fs.checksum`. The latter hashes **file content** for the
+`file.checksum` field; `fs.hash_algorithm` only affects document and folder `_id`s (and related
+`path.root` hashes).
+
+When `fs.filename_as_id` is `true`, the raw filename is used as `_id` and `fs.hash_algorithm` is
+ignored.
+
+The same setting applies to the crawler and to the REST `_document` endpoint when an id is not
+provided explicitly.
+
+## Changing the algorithm (reindex checklist)
+
+Changing `fs.hash_algorithm` (or switching between hashed ids and `filename_as_id`) produces
+**new `_id`s** for the same files. FSCrawler will treat them as new documents unless you start
+from a clean index. There is no automatic id-migration tool.
+
+Recommended steps:
+
+1. Stop FSCrawler.
+2. Create a **new** Elasticsearch index (or delete / empty the existing documents and folder index).
+3. Update `fs.hash_algorithm` in `_settings.yaml` (or remove it to fall back to `MD5`).
+4. Optionally point `elasticsearch.index` / `elasticsearch.index_folder` at the new indices.
+5. Restart with `--restart` so the checkpoint is cleared and the filesystem is fully re-scanned.
+6. After verification, remove the old index or update aliases.
+7. Remember that `path.root` and folder documents are hashed with the same algorithm; they must
+   stay consistent with file documents.
+
+See also the Elasticsearch [Reindex API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-reindex)
+if you need to copy other data between indices.

--- a/docs/source/admin/fs/local-fs.md
+++ b/docs/source/admin/fs/local-fs.md
@@ -23,6 +23,7 @@ Here is a list of Local FS settings (under `fs.` prefix):
 | `fs.acl_support`         | `FSCRAWLER_FS_ACL_SUPPORT`         | `false`         | [Collecting ACL metadata](#collecting-acl-metadata)     |
 | `fs.raw_metadata`        | `FSCRAWLER_FS_RAW_METADATA`        | `false`         | [Enabling raw metadata](#enabling-raw-metadata)         |
 | `fs.filename_as_id`      | `FSCRAWLER_FS_FILENAME_AS_ID`      | `false`         | {ref}`filename-as-id`                                   |
+| `fs.hash_algorithm`      | `FSCRAWLER_FS_HASH_ALGORITHM`      | `"MD5"`         | {ref}`document-ids`                                     |
 | `fs.add_filesize`        | `FSCRAWLER_FS_ADD_FILESIZE`        | `true`          | [Disabling file size field](#disabling-file-size-field) |
 | `fs.remove_deleted`      | `FSCRAWLER_FS_REMOVE_DELETED`      | `true`          | [Ignore deleted files](#ignore-deleted-files)           |
 | `fs.store_source`        | `FSCRAWLER_FS_STORE_SOURCE`        | `false`         | {ref}`store_binary`                                     |
@@ -401,9 +402,8 @@ elasticsearch:
 (filename-as-id)=
 ## Using filename as elasticsearch `_id`
 
-Please note that the document `_id` is generated as a hash value
-from the filename to avoid issues with special characters in filename.
-You can force to use the `_id` to be the filename using
+Please note that by default the document `_id` is generated as a hash of the file path
+(see {ref}`document-ids`). You can force the `_id` to be the filename using the
 `filename_as_id` attribute:
 
 ```yaml
@@ -411,6 +411,8 @@ name: "test"
 fs:
   filename_as_id: true
 ```
+
+When `filename_as_id` is `true`, `fs.hash_algorithm` is ignored.
 
 ## Adding file attributes
 

--- a/docs/source/admin/fs/rest.md
+++ b/docs/source/admin/fs/rest.md
@@ -421,11 +421,12 @@ echo "This is my text" > test.txt
 curl -F "file=@test.txt" "http://127.0.0.1:8080/_document?debug=true&simulate=true"
 ```
 
+(rest-document-id)=
 ## Document ID
 
-By default, FSCrawler encodes the filename to generate an id. Which
-means that if you send 2 files with the same filename `test.txt`, the
-second one will overwrite the first one because they will both share the
+By default, FSCrawler hashes the filename to generate an id, using `fs.hash_algorithm`
+(see {ref}`document-ids`). Which means that if you send 2 files with the same filename
+`test.txt`, the second one will overwrite the first one because they will both share the
 same ID.
 
 You can force any id you wish by adding `id=YOUR_ID` as a parameter:

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -62,6 +62,7 @@ admin/otel
 admin/fs/index
 admin/fs/simple
 admin/fs/local-fs
+admin/fs/document-ids
 admin/fs/tags
 admin/fs/ssh
 admin/fs/ftp

--- a/docs/source/release/3.0.md
+++ b/docs/source/release/3.0.md
@@ -15,6 +15,9 @@
 - We don't support anymore the `elasticsearch.nodes.url` setting. You need to use `elasticsearch.urls`
   instead. Thanks to dadoonet.
 - The `_upload` REST endpoint has been removed. Please now use the `_document` endpoint. Thanks to dadoonet.
+- New jobs created with `--setup` set `fs.hash_algorithm` to `SHA-256` in the example settings. Existing jobs that
+  omit the setting keep `MD5` so document `_id`s stay unchanged. Changing the algorithm later requires a full
+  reindex. See {ref}`document-ids`. Closes [#2425](https://github.com/dadoonet/fscrawler/issues/2425). Thanks to dadoonet.
 
 ## New
 
@@ -49,6 +52,8 @@
 - Add support for pause/resume functionality with checkpoint persistence. The crawler can now be paused and resumed
   without losing progress. It also automatically recovers from network errors with exponential backoff retry.
   See {ref}`rest-service`. Thanks to dadoonet.
+- Document `_id` hashing is configurable via `fs.hash_algorithm` (any Java `MessageDigest` algorithm). See
+  {ref}`document-ids`. Closes [#2425](https://github.com/dadoonet/fscrawler/issues/2425). Thanks to dadoonet.
 
 ## Fix
 

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/Digests.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/Digests.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
+ */
+package fr.pilato.elasticsearch.crawler.fs.framework;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * Helpers around {@link MessageDigest} algorithms used for content checksums ({@code fs.checksum}) and document
+ * {@code _id} generation ({@code fs.hash_algorithm}).
+ */
+public final class Digests {
+
+    private Digests() {
+        // Utility class, do not instantiate
+    }
+
+    /** @return {@code true} if {@code algorithm} is a known {@link MessageDigest} name */
+    public static boolean isSupported(String algorithm) {
+        if (algorithm == null) {
+            return false;
+        }
+        try {
+            MessageDigest.getInstance(algorithm);
+            return true;
+        } catch (NoSuchAlgorithmException e) {
+            return false;
+        }
+    }
+
+    /**
+     * @param algorithm a {@link MessageDigest} algorithm name (must not be {@code null})
+     * @return a new digest instance
+     * @throws NoSuchAlgorithmException if the algorithm is unknown
+     */
+    public static MessageDigest get(String algorithm) throws NoSuchAlgorithmException {
+        return MessageDigest.getInstance(algorithm);
+    }
+
+    /**
+     * Like {@link #get(String)} but returns {@code null} when {@code algorithm} is {@code null}. Unknown algorithms
+     * raise {@link IllegalArgumentException} (expected after startup validation).
+     *
+     * @param algorithm digest name, or {@code null} when no digest is requested
+     * @return a new digest instance, or {@code null}
+     */
+    public static MessageDigest getOrNull(String algorithm) {
+        if (algorithm == null) {
+            return null;
+        }
+        try {
+            return get(algorithm);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalArgumentException(
+                    "Algorithm [" + algorithm + "] not found. This should never happen as we checked that previously",
+                    e);
+        }
+    }
+
+    /** Standard zero-padded lowercase hexadecimal encoding of {@code digest} bytes. */
+    public static String toHex(byte[] digest) {
+        StringBuilder result = new StringBuilder(digest.length * 2);
+        for (byte aDigest : digest) {
+            result.append(Integer.toString((aDigest & 0xff) + 0x100, 16).substring(1));
+        }
+        return result.toString();
+    }
+}

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/SignTool.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/SignTool.java
@@ -20,48 +20,78 @@
  */
 package fr.pilato.elasticsearch.crawler.fs.framework;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 /**
- * Utility class to sign *things*
+ * Utility class to sign *things* (typically file paths used as Elasticsearch document {@code _id}s).
  *
  * @author David Pilato (aka dadoonet)
  */
 public class SignTool {
+
+    /** Default algorithm for document ids when {@code fs.hash_algorithm} is unset (backward compatible). */
+    public static final String DEFAULT_ALGORITHM = "MD5";
 
     private SignTool() {
         // Utility class, do not instantiate
     }
 
     /**
-     * Signs the given input by computing an MD5 digest of its bytes.
+     * Signs the given input by computing an MD5 digest of its bytes using the legacy encoding.
      *
-     * <p>The resulting hash is used as the Elasticsearch document {@code _id}. MD5 is kept here only as a
-     * non-cryptographic checksum: it is <strong>not</strong> used in a security-sensitive context. Changing the
-     * algorithm would change every generated {@code _id} and force a full reindex, so MD5 remains the default for
-     * backward compatibility.
+     * <p>Prefer {@link #sign(String, String)} with {@code fs.hash_algorithm}.
      *
      * @param toSign the value to hash (e.g. a file path)
      * @return the hexadecimal MD5 digest of {@code toSign}
      * @throws NoSuchAlgorithmException if the MD5 algorithm is not available
-     * @deprecated the hash algorithm should become configurable; this hard-coded MD5 variant is kept for backward
-     *     compatibility. See <a href="https://github.com/dadoonet/fscrawler/issues/2425">#2425</a>.
+     * @deprecated use {@link #sign(String, String)} with a configurable algorithm; this hard-coded MD5 variant is kept
+     *     for backward compatibility. See <a href="https://github.com/dadoonet/fscrawler/issues/2425">#2425</a>.
      */
     @Deprecated(since = "3.0")
-    @SuppressWarnings("java:S4790") // MD5 is a non-cryptographic checksum used to derive document ids, not for security
     public static String sign(String toSign) throws NoSuchAlgorithmException {
+        return sign(DEFAULT_ALGORITHM, toSign);
+    }
 
-        MessageDigest md = MessageDigest.getInstance("MD5");
-        md.update(toSign.getBytes());
+    /**
+     * Signs {@code toSign} with the given {@link MessageDigest} algorithm.
+     *
+     * <p>For {@code MD5}, bytes are taken with the platform default charset and encoded with the historical non-padded
+     * hex format so existing document {@code _id}s stay stable. For any other algorithm, bytes are UTF-8 and the hex
+     * form is standard zero-padded lowercase.
+     *
+     * @param algorithm digest algorithm name (e.g. {@code MD5}, {@code SHA-256})
+     * @param toSign the value to hash (e.g. a file path)
+     * @return hexadecimal digest used as document {@code _id}
+     * @throws NoSuchAlgorithmException if {@code algorithm} is not available
+     */
+    @SuppressWarnings("java:S4790") // MD5 is a non-cryptographic checksum used to derive document ids, not for security
+    public static String sign(String algorithm, String toSign) throws NoSuchAlgorithmException {
+        boolean legacyMd5 = DEFAULT_ALGORITHM.equalsIgnoreCase(algorithm);
+        Charset charset = legacyMd5 ? Charset.defaultCharset() : StandardCharsets.UTF_8;
 
+        MessageDigest md = Digests.get(algorithm);
+        md.update(toSign.getBytes(charset));
+        byte[] digest = md.digest();
+
+        if (legacyMd5) {
+            return toLegacyHex(digest);
+        }
+        return Digests.toHex(digest);
+    }
+
+    /**
+     * Historical FSCrawler hex encoding: no zero-padding ({@code 0x0A} → {@code "a"}), unsigned via {@code 256 + b} for
+     * negative bytes.
+     */
+    private static String toLegacyHex(byte[] digest) {
         StringBuilder key = new StringBuilder();
-        byte[] b = md.digest();
-        for (byte aB : b) {
+        for (byte aB : digest) {
             long t = aB < 0 ? 256 + aB : aB;
             key.append(Long.toHexString(t));
         }
-
         return key.toString();
     }
 }

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/SignTool.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/SignTool.java
@@ -32,27 +32,11 @@ import java.security.NoSuchAlgorithmException;
  */
 public class SignTool {
 
-    /** Default algorithm for document ids when {@code fs.hash_algorithm} is unset (backward compatible). */
-    public static final String DEFAULT_ALGORITHM = "MD5";
+    /** Default legacy algorithm for document ids when {@code fs.hash_algorithm} is unset (backward compatible). */
+    public static final String LEGACY_MD5_ALGORITHM = "MD5";
 
     private SignTool() {
         // Utility class, do not instantiate
-    }
-
-    /**
-     * Signs the given input by computing an MD5 digest of its bytes using the legacy encoding.
-     *
-     * <p>Prefer {@link #sign(String, String)} with {@code fs.hash_algorithm}.
-     *
-     * @param toSign the value to hash (e.g. a file path)
-     * @return the hexadecimal MD5 digest of {@code toSign}
-     * @throws NoSuchAlgorithmException if the MD5 algorithm is not available
-     * @deprecated use {@link #sign(String, String)} with a configurable algorithm; this hard-coded MD5 variant is kept
-     *     for backward compatibility. See <a href="https://github.com/dadoonet/fscrawler/issues/2425">#2425</a>.
-     */
-    @Deprecated(since = "3.0")
-    public static String sign(String toSign) throws NoSuchAlgorithmException {
-        return sign(DEFAULT_ALGORITHM, toSign);
     }
 
     /**
@@ -69,7 +53,7 @@ public class SignTool {
      */
     @SuppressWarnings("java:S4790") // MD5 is a non-cryptographic checksum used to derive document ids, not for security
     public static String sign(String algorithm, String toSign) throws NoSuchAlgorithmException {
-        boolean legacyMd5 = DEFAULT_ALGORITHM.equalsIgnoreCase(algorithm);
+        boolean legacyMd5 = LEGACY_MD5_ALGORITHM.equalsIgnoreCase(algorithm);
         Charset charset = legacyMd5 ? Charset.defaultCharset() : StandardCharsets.UTF_8;
 
         MessageDigest md = Digests.get(algorithm);

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/DigestsTest.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/DigestsTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
+ */
+package fr.pilato.elasticsearch.crawler.fs.framework;
+
+import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class DigestsTest extends AbstractFSCrawlerTestCase {
+
+    @Test
+    void isSupportedKnownAlgorithms() {
+        Assertions.assertThat(Digests.isSupported("MD5")).isTrue();
+        Assertions.assertThat(Digests.isSupported("SHA-256")).isTrue();
+    }
+
+    @Test
+    void isSupportedUnknownAlgorithm() {
+        Assertions.assertThat(Digests.isSupported("NOT-A-REAL-DIGEST")).isFalse();
+    }
+
+    @Test
+    void isSupportedNull() {
+        Assertions.assertThat(Digests.isSupported(null)).isFalse();
+    }
+
+    @Test
+    void getReturnsInstance() throws NoSuchAlgorithmException {
+        MessageDigest md = Digests.get("SHA-256");
+        Assertions.assertThat(md.getAlgorithm()).isEqualTo("SHA-256");
+    }
+
+    @Test
+    void getUnknownThrows() {
+        Assertions.assertThatThrownBy(() -> Digests.get("NOT-A-REAL-DIGEST"))
+                .isInstanceOf(NoSuchAlgorithmException.class);
+    }
+
+    @Test
+    void getOrNullWithNullReturnsNull() {
+        Assertions.assertThat(Digests.getOrNull(null)).isNull();
+    }
+
+    @Test
+    void getOrNullWithAlgorithmReturnsInstance() {
+        MessageDigest md = Digests.getOrNull("MD5");
+        Assertions.assertThat(md).isNotNull();
+        Assertions.assertThat(md.getAlgorithm()).isEqualTo("MD5");
+    }
+
+    @Test
+    void getOrNullUnknownThrowsUnchecked() {
+        Assertions.assertThatThrownBy(() -> Digests.getOrNull("NOT-A-REAL-DIGEST"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasCauseInstanceOf(NoSuchAlgorithmException.class);
+    }
+
+    @Test
+    void toHexStandardPadding() {
+        byte[] bytes = new byte[] {0x0A, (byte) 0xFF, 0x00};
+        Assertions.assertThat(Digests.toHex(bytes)).isEqualTo("0aff00");
+    }
+}

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/SignToolTest.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/SignToolTest.java
@@ -21,6 +21,8 @@
 package fr.pilato.elasticsearch.crawler.fs.framework;
 
 import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -28,8 +30,19 @@ import org.junit.jupiter.api.Test;
 class SignToolTest extends AbstractFSCrawlerTestCase {
 
     @Test
-    void sign() throws NoSuchAlgorithmException {
+    void signMd5LegacyCompat() throws NoSuchAlgorithmException {
         String signature = SignTool.sign("ABCD");
         Assertions.assertThat(signature).isEqualTo("cb8ca4a7bb5f9683c19133a84872ca7");
+        Assertions.assertThat(SignTool.sign("MD5", "ABCD")).isEqualTo(signature);
+    }
+
+    @Test
+    void signSha256Utf8StandardHex() throws NoSuchAlgorithmException {
+        MessageDigest expected = MessageDigest.getInstance("SHA-256");
+        expected.update("ABCD".getBytes(StandardCharsets.UTF_8));
+        String expectedHex = Digests.toHex(expected.digest());
+
+        Assertions.assertThat(SignTool.sign("SHA-256", "ABCD")).isEqualTo(expectedHex);
+        Assertions.assertThat(expectedHex).hasSize(64);
     }
 }

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/SignToolTest.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/SignToolTest.java
@@ -21,8 +21,6 @@
 package fr.pilato.elasticsearch.crawler.fs.framework;
 
 import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -31,18 +29,14 @@ class SignToolTest extends AbstractFSCrawlerTestCase {
 
     @Test
     void signMd5LegacyCompat() throws NoSuchAlgorithmException {
-        String signature = SignTool.sign("ABCD");
-        Assertions.assertThat(signature).isEqualTo("cb8ca4a7bb5f9683c19133a84872ca7");
-        Assertions.assertThat(SignTool.sign("MD5", "ABCD")).isEqualTo(signature);
+        Assertions.assertThat(SignTool.sign(SignTool.LEGACY_MD5_ALGORITHM, "ABCD"))
+                .isEqualTo("cb8ca4a7bb5f9683c19133a84872ca7");
     }
 
     @Test
     void signSha256Utf8StandardHex() throws NoSuchAlgorithmException {
-        MessageDigest expected = MessageDigest.getInstance("SHA-256");
-        expected.update("ABCD".getBytes(StandardCharsets.UTF_8));
-        String expectedHex = Digests.toHex(expected.digest());
-
-        Assertions.assertThat(SignTool.sign("SHA-256", "ABCD")).isEqualTo(expectedHex);
-        Assertions.assertThat(expectedHex).hasSize(64);
+        Assertions.assertThat(SignTool.sign("SHA-256", "ABCD"))
+                .isEqualTo("e12e115acf4552b2568b55e93cbd39394c4ef81c82447fafc997882a02d23677")
+                .hasSize(64);
     }
 }

--- a/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/DocumentApi.java
+++ b/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/DocumentApi.java
@@ -178,7 +178,8 @@ public class DocumentApi extends RestApi {
                             + "Either call DELETE /_document/ID or DELETE /_document?filename=foo.txt");
         }
 
-        return removeDocumentInDocumentService(SignTool.sign(filename), filename, index);
+        return removeDocumentInDocumentService(
+                SignTool.sign(settings.getFs().getHashAlgorithm(), filename), filename, index);
     }
 
     @Path("/{id}")
@@ -242,7 +243,8 @@ public class DocumentApi extends RestApi {
             if (settings.getFs().isFilenameAsId()) {
                 id = doc.getFile().getFilename();
             } else {
-                id = SignTool.sign(doc.getFile().getFilename());
+                id = SignTool.sign(
+                        settings.getFs().getHashAlgorithm(), doc.getFile().getFilename());
             }
         } else if (id.equals("_auto_")) {
             // We are using a specific id which tells us to generate a unique _id like elasticsearch does

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Fs.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Fs.java
@@ -100,7 +100,7 @@ public class Fs {
     @Nullable
     private String checksum;
 
-    @Config(defaultVal = SignTool.DEFAULT_ALGORITHM)
+    @Config(defaultVal = SignTool.LEGACY_MD5_ALGORITHM)
     private String hashAlgorithm;
 
     @Config(defaultVal = "true")

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Fs.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Fs.java
@@ -22,6 +22,7 @@ package fr.pilato.elasticsearch.crawler.fs.settings;
 
 import fr.pilato.elasticsearch.crawler.fs.framework.ByteSizeValue;
 import fr.pilato.elasticsearch.crawler.fs.framework.Percentage;
+import fr.pilato.elasticsearch.crawler.fs.framework.SignTool;
 import fr.pilato.elasticsearch.crawler.fs.framework.TimeValue;
 import jakarta.annotation.Nullable;
 import java.util.List;
@@ -98,6 +99,9 @@ public class Fs {
     @Config
     @Nullable
     private String checksum;
+
+    @Config(defaultVal = SignTool.DEFAULT_ALGORITHM)
+    private String hashAlgorithm;
 
     @Config(defaultVal = "true")
     private boolean indexFolders;
@@ -257,6 +261,14 @@ public class Fs {
         this.checksum = checksum;
     }
 
+    public String getHashAlgorithm() {
+        return hashAlgorithm;
+    }
+
+    public void setHashAlgorithm(String hashAlgorithm) {
+        this.hashAlgorithm = hashAlgorithm;
+    }
+
     public boolean isXmlSupport() {
         return xmlSupport;
     }
@@ -387,6 +399,7 @@ public class Fs {
                 && Objects.equals(filters, fs.filters)
                 && Objects.equals(indexedChars, fs.indexedChars)
                 && Objects.equals(checksum, fs.checksum)
+                && Objects.equals(hashAlgorithm, fs.hashAlgorithm)
                 && Objects.equals(ocr, fs.ocr)
                 && Objects.equals(ignoreAbove, fs.ignoreAbove)
                 && Objects.equals(tikaConfigPath, fs.tikaConfigPath)
@@ -415,6 +428,7 @@ public class Fs {
                 rawMetadata,
                 xmlSupport,
                 checksum,
+                hashAlgorithm,
                 indexFolders,
                 langDetect,
                 continueOnError,
@@ -445,7 +459,8 @@ public class Fs {
                 + aclSupport + ", rawMetadata="
                 + rawMetadata + ", xmlSupport="
                 + xmlSupport + ", checksum='"
-                + checksum + '\'' + ", indexFolders="
+                + checksum + '\'' + ", hashAlgorithm='"
+                + hashAlgorithm + '\'' + ", indexFolders="
                 + indexFolders + ", langDetect="
                 + langDetect + ", continueOnError="
                 + continueOnError + ", ocr="

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsCrawlerValidator.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsCrawlerValidator.java
@@ -20,10 +20,9 @@
  */
 package fr.pilato.elasticsearch.crawler.fs.settings;
 
+import fr.pilato.elasticsearch.crawler.fs.framework.Digests;
 import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil;
 import fr.pilato.elasticsearch.crawler.fs.framework.OsValidator;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import org.apache.logging.log4j.Logger;
 
 public class FsCrawlerValidator {
@@ -71,16 +70,21 @@ public class FsCrawlerValidator {
         }
 
         // Checking Checksum Algorithm
-        if (settings.getFs().getChecksum() != null) {
-            try {
-                MessageDigest.getInstance(settings.getFs().getChecksum());
-            } catch (NoSuchAlgorithmException e) {
-                // Non supported protocol
-                logger.error(
-                        "Algorithm [{}] not found. Disabling crawler",
-                        settings.getFs().getChecksum());
-                return true;
-            }
+        if (settings.getFs().getChecksum() != null
+                && !Digests.isSupported(settings.getFs().getChecksum())) {
+            logger.error(
+                    "Algorithm [{}] not found. Disabling crawler",
+                    settings.getFs().getChecksum());
+            return true;
+        }
+
+        // Checking document _id hash algorithm
+        if (settings.getFs().getHashAlgorithm() != null
+                && !Digests.isSupported(settings.getFs().getHashAlgorithm())) {
+            logger.error(
+                    "Hash algorithm [{}] not found. Disabling crawler",
+                    settings.getFs().getHashAlgorithm());
+            return true;
         }
 
         // Checking That we don't try to do both xml and json

--- a/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/settings/fscrawler-default.properties
+++ b/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/settings/fscrawler-default.properties
@@ -13,6 +13,7 @@ fs.attributes_support=false
 fs.acl_support=false
 fs.raw_metadata=false
 fs.filename_as_id=false
+fs.hash_algorithm=MD5
 fs.add_filesize=true
 fs.remove_deleted=true
 fs.store_source=false

--- a/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/settings/fscrawler-default.yaml
+++ b/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/settings/fscrawler-default.yaml
@@ -35,8 +35,14 @@
   # optional: do not send big files to TIKA
   #ignore_above: "512mb"
 
-  # optional: use MD5 from filename (instead of filename) if set to false
+  # optional: use filename as document _id instead of hashing the path
   #filename_as_id: true
+
+  # Algorithm used to derive Elasticsearch document _ids from file paths (any MessageDigest name).
+  # Changing this value changes every _id and requires a full reindex.
+  # When unset, FSCrawler defaults to MD5 for backward compatibility with existing jobs.
+  # New jobs created with --setup use SHA-256.
+  hash_algorithm: "SHA-256"
 
   # you may want to store (partial) content of the file (see indexed_chars)
   #index_content: true

--- a/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/settings/fscrawler-default.yaml
+++ b/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/settings/fscrawler-default.yaml
@@ -2,7 +2,7 @@
 #name: "test"
 
 # optional: set file system crawler parameters
-#fs:
+fs:
   # define a "local" file path crawler, if running inside a docker container this must be the path INSIDE the container
   #url: "/tmp/es"
   # optional: scan every 15 minutes for changes in url defined above

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsCrawlerValidatorTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsCrawlerValidatorTest.java
@@ -53,6 +53,16 @@ class FsCrawlerValidatorTest extends AbstractFSCrawlerTestCase {
         Assertions.assertThat(FsCrawlerValidator.validateSettings(logger, settings))
                 .isTrue();
 
+        // Checking document _id hash algorithm
+        settings = FsSettingsLoader.load();
+        Assertions.assertThat(settings.getFs().getHashAlgorithm()).isEqualTo("MD5");
+        settings.getFs().setHashAlgorithm("FSCRAWLER");
+        Assertions.assertThat(FsCrawlerValidator.validateSettings(logger, settings))
+                .isTrue();
+        settings.getFs().setHashAlgorithm("SHA-256");
+        Assertions.assertThat(FsCrawlerValidator.validateSettings(logger, settings))
+                .isFalse();
+
         // Checking protocol
         settings = FsSettingsLoader.load();
         settings.getServer().setProtocol("FSCRAWLER");

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsLoaderTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsLoaderTest.java
@@ -151,6 +151,7 @@ class FsSettingsLoaderTest extends AbstractFSCrawlerTestCase {
         expected.getFs().setIndexedChars(new Percentage(10000.0));
         expected.getFs().setRawMetadata(true);
         expected.getFs().setChecksum("MD5");
+        expected.getFs().setHashAlgorithm("MD5");
         expected.getFs().setIndexFolders(false);
         expected.getFs().setTikaConfigPath("/path/to/tika-config.xml");
         Ocr ocr = new Ocr();
@@ -225,6 +226,7 @@ class FsSettingsLoaderTest extends AbstractFSCrawlerTestCase {
         fs.setIndexContent(true);
         fs.setAddFilesize(true);
         fs.setIndexFolders(true);
+        fs.setHashAlgorithm("MD5");
 
         Ocr ocr = new Ocr();
         ocr.setEnabled(true);

--- a/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
+++ b/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
@@ -21,6 +21,7 @@
 package fr.pilato.elasticsearch.crawler.fs.tika;
 
 import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
+import fr.pilato.elasticsearch.crawler.fs.framework.Digests;
 import fr.pilato.elasticsearch.crawler.fs.framework.FSCrawlerLogger;
 import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerIllegalConfigurationException;
 import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil;
@@ -88,15 +89,7 @@ public class TikaDocParser {
     private static final long IN_MEMORY_THRESHOLD = 64L * 1024; // 64KB
 
     private static MessageDigest findMessageDigest(FsSettings fsSettings) {
-        if (fsSettings.getFs().getChecksum() != null) {
-            try {
-                return MessageDigest.getInstance(fsSettings.getFs().getChecksum());
-            } catch (NoSuchAlgorithmException e) {
-                throw new RuntimeException("This should never happen as we checked that previously");
-            }
-        } else {
-            return null;
-        }
+        return Digests.getOrNull(fsSettings.getFs().getChecksum());
     }
 
     /**
@@ -225,7 +218,9 @@ public class TikaDocParser {
                             FSCrawlerLogger.documentError(
                                     fsSettings.getFs().isFilenameAsId()
                                             ? doc.getFile().getFilename()
-                                            : SignTool.sign(doc.getPath().getReal()),
+                                            : SignTool.sign(
+                                                    fsSettings.getFs().getHashAlgorithm(),
+                                                    doc.getPath().getReal()),
                                     FsCrawlerUtil.computeVirtualPathName(
                                             fsSettings.getFs().getUrl(),
                                             doc.getPath().getReal()),
@@ -260,14 +255,7 @@ public class TikaDocParser {
                     }
 
                     if (messageDigest != null) {
-                        byte[] digest = messageDigest.digest();
-                        StringBuilder result = new StringBuilder();
-                        // Convert to Hexa
-                        for (byte aDigest : digest) {
-                            result.append(Integer.toString((aDigest & 0xff) + 0x100, 16)
-                                    .substring(1));
-                        }
-                        doc.getFile().setChecksum(result.toString());
+                        doc.getFile().setChecksum(Digests.toHex(messageDigest.digest()));
                     }
                     // File
 

--- a/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
+++ b/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
@@ -88,10 +88,6 @@ public class TikaDocParser {
      */
     private static final long IN_MEMORY_THRESHOLD = 64L * 1024; // 64KB
 
-    private static MessageDigest findMessageDigest(FsSettings fsSettings) {
-        return Digests.getOrNull(fsSettings.getFs().getChecksum());
-    }
-
     /**
      * Parses one document and fills the given {@link Doc} (content, metadata, checksum, attachment) according to this
      * job's settings.
@@ -138,7 +134,7 @@ public class TikaDocParser {
             // We also use a temp file when storeSource is enabled, so we can read the file twice
             // (once for Tika, once for storing as attachment).
             // For small files (below IN_MEMORY_THRESHOLD), we keep everything in memory to avoid disk I/O.
-            MessageDigest messageDigest = findMessageDigest(fsSettings);
+            MessageDigest messageDigest = Digests.getOrNull(fsSettings.getFs().getChecksum());
             boolean needsBuffering = messageDigest != null || fsSettings.getFs().isStoreSource();
             // Use in-memory only when we KNOW the file is small (filesize > 0 and <= threshold)
             // When filesize is unknown (-1 or 0), use temp file to be safe and avoid OOM


### PR DESCRIPTION
## Summary
- Introduce `fs.hash_algorithm` (any `MessageDigest` name) for Elasticsearch document `_id` / `path.root` hashing, with shared `Digests` helper used by validation, Tika checksums, and `SignTool`
- Keep **MD5** + legacy hex encoding as the runtime default for existing jobs; `--setup` example settings use **SHA-256**
- Document the setting, defaults, and reindex checklist on a dedicated page

Closes #2425.

## Test plan
- [x] `mvn test -pl framework -am -DskipIntegTests -Dtest=DigestsTest,SignToolTest`
- [x] `mvn test -pl settings -am -DskipIntegTests -Dtest=FsCrawlerValidatorTest`
- [ ] Spot-check `--setup` creates `_settings.yaml` with `hash_algorithm: SHA-256` and logs the INFO message
- [ ] Optional: crawl with default MD5 vs `SHA-256` and confirm `_id`s differ / MD5 matches pre-change behavior


Made with [Cursor](https://cursor.com)