### PR TITLE
fix: declare Mockito as a Surefire javaagent

### DIFF
--- a/elasticsearch-client/pom.xml
+++ b/elasticsearch-client/pom.xml
@@ -103,12 +103,16 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
             </plugin>
-            <!-- Resolve ${org.mockito:mockito-core:jar} for the Surefire javaagent below (JDK 21+). -->
+            <!-- Resolve ${org.mockito:mockito-core:jar} for the Surefire javaagent below (JDK 21+).
+                 Bound to process-test-classes (not initialize) so mvn generate-resources stays clean
+                 on CI without pre-installed reactor SNAPSHOT jars. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>mockito-agent-path</id>
+                        <phase>process-test-classes</phase>
                         <goals>
                             <goal>properties</goal>
                         </goals>

--- a/elasticsearch-client/pom.xml
+++ b/elasticsearch-client/pom.xml
@@ -103,9 +103,25 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
             </plugin>
+            <!-- Resolve ${org.mockito:mockito-core:jar} for the Surefire javaagent below (JDK 21+). -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- Explicit agent: avoids Mockito self-attach (deprecated, will break on future JDKs). -->
+                    <argLine>-javaagent:${org.mockito:mockito-core:jar} -Xshare:off</argLine>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/elasticsearch-client/pom.xml
+++ b/elasticsearch-client/pom.xml
@@ -112,10 +112,10 @@
                 <executions>
                     <execution>
                         <id>mockito-agent-path</id>
-                        <phase>process-test-classes</phase>
                         <goals>
                             <goal>properties</goal>
                         </goals>
+                        <phase>process-test-classes</phase>
                     </execution>
                 </executions>
             </plugin>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -81,12 +81,16 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
             </plugin>
-            <!-- Resolve ${org.mockito:mockito-core:jar} for the Surefire javaagent below (JDK 21+). -->
+            <!-- Resolve ${org.mockito:mockito-core:jar} for the Surefire javaagent below (JDK 21+).
+                 Bound to process-test-classes (not initialize) so mvn generate-resources stays clean
+                 on CI without pre-installed reactor SNAPSHOT jars. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>mockito-agent-path</id>
+                        <phase>process-test-classes</phase>
                         <goals>
                             <goal>properties</goal>
                         </goals>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -90,10 +90,10 @@
                 <executions>
                     <execution>
                         <id>mockito-agent-path</id>
-                        <phase>process-test-classes</phase>
                         <goals>
                             <goal>properties</goal>
                         </goals>
+                        <phase>process-test-classes</phase>
                     </execution>
                 </executions>
             </plugin>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -81,9 +81,25 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
             </plugin>
+            <!-- Resolve ${org.mockito:mockito-core:jar} for the Surefire javaagent below (JDK 21+). -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- Explicit agent: avoids Mockito self-attach (deprecated, will break on future JDKs). -->
+                    <argLine>-javaagent:${org.mockito:mockito-core:jar} -Xshare:off</argLine>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary

- Declare Mockito's byte-buddy agent explicitly via Surefire `-javaagent` in `rest` and `elasticsearch-client` (the only modules that use Mockito).
- Removes the JDK 21+ self-attach / dynamic agent loading warnings and makes these tests future-JDK proof.
- Scoped per module (not parent) so modules without `mockito-core` keep a valid Surefire `argLine`.

## Test plan

- [x] `mvn -pl rest test -Dtest=CrawlerApiTest` — no Mockito self-attach warning; tests pass
- [x] `mvn -pl elasticsearch-client test -Dtest=ElasticsearchEngineTest#bulkWithPrettyPrintedJson` — same
- [x] `mvn -pl beans test` — unaffected module still OK

Closes #2426


Made with [Cursor](https://cursor.com)