### PR TITLE
fix bulk indexing of large JSON string values

### DIFF
--- a/elasticsearch-client/pom.xml
+++ b/elasticsearch-client/pom.xml
@@ -62,6 +62,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers-nginx</artifactId>
             <scope>test</scope>

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchEngine.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchEngine.java
@@ -20,7 +20,6 @@
  */
 package fr.pilato.elasticsearch.crawler.fs.client;
 
-import fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil;
 import fr.pilato.elasticsearch.crawler.fs.framework.bulk.Engine;
 import java.util.Locale;
 import org.apache.logging.log4j.LogManager;
@@ -61,9 +60,11 @@ public class ElasticsearchEngine
             }
             bulkRequest.append("}}\n");
             if (r instanceof ElasticsearchIndexOperation indexOp) {
-                bulkRequest
-                        .append(JsonUtil.serialize(JsonUtil.deserialize(indexOp.getJson(), Object.class)))
-                        .append("\n");
+                // NDJSON needs one JSON object per line. Pretty-printed documents may contain
+                // structural CR/LF; strip them without a Jackson round-trip (which rejects large
+                // string values via StreamReadConstraints). Valid JSON never has raw CR/LF inside
+                // strings — those must be escaped as \n / \r.
+                bulkRequest.append(toSingleLineJson(indexOp.getJson())).append("\n");
             }
             logger.trace("Adding to bulk request: {}", bulkRequest);
             ndjson.append(bulkRequest);
@@ -79,5 +80,18 @@ public class ElasticsearchEngine
             return new ElasticsearchBulkResponse(e);
         }
         return new ElasticsearchBulkResponse(response);
+    }
+
+    /**
+     * Collapse a JSON document onto a single line for NDJSON bulk requests.
+     *
+     * @param json JSON document, possibly pretty-printed
+     * @return the same JSON without raw CR/LF characters
+     */
+    static String toSingleLineJson(String json) {
+        if (json.indexOf('\n') < 0 && json.indexOf('\r') < 0) {
+            return json;
+        }
+        return json.replace("\r", "").replace("\n", "");
     }
 }

--- a/elasticsearch-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchEngineTest.java
+++ b/elasticsearch-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchEngineTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
+ */
+package fr.pilato.elasticsearch.crawler.fs.client;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import com.carrotsearch.randomizedtesting.jupiter.RandomizedTest;
+import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
+import fr.pilato.elasticsearch.crawler.fs.test.framework.VerySlow;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+/**
+ * Reproduces bulk indexing of documents whose JSON contains a single string value larger than Jackson's default
+ * {@code StreamReadConstraints} max string length (100_000_000 on Jackson 3.1.x). The payload binary is written under
+ * {@code target/} and must not be committed.
+ */
+@Execution(ExecutionMode.SAME_THREAD)
+class ElasticsearchEngineTest extends AbstractFSCrawlerTestCase {
+
+    private static final Logger logger = LogManager.getLogger();
+    private static final long MIN_PAYLOAD_BYTES = 150L * 1024 * 1024;
+    private static final long MAX_PAYLOAD_BYTES = 300L * 1024 * 1024;
+    private static final int WRITE_CHUNK = 1024 * 1024;
+
+    @Test
+    void bulkWithPrettyPrintedJson() throws Exception {
+        String prettyJson = """
+                {
+                  "foo": "bar",
+                  "note": "line1\\nline2",
+                  "nested": {
+                    "x": 1
+                  }
+                }
+                """;
+        Assertions.assertThat(prettyJson).contains("\n");
+
+        AtomicReference<String> capturedNdjson = new AtomicReference<>();
+        IElasticsearchClient client = mock(IElasticsearchClient.class);
+        doAnswer(invocation -> {
+                    capturedNdjson.set(invocation.getArgument(0));
+                    return "{\"errors\":false,\"items\":[{\"index\":{\"_index\":\"idx\",\"_id\":\"1\"}}]}";
+                })
+                .when(client)
+                .bulk(anyString());
+
+        ElasticsearchBulkRequest request = new ElasticsearchBulkRequest();
+        request.add(new ElasticsearchIndexOperation("idx", "1", null, prettyJson));
+
+        ElasticsearchBulkResponse response = new ElasticsearchEngine(client).bulk(request);
+
+        Assertions.assertThat(response.isErrors()).isFalse();
+        String ndjson = capturedNdjson.get();
+        String[] lines = ndjson.split("\n", -1);
+        // action meta + document + trailing empty segment after final \n
+        Assertions.assertThat(lines).hasSize(3);
+        Assertions.assertThat(lines[0]).startsWith("{\"index\":");
+        Assertions.assertThat(lines[1])
+                .doesNotContain("\r")
+                .contains("\"foo\": \"bar\"")
+                .contains("\"note\": \"line1\\nline2\"")
+                .contains("\"x\": 1");
+        Assertions.assertThat(lines[2]).isEmpty();
+    }
+
+    @Test
+    void toSingleLineJsonRemovesStructuralNewlinesOnly() {
+        String pretty = """
+                {
+                  "a": "b\\nc"
+                }
+                """;
+        Assertions.assertThat(ElasticsearchEngine.toSingleLineJson(pretty)).isEqualTo("{  \"a\": \"b\\nc\"}");
+        Assertions.assertThat(ElasticsearchEngine.toSingleLineJson("{\"a\":\"b\"}"))
+                .isEqualTo("{\"a\":\"b\"}");
+    }
+
+    @Test
+    @VerySlow
+    void bulkWithLargeJsonStringValue() throws Exception {
+        long payloadSize =
+                RandomizedTest.randomLongInRange(randomizedRandomForTests, MIN_PAYLOAD_BYTES, MAX_PAYLOAD_BYTES);
+        Path binary = Path.of("target", "large-bulk-payload-" + payloadSize + ".bin");
+        Files.createDirectories(binary.getParent());
+
+        logger.info("Generating binary payload of {} bytes at {}", payloadSize, binary.toAbsolutePath());
+        writeAsciiBinary(binary, payloadSize);
+
+        String json;
+        try {
+            json = buildJsonDocument(binary);
+            logger.info("Built JSON document of {} characters", json.length());
+
+            AtomicLong capturedNdjsonLength = new AtomicLong();
+            IElasticsearchClient client = mock(IElasticsearchClient.class);
+            doAnswer(invocation -> {
+                        String ndjson = invocation.getArgument(0);
+                        capturedNdjsonLength.set(ndjson.length());
+                        Assertions.assertThat(ndjson).startsWith("{\"index\":");
+                        Assertions.assertThat(ndjson).contains("\"content\":\"");
+                        return "{\"errors\":false,\"items\":[{\"index\":{\"_index\":\"idx\",\"_id\":\"1\"}}]}";
+                    })
+                    .when(client)
+                    .bulk(anyString());
+
+            ElasticsearchBulkRequest request = new ElasticsearchBulkRequest();
+            request.add(new ElasticsearchIndexOperation("idx", "1", null, json));
+
+            ElasticsearchEngine engine = new ElasticsearchEngine(client);
+            ElasticsearchBulkResponse response = engine.bulk(request);
+
+            Assertions.assertThat(response.isErrors()).isFalse();
+            Assertions.assertThat(response.hasFailures()).isFalse();
+            Assertions.assertThat(capturedNdjsonLength.get()).isGreaterThan(payloadSize);
+        } finally {
+            Files.deleteIfExists(binary);
+        }
+    }
+
+    private static void writeAsciiBinary(Path binary, long payloadSize) throws IOException {
+        byte[] chunk = new byte[WRITE_CHUNK];
+        Arrays.fill(chunk, (byte) 'x');
+        try (OutputStream out = Files.newOutputStream(binary)) {
+            long remaining = payloadSize;
+            while (remaining > 0) {
+                int n = (int) Math.min(chunk.length, remaining);
+                out.write(chunk, 0, n);
+                remaining -= n;
+            }
+        }
+    }
+
+    private static String buildJsonDocument(Path binary) throws IOException {
+        // Safe printable ASCII so the value needs no JSON escaping; one byte == one char.
+        String content = Files.readString(binary, StandardCharsets.ISO_8859_1);
+        return "{\"content\":\"" + content + "\"}";
+    }
+}


### PR DESCRIPTION
## Summary

- Bulk indexing no longer round-trips documents through Jackson `deserialize`/`serialize`, which failed when a single string field exceeded `StreamReadConstraints` max length (~20M on Jackson 2.x / 100M on Jackson 3.1.x).
- Pretty-printed JSON is still collapsed to one NDJSON line by stripping structural CR/LF only (valid JSON never has raw newlines inside strings).
- Adds unit tests for multiline JSON compaction and oversized payloads; `bulk_index_with_multiline_json` continues to pass.

## Test plan

- [x] `ElasticsearchEngineTest` (unit)
- [x] `ElasticsearchClientIT#bulk_index_with_multiline_json`

Closes #2442.


Made with [Cursor](https://cursor.com)