### PR TITLE
fix: wait on ACL size in aclChangeTriggersReindex

### DIFF
--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestAttributesIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestAttributesIT.java
@@ -45,9 +45,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
@@ -152,27 +150,22 @@ class FsCrawlerTestAttributesIT extends AbstractFsCrawlerITCase {
 
         DocumentContext initialDocument = fetchSingleDocument(fsSettings);
         int initialAclSize = readAclSize(initialDocument);
-        String initialIndexingDate = initialDocument.read("$.file.indexing_date");
 
         addCustomAclEntry(file);
 
-        AtomicReference<DocumentContext> updatedDocument = new AtomicReference<>();
+        // Wait on ACL size, not indexing_date: with updateRate=1s the crawler can reindex
+        // every run on Windows (scanDate = start-2s) before the ACL change is visible.
         Awaitility.await()
                 .atMost(60, TimeUnit.SECONDS)
-                .alias("Document should be reindexed when ACL metadata changes")
+                .alias("Document ACL size should increase when ACL metadata changes")
                 .pollInterval(ExponentialBackoffPollInterval.exponential(Duration.ofMillis(500), Duration.ofSeconds(5)))
                 .until(() -> {
                     try {
-                        DocumentContext current = fetchSingleDocument(fsSettings);
-                        updatedDocument.set(current);
-                        String currentIndexingDate = current.read("$.file.indexing_date");
-                        return !Objects.equals(initialIndexingDate, currentIndexingDate);
+                        return readAclSize(fetchSingleDocument(fsSettings)) > initialAclSize;
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     }
                 });
-
-        Assertions.assertThat(readAclSize(updatedDocument.get())).isGreaterThan(initialAclSize);
     }
 
     private DocumentContext fetchSingleDocument(FsSettings fsSettings) throws Exception {


### PR DESCRIPTION
## Summary
- Make `aclChangeTriggersReindex` wait for `attributes.acl` size to grow instead of only watching `indexing_date`.
- Avoids flaky Windows CI failures where `updateRate=1s` plus `scanDate = start-2s` causes mtime-driven reindexes that satisfy the old wait before the ACL change is indexed.

## Test plan
- [x] Re-run Windows IT job / `FsCrawlerTestAttributesIT#aclChangeTriggersReindex`
- [x] Confirm the test still passes on platforms with ACL support when an ACE is actually added


Made with [Cursor](https://cursor.com)