### PR TITLE
fix: use Instant for checkpoints and document dates

### DIFF
--- a/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/File.java
+++ b/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/File.java
@@ -20,17 +20,17 @@
  */
 package fr.pilato.elasticsearch.crawler.fs.beans;
 
-import java.util.Date;
+import java.time.Instant;
 
 /** Represents File attributes */
 public class File {
 
     private String extension;
     private String contentType;
-    private Date created;
-    private Date lastModified;
-    private Date lastAccessed;
-    private Date indexingDate;
+    private Instant created;
+    private Instant lastModified;
+    private Instant lastAccessed;
+    private Instant indexingDate;
     private Long filesize;
     private String filename;
     private String url;
@@ -53,35 +53,35 @@ public class File {
         this.contentType = contentType;
     }
 
-    public Date getCreated() {
+    public Instant getCreated() {
         return created;
     }
 
-    public void setCreated(Date created) {
+    public void setCreated(Instant created) {
         this.created = created;
     }
 
-    public Date getLastModified() {
+    public Instant getLastModified() {
         return lastModified;
     }
 
-    public void setLastModified(Date lastModified) {
+    public void setLastModified(Instant lastModified) {
         this.lastModified = lastModified;
     }
 
-    public Date getLastAccessed() {
+    public Instant getLastAccessed() {
         return lastAccessed;
     }
 
-    public void setLastAccessed(Date lastAccessed) {
+    public void setLastAccessed(Instant lastAccessed) {
         this.lastAccessed = lastAccessed;
     }
 
-    public Date getIndexingDate() {
+    public Instant getIndexingDate() {
         return indexingDate;
     }
 
-    public void setIndexingDate(Date indexingDate) {
+    public void setIndexingDate(Instant indexingDate) {
         this.indexingDate = indexingDate;
     }
 

--- a/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/FileAbstractModel.java
+++ b/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/FileAbstractModel.java
@@ -21,7 +21,7 @@
 package fr.pilato.elasticsearch.crawler.fs.beans;
 
 import fr.pilato.elasticsearch.crawler.fs.framework.FileAcl;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 /**
@@ -32,9 +32,9 @@ public class FileAbstractModel {
     private final String name;
     private final boolean file;
     private final boolean directory;
-    private final LocalDateTime lastModifiedDate;
-    private final LocalDateTime creationDate;
-    private final LocalDateTime accessDate;
+    private final Instant lastModifiedDate;
+    private final Instant creationDate;
+    private final Instant accessDate;
     private final String path;
     private final String fullpath;
     private final long size;
@@ -48,9 +48,9 @@ public class FileAbstractModel {
     public FileAbstractModel(
             String name,
             boolean file,
-            LocalDateTime lastModifiedDate,
-            LocalDateTime creationDate,
-            LocalDateTime accessDate,
+            Instant lastModifiedDate,
+            Instant creationDate,
+            Instant accessDate,
             String extension,
             String path,
             String fullpath,
@@ -89,15 +89,15 @@ public class FileAbstractModel {
         return directory;
     }
 
-    public LocalDateTime getLastModifiedDate() {
+    public Instant getLastModifiedDate() {
         return lastModifiedDate;
     }
 
-    public LocalDateTime getCreationDate() {
+    public Instant getCreationDate() {
         return creationDate;
     }
 
-    public LocalDateTime getAccessDate() {
+    public Instant getAccessDate() {
         return accessDate;
     }
 

--- a/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/Folder.java
+++ b/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/Folder.java
@@ -20,8 +20,7 @@
  */
 package fr.pilato.elasticsearch.crawler.fs.beans;
 
-import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil;
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 /** Represents a folder we have visited */
 public class Folder {
@@ -54,9 +53,9 @@ public class Folder {
             String root,
             String real,
             String virtual,
-            LocalDateTime creation,
-            LocalDateTime modification,
-            LocalDateTime lastAccess) {
+            Instant creation,
+            Instant modification,
+            Instant lastAccess) {
         path = new Path();
         path.setRoot(root);
         path.setReal(real);
@@ -64,9 +63,9 @@ public class Folder {
         file = new File();
         file.setFilename(name);
         file.setContentType(CONTENT_TYPE);
-        file.setLastModified(FsCrawlerUtil.localDateTimeToDate(modification));
-        file.setCreated(FsCrawlerUtil.localDateTimeToDate(creation));
-        file.setLastAccessed(FsCrawlerUtil.localDateTimeToDate(lastAccess));
+        file.setLastModified(modification);
+        file.setCreated(creation);
+        file.setLastAccessed(lastAccess);
     }
 
     public Path getPath() {

--- a/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/FsCrawlerCheckpoint.java
+++ b/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/FsCrawlerCheckpoint.java
@@ -21,8 +21,7 @@
 package fr.pilato.elasticsearch.crawler.fs.beans;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.Iterator;
@@ -45,7 +44,7 @@ public class FsCrawlerCheckpoint {
     private String scanId;
 
     /** When this scan started */
-    private LocalDateTime scanStartTime;
+    private Instant scanStartTime;
 
     /** The directory currently being processed */
     private String currentPath;
@@ -91,13 +90,13 @@ public class FsCrawlerCheckpoint {
     private String lastError;
 
     /** The scan date used for comparison (to detect modified files) */
-    private LocalDateTime scanDate;
+    private Instant scanDate;
 
     /** When this scan was completed (replaces FsJob.lastrun) */
-    private LocalDateTime scanEndTime;
+    private Instant scanEndTime;
 
     /** When the next scan should run (replaces FsJob.nextCheck) */
-    private LocalDateTime nextCheck;
+    private Instant nextCheck;
 
     /**
      * When the crawler was interrupted (pause/close) while processing {@link #currentPath}, this is the number of files
@@ -161,7 +160,7 @@ public class FsCrawlerCheckpoint {
     public static FsCrawlerCheckpoint newCheckpoint(String rootPath) {
         FsCrawlerCheckpoint checkpoint = new FsCrawlerCheckpoint();
         checkpoint.setScanId(UUID.randomUUID().toString());
-        checkpoint.setScanStartTime(LocalDateTime.now(ZoneId.systemDefault()));
+        checkpoint.setScanStartTime(Instant.now());
         checkpoint.addPath(rootPath);
         checkpoint.setState(CrawlerState.RUNNING);
         return checkpoint;
@@ -177,11 +176,11 @@ public class FsCrawlerCheckpoint {
         this.scanId = scanId;
     }
 
-    public LocalDateTime getScanStartTime() {
+    public Instant getScanStartTime() {
         return scanStartTime;
     }
 
-    public void setScanStartTime(LocalDateTime scanStartTime) {
+    public void setScanStartTime(Instant scanStartTime) {
         this.scanStartTime = scanStartTime;
     }
 
@@ -280,27 +279,27 @@ public class FsCrawlerCheckpoint {
         this.lastError = lastError;
     }
 
-    public LocalDateTime getScanDate() {
+    public Instant getScanDate() {
         return scanDate;
     }
 
-    public void setScanDate(LocalDateTime scanDate) {
+    public void setScanDate(Instant scanDate) {
         this.scanDate = scanDate;
     }
 
-    public LocalDateTime getScanEndTime() {
+    public Instant getScanEndTime() {
         return scanEndTime;
     }
 
-    public void setScanEndTime(LocalDateTime scanEndTime) {
+    public void setScanEndTime(Instant scanEndTime) {
         this.scanEndTime = scanEndTime;
     }
 
-    public LocalDateTime getNextCheck() {
+    public Instant getNextCheck() {
         return nextCheck;
     }
 
-    public void setNextCheck(LocalDateTime nextCheck) {
+    public void setNextCheck(Instant nextCheck) {
         this.nextCheck = nextCheck;
     }
 

--- a/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/FsCrawlerCheckpointFileHandler.java
+++ b/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/FsCrawlerCheckpointFileHandler.java
@@ -103,7 +103,7 @@ public class FsCrawlerCheckpointFileHandler extends MetaFileHandler {
                 // Create a completed checkpoint from the legacy job.
                 // scanEndTime is required: loadOrCreateCheckpoint uses it (not scanDate) as the
                 // reference for the next scan when state is COMPLETED. Without it, we would fall
-                // back to LocalDateTime.MIN and trigger a full re-index.
+                // back to Instant.EPOCH and trigger a full re-index.
                 FsCrawlerCheckpoint migratedCheckpoint = new FsCrawlerCheckpoint();
                 migratedCheckpoint.setScanDate(legacyJob.getLastrun());
                 migratedCheckpoint.setScanEndTime(legacyJob.getLastrun());

--- a/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/FsJob.java
+++ b/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/FsJob.java
@@ -20,21 +20,21 @@
  */
 package fr.pilato.elasticsearch.crawler.fs.beans;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Objects;
 
 /** Define a FS Job meta data */
 public class FsJob {
 
     private String name;
-    private LocalDateTime lastrun;
-    private LocalDateTime nextCheck;
+    private Instant lastrun;
+    private Instant nextCheck;
     private long indexed;
     private long deleted;
 
     public FsJob() {}
 
-    public FsJob(String name, LocalDateTime lastrun, LocalDateTime nextCheck, long indexed, long deleted) {
+    public FsJob(String name, Instant lastrun, Instant nextCheck, long indexed, long deleted) {
         this.name = name;
         this.lastrun = lastrun;
         this.nextCheck = nextCheck;
@@ -50,19 +50,19 @@ public class FsJob {
         this.name = name;
     }
 
-    public LocalDateTime getLastrun() {
+    public Instant getLastrun() {
         return lastrun;
     }
 
-    public void setLastrun(LocalDateTime lastrun) {
+    public void setLastrun(Instant lastrun) {
         this.lastrun = lastrun;
     }
 
-    public LocalDateTime getNextCheck() {
+    public Instant getNextCheck() {
         return nextCheck;
     }
 
-    public void setNextCheck(LocalDateTime nextCheck) {
+    public void setNextCheck(Instant nextCheck) {
         this.nextCheck = nextCheck;
     }
 

--- a/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/Meta.java
+++ b/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/Meta.java
@@ -20,7 +20,7 @@
  */
 package fr.pilato.elasticsearch.crawler.fs.beans;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,7 +30,7 @@ public class Meta {
 
     private String author;
     private String title;
-    private Date date;
+    private Instant date;
     private List<String> keywords;
     private String language;
     private String format;
@@ -45,9 +45,9 @@ public class Meta {
     private String source;
     private String type;
     private String description;
-    private Date created;
-    private Date printDate;
-    private Date metadataDate;
+    private Instant created;
+    private Instant printDate;
+    private Instant metadataDate;
     private String latitude;
     private String longitude;
     private String altitude;
@@ -72,11 +72,11 @@ public class Meta {
         this.title = title;
     }
 
-    public Date getDate() {
+    public Instant getDate() {
         return date;
     }
 
-    public void setDate(Date date) {
+    public void setDate(Instant date) {
         this.date = date;
     }
 
@@ -207,27 +207,27 @@ public class Meta {
         this.description = description;
     }
 
-    public Date getCreated() {
+    public Instant getCreated() {
         return created;
     }
 
-    public void setCreated(Date created) {
+    public void setCreated(Instant created) {
         this.created = created;
     }
 
-    public Date getPrintDate() {
+    public Instant getPrintDate() {
         return printDate;
     }
 
-    public void setPrintDate(Date printDate) {
+    public void setPrintDate(Instant printDate) {
         this.printDate = printDate;
     }
 
-    public Date getMetadataDate() {
+    public Instant getMetadataDate() {
         return metadataDate;
     }
 
-    public void setMetadataDate(Date metadataDate) {
+    public void setMetadataDate(Instant metadataDate) {
         this.metadataDate = metadataDate;
     }
 

--- a/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/ScanStatistic.java
+++ b/beans/src/main/java/fr/pilato/elasticsearch/crawler/fs/beans/ScanStatistic.java
@@ -21,8 +21,7 @@
 package fr.pilato.elasticsearch.crawler.fs.beans;
 
 import java.time.Duration;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.Instant;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -35,8 +34,8 @@ public class ScanStatistic {
     private final AtomicInteger nbDocDeleted = new AtomicInteger();
     private String rootPath = "/";
     private String rootPathId;
-    private LocalDateTime startTime;
-    private LocalDateTime endTime;
+    private Instant startTime;
+    private Instant endTime;
 
     public ScanStatistic() {}
 
@@ -95,29 +94,28 @@ public class ScanStatistic {
     }
 
     /** @return the start time of the scan */
-    public LocalDateTime getStartTime() {
+    public Instant getStartTime() {
         return startTime;
     }
 
     /** @param startTime the start time to set */
-    public void setStartTime(LocalDateTime startTime) {
+    public void setStartTime(Instant startTime) {
         this.startTime = startTime;
     }
 
     /** @return the end time of the scan */
-    public LocalDateTime getEndTime() {
+    public Instant getEndTime() {
         return endTime;
     }
 
     /** @param endTime the end time to set */
-    public void setEndTime(LocalDateTime endTime) {
+    public void setEndTime(Instant endTime) {
         this.endTime = endTime;
     }
 
     public Duration computeDuration() {
         if (startTime != null && endTime != null) {
-            ZoneId zone = ZoneId.systemDefault();
-            return Duration.between(startTime.atZone(zone), endTime.atZone(zone));
+            return Duration.between(startTime, endTime);
         }
         return Duration.ZERO;
     }

--- a/beans/src/test/java/fr/pilato/elasticsearch/crawler/fs/beans/FsCrawlerCheckpointFileHandlerTest.java
+++ b/beans/src/test/java/fr/pilato/elasticsearch/crawler/fs/beans/FsCrawlerCheckpointFileHandlerTest.java
@@ -22,7 +22,7 @@ package fr.pilato.elasticsearch.crawler.fs.beans;
 
 import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
 import java.io.IOException;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -101,7 +101,7 @@ class FsCrawlerCheckpointFileHandlerTest extends AbstractFSCrawlerTestCase {
     void testCompleteCheckpointRoundTrip() throws IOException {
         FsCrawlerCheckpoint checkpoint = new FsCrawlerCheckpoint();
         checkpoint.setScanId("test-scan-id");
-        checkpoint.setScanStartTime(LocalDateTime.now());
+        checkpoint.setScanStartTime(Instant.now());
         checkpoint.setCurrentPath("/current");
         checkpoint.addPath("/pending1");
         checkpoint.addPath("/pending2");
@@ -112,7 +112,7 @@ class FsCrawlerCheckpointFileHandlerTest extends AbstractFSCrawlerTestCase {
         checkpoint.setState(CrawlerState.RUNNING);
         checkpoint.setRetryCount(3);
         checkpoint.setLastError("Some error");
-        checkpoint.setScanDate(LocalDateTime.now().minusDays(1));
+        checkpoint.setScanDate(Instant.now().minus(1, java.time.temporal.ChronoUnit.DAYS));
 
         handler.write(jobName, checkpoint);
 
@@ -134,8 +134,8 @@ class FsCrawlerCheckpointFileHandlerTest extends AbstractFSCrawlerTestCase {
         // Create a legacy _status.json file
         FsJobFileHandler legacyHandler = new FsJobFileHandler(testTmpDir);
         FsJob legacyJob = new FsJob();
-        legacyJob.setLastrun(LocalDateTime.now().minusHours(1));
-        legacyJob.setNextCheck(LocalDateTime.now().plusHours(1));
+        legacyJob.setLastrun(Instant.now().minus(1, java.time.temporal.ChronoUnit.HOURS));
+        legacyJob.setNextCheck(Instant.now().plus(1, java.time.temporal.ChronoUnit.HOURS));
         legacyJob.setIndexed(50);
         legacyJob.setDeleted(2);
         legacyHandler.write(jobName, legacyJob);

--- a/beans/src/test/java/fr/pilato/elasticsearch/crawler/fs/beans/FsCrawlerCheckpointTest.java
+++ b/beans/src/test/java/fr/pilato/elasticsearch/crawler/fs/beans/FsCrawlerCheckpointTest.java
@@ -24,7 +24,9 @@ import fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil;
 import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.assertj.core.api.Assertions;
@@ -56,7 +58,7 @@ class FsCrawlerCheckpointTest extends AbstractFSCrawlerTestCase {
     void parseCheckpointWithData() throws IOException {
         FsCrawlerCheckpoint checkpoint = new FsCrawlerCheckpoint();
         checkpoint.setScanId("test-scan-123");
-        checkpoint.setScanStartTime(LocalDateTime.now());
+        checkpoint.setScanStartTime(Instant.now());
         checkpoint.setCurrentPath("/current/path");
         checkpoint.addPath("/pending/path1");
         checkpoint.addPath("/pending/path2");
@@ -66,9 +68,9 @@ class FsCrawlerCheckpointTest extends AbstractFSCrawlerTestCase {
         checkpoint.setState(CrawlerState.RUNNING);
         checkpoint.setRetryCount(2);
         checkpoint.setLastError("Test error");
-        checkpoint.setScanDate(LocalDateTime.now().minusDays(1));
-        checkpoint.setScanEndTime(LocalDateTime.now());
-        checkpoint.setNextCheck(LocalDateTime.now().plusHours(1));
+        checkpoint.setScanDate(Instant.now().minus(1, java.time.temporal.ChronoUnit.DAYS));
+        checkpoint.setScanEndTime(Instant.now());
+        checkpoint.setNextCheck(Instant.now().plus(1, java.time.temporal.ChronoUnit.HOURS));
 
         checkpointTester(checkpoint);
     }
@@ -184,12 +186,12 @@ class FsCrawlerCheckpointTest extends AbstractFSCrawlerTestCase {
     /** Test that date serialization is stable */
     @Test
     void dateTimeSerialization() throws IOException {
-        LocalDateTime now = LocalDateTime.now();
+        Instant now = Instant.now();
         FsCrawlerCheckpoint checkpoint = new FsCrawlerCheckpoint();
         checkpoint.setScanStartTime(now);
         checkpoint.setScanDate(now);
         checkpoint.setScanEndTime(now);
-        checkpoint.setNextCheck(now.plusHours(1));
+        checkpoint.setNextCheck(now.plus(1, java.time.temporal.ChronoUnit.HOURS));
 
         String json = JsonUtil.prettyMapper.writeValueAsString(checkpoint);
         FsCrawlerCheckpoint generated = JsonUtil.prettyMapper.readValue(json, FsCrawlerCheckpoint.class);
@@ -197,7 +199,7 @@ class FsCrawlerCheckpointTest extends AbstractFSCrawlerTestCase {
         Assertions.assertThat(generated.getScanStartTime()).isEqualTo(now);
         Assertions.assertThat(generated.getScanDate()).isEqualTo(now);
         Assertions.assertThat(generated.getScanEndTime()).isEqualTo(now);
-        Assertions.assertThat(generated.getNextCheck()).isEqualTo(now.plusHours(1));
+        Assertions.assertThat(generated.getNextCheck()).isEqualTo(now.plus(1, java.time.temporal.ChronoUnit.HOURS));
     }
 
     /** Test completed checkpoint scenario (replaces FsJob) */
@@ -206,8 +208,8 @@ class FsCrawlerCheckpointTest extends AbstractFSCrawlerTestCase {
         FsCrawlerCheckpoint checkpoint = new FsCrawlerCheckpoint();
         checkpoint.setScanId("completed-scan-123");
         checkpoint.setState(CrawlerState.COMPLETED);
-        checkpoint.setScanEndTime(LocalDateTime.now());
-        checkpoint.setNextCheck(LocalDateTime.now().plusMinutes(15));
+        checkpoint.setScanEndTime(Instant.now());
+        checkpoint.setNextCheck(Instant.now().plus(15, java.time.temporal.ChronoUnit.MINUTES));
         checkpoint.setFilesProcessed(500);
         checkpoint.setFilesDeleted(10);
 
@@ -248,5 +250,39 @@ class FsCrawlerCheckpointTest extends AbstractFSCrawlerTestCase {
         Assertions.assertThat(checkpoint.getPendingPaths()).isNotNull();
         Assertions.assertThat(checkpoint.getCompletedPaths()).isNotNull();
         Assertions.assertThat(checkpoint.toString()).contains("pendingPaths=0").contains("completedPaths=0");
+    }
+
+    @Test
+    void legacy_local_date_time_checkpoint_deserializes_to_instant() throws IOException {
+        // Pre-3.0 checkpoints stored zone-less LocalDateTime strings.
+        String legacyJson = """
+                {
+                  "scan_id" : "legacy",
+                  "scan_start_time" : "2026-07-02T12:10:57",
+                  "scan_date" : "2026-07-02T12:10:55",
+                  "scan_end_time" : "2026-07-02T12:11:00",
+                  "next_check" : "2026-07-02T12:26:00",
+                  "state" : "COMPLETED",
+                  "files_processed" : 3,
+                  "files_deleted" : 0,
+                  "retry_count" : 0,
+                  "pending_paths" : [ ],
+                  "completed_paths" : [ ]
+                }
+                """;
+        FsCrawlerCheckpoint checkpoint = JsonUtil.prettyMapper.readValue(legacyJson, FsCrawlerCheckpoint.class);
+        ZoneId zone = ZoneId.systemDefault();
+        Assertions.assertThat(checkpoint.getScanStartTime())
+                .isEqualTo(
+                        LocalDateTime.parse("2026-07-02T12:10:57").atZone(zone).toInstant());
+        Assertions.assertThat(checkpoint.getScanDate())
+                .isEqualTo(
+                        LocalDateTime.parse("2026-07-02T12:10:55").atZone(zone).toInstant());
+        Assertions.assertThat(checkpoint.getScanEndTime())
+                .isEqualTo(
+                        LocalDateTime.parse("2026-07-02T12:11:00").atZone(zone).toInstant());
+        Assertions.assertThat(checkpoint.getNextCheck())
+                .isEqualTo(
+                        LocalDateTime.parse("2026-07-02T12:26:00").atZone(zone).toInstant());
     }
 }

--- a/beans/src/test/java/fr/pilato/elasticsearch/crawler/fs/beans/FsJobParserTest.java
+++ b/beans/src/test/java/fr/pilato/elasticsearch/crawler/fs/beans/FsJobParserTest.java
@@ -23,7 +23,7 @@ package fr.pilato.elasticsearch.crawler.fs.beans;
 import fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil;
 import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
 import java.io.IOException;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.assertj.core.api.Assertions;
@@ -47,7 +47,7 @@ class FsJobParserTest extends AbstractFSCrawlerTestCase {
 
     @Test
     void parseJob() throws IOException {
-        jobTester(new FsJob(jobName, LocalDateTime.now(), LocalDateTime.now(), 1000, 5));
+        jobTester(new FsJob(jobName, Instant.now(), Instant.now(), 1000, 5));
     }
 
     /**
@@ -57,7 +57,7 @@ class FsJobParserTest extends AbstractFSCrawlerTestCase {
      */
     @Test
     void dateTimeSerialization() throws IOException {
-        LocalDateTime now = LocalDateTime.now();
+        Instant now = Instant.now();
         FsJob job = new FsJob(jobName, now, now, 1000, 5);
         String json = JsonUtil.prettyMapper.writeValueAsString(job);
         FsJob generated = JsonUtil.prettyMapper.readValue(json, FsJob.class);

--- a/cli/src/test/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCliTest.java
+++ b/cli/src/test/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCliTest.java
@@ -33,7 +33,7 @@ import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCa
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.AfterEach;
@@ -224,8 +224,8 @@ class FsCrawlerCliTest extends AbstractFSCrawlerTestCase {
 
         // Write legacy status file
         FsJob legacyJob = new FsJob();
-        legacyJob.setLastrun(LocalDateTime.now().minusHours(1));
-        legacyJob.setNextCheck(LocalDateTime.now().plusHours(1));
+        legacyJob.setLastrun(Instant.now().minus(1, java.time.temporal.ChronoUnit.HOURS));
+        legacyJob.setNextCheck(Instant.now().plus(1, java.time.temporal.ChronoUnit.HOURS));
         legacyJob.setIndexed(50);
         legacyJob.setDeleted(2);
         legacyHandler.write(jobName, legacyJob);

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParser.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParser.java
@@ -58,8 +58,7 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -331,16 +330,15 @@ public class FsParser implements Runnable, AutoCloseable {
                     // REST-only (no provider) or no folder to monitor: no-op run, checkpoint completed with 0 files
                     logger.info(
                             "Run #{}: job [{}]: skipping crawl (REST-only or no fs.url).", run, fsSettings.getName());
-                    LocalDateTime scanDatenew =
-                            LocalDateTime.now(ZoneId.systemDefault()).minusSeconds(2);
-                    LocalDateTime nextCheck =
+                    Instant scanDatenew = Instant.now().minusSeconds(2);
+                    Instant nextCheck =
                             scanDatenew.plus(fsSettings.getFs().getUpdateRate().millis(), ChronoUnit.MILLIS);
                     setCurrentCheckpoint(FsCrawlerCheckpoint.newCheckpoint(""));
                     checkpoint.get().ensureConcurrentCollections();
                     updateCheckpointAsCompleted(scanDatenew, nextCheck);
                 } else {
                     ScanStatistic stats = new ScanStatistic(url);
-                    LocalDateTime startDate = LocalDateTime.now(ZoneId.systemDefault());
+                    Instant startDate = Instant.now();
                     stats.setStartTime(startDate);
 
                     crawlerPlugin.openConnection();
@@ -354,7 +352,7 @@ public class FsParser implements Runnable, AutoCloseable {
 
                     // We need to round that latest date to the lower second and remove 2 seconds.
                     // See #82: https://github.com/dadoonet/fscrawler/issues/82
-                    LocalDateTime scanDatenew = startDate.minusSeconds(2);
+                    Instant scanDatenew = startDate.minusSeconds(2);
 
                     // Load or create checkpoint (handles migration from legacy _status.json)
                     setCurrentCheckpoint(loadOrCreateCheckpoint(url));
@@ -372,18 +370,18 @@ public class FsParser implements Runnable, AutoCloseable {
 
                     // We only index the root directory once (first run)
                     // That means that we don't have a scanDate yet (checkpoint.scanDate is MIN)
-                    LocalDateTime scanDate = checkpoint.get().getScanDate();
-                    if ((scanDate == null || scanDate.equals(LocalDateTime.MIN))
+                    Instant scanDate = checkpoint.get().getScanDate();
+                    if ((scanDate == null || scanDate.equals(Instant.EPOCH))
                             && fsSettings.getFs().isIndexFolders()) {
                         indexDirectory(url, url);
                     }
 
-                    LocalDateTime effectiveScanDate = scanDate != null ? scanDate : LocalDateTime.MIN;
+                    Instant effectiveScanDate = scanDate != null ? scanDate : Instant.EPOCH;
 
                     // Process directories using work queue instead of recursion
                     processDirectoriesWithCheckpoint(effectiveScanDate, stats);
 
-                    stats.setEndTime(LocalDateTime.now(ZoneId.systemDefault()));
+                    stats.setEndTime(Instant.now());
                     stats.setNbDocScan((int) checkpoint.get().getFilesProcessed());
                     stats.setNbDocDeleted((int) checkpoint.get().getFilesDeleted());
 
@@ -403,7 +401,7 @@ public class FsParser implements Runnable, AutoCloseable {
                             scanDuration != null ? scanDuration.toMillis() : 0L);
 
                     // Compute the next check time by adding fsSettings.getFs().getUpdateRate().millis()
-                    LocalDateTime nextCheck =
+                    Instant nextCheck =
                             scanDatenew.plus(fsSettings.getFs().getUpdateRate().millis(), ChronoUnit.MILLIS);
                     logger.info(
                             "Run #{}: job [{}]: indexed [{}], deleted [{}], documents up to [{}]. "
@@ -513,8 +511,7 @@ public class FsParser implements Runnable, AutoCloseable {
                                     FsCrawlerCheckpoint savedCheckpoint = checkpointHandler.read(fsSettings.getName());
                                     if (savedCheckpoint == null
                                             || savedCheckpoint.getNextCheck() == null
-                                            || LocalDateTime.now(ZoneId.systemDefault())
-                                                    .isAfter(savedCheckpoint.getNextCheck())) {
+                                            || Instant.now().isAfter(savedCheckpoint.getNextCheck())) {
                                         logger.debug(
                                                 "Fs crawler is waking up because next check time [{}] is in the past.",
                                                 savedCheckpoint != null ? savedCheckpoint.getNextCheck() : "null");
@@ -595,7 +592,7 @@ public class FsParser implements Runnable, AutoCloseable {
                 logger.debug("Found checkpoint for job [{}] but no pending work, starting fresh", fsSettings.getName());
                 FsCrawlerCheckpoint newCheckpoint = FsCrawlerCheckpoint.newCheckpoint(rootPath);
                 newCheckpoint.setScanDate(
-                        existing.getScanEndTime() != null ? existing.getScanEndTime() : LocalDateTime.MIN);
+                        existing.getScanEndTime() != null ? existing.getScanEndTime() : Instant.EPOCH);
                 return newCheckpoint;
             }
         }
@@ -636,7 +633,7 @@ public class FsParser implements Runnable, AutoCloseable {
      * Update the checkpoint as completed with scan end time and next check time. The checkpoint is kept (not deleted)
      * to serve as the source of truth for lastrun.
      */
-    private void updateCheckpointAsCompleted(LocalDateTime scanEndTime, LocalDateTime nextCheck) {
+    private void updateCheckpointAsCompleted(Instant scanEndTime, Instant nextCheck) {
         FsCrawlerCheckpoint localCheckpoint = checkpoint.get();
         if (localCheckpoint == null) {
             return;
@@ -673,7 +670,7 @@ public class FsParser implements Runnable, AutoCloseable {
     }
 
     /** Process directories using a work queue with checkpoint support */
-    private void processDirectoriesWithCheckpoint(LocalDateTime lastScanDate, ScanStatistic stats) throws Exception {
+    private void processDirectoriesWithCheckpoint(Instant lastScanDate, ScanStatistic stats) throws Exception {
         Span traverseSpan = FsCrawlerTracing.startSpan("fscrawler.directory.traverse");
         try (Scope ignored = traverseSpan.makeCurrent()) {
             traverseSpan.setAttribute("scan.id", String.valueOf(runNumber.get()));
@@ -831,8 +828,7 @@ public class FsParser implements Runnable, AutoCloseable {
      *
      * @return true if the directory was fully processed, false if interrupted by pause/close
      */
-    private boolean processDirectory(String filepath, LocalDateTime lastScanDate, ScanStatistic stats)
-            throws Exception {
+    private boolean processDirectory(String filepath, Instant lastScanDate, ScanStatistic stats) throws Exception {
         Span dirSpan = FsCrawlerTracing.startSpan("fscrawler.directory.process");
         dirSpan.setAttribute("fs.path", filepath);
         try (Scope ignored = dirSpan.makeCurrent()) {
@@ -1212,7 +1208,7 @@ public class FsParser implements Runnable, AutoCloseable {
     }
 
     private boolean shouldIndexBecauseOfChanges(
-            FileAbstractModel child, LocalDateTime lastScanDate, String filename, String filepath)
+            FileAbstractModel child, Instant lastScanDate, String filename, String filepath)
             throws NoSuchAlgorithmException {
         if (child.getLastModifiedDate().isAfter(lastScanDate)) {
             return true;
@@ -1261,9 +1257,9 @@ public class FsParser implements Runnable, AutoCloseable {
         fileSpan.setAttribute("file.size", filesize);
         try (Scope ignored = fileSpan.makeCurrent()) {
             final String filename = fileAbstractModel.getName();
-            final LocalDateTime created = fileAbstractModel.getCreationDate();
-            final LocalDateTime lastModified = fileAbstractModel.getLastModifiedDate();
-            final LocalDateTime lastAccessed = fileAbstractModel.getAccessDate();
+            final Instant created = fileAbstractModel.getCreationDate();
+            final Instant lastModified = fileAbstractModel.getLastModifiedDate();
+            final Instant lastAccessed = fileAbstractModel.getAccessDate();
             final String extension = fileAbstractModel.getExtension();
             final long size = fileAbstractModel.getSize();
 
@@ -1280,11 +1276,10 @@ public class FsParser implements Runnable, AutoCloseable {
 
                 // File
                 doc.getFile().setFilename(filename);
-                doc.getFile().setCreated(FsCrawlerUtil.localDateTimeToDate(created));
-                doc.getFile().setLastModified(FsCrawlerUtil.localDateTimeToDate(lastModified));
-                doc.getFile().setLastAccessed(FsCrawlerUtil.localDateTimeToDate(lastAccessed));
-                doc.getFile()
-                        .setIndexingDate(FsCrawlerUtil.localDateTimeToDate(LocalDateTime.now(ZoneId.systemDefault())));
+                doc.getFile().setCreated(created);
+                doc.getFile().setLastModified(lastModified);
+                doc.getFile().setLastAccessed(lastAccessed);
+                doc.getFile().setIndexingDate(Instant.now());
                 if (fsSettings.getServer() == null
                         || PROTOCOL.LOCAL.equals(fsSettings.getServer().getProtocol())) {
                     doc.getFile().setUrl("file://" + fullFilename);

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/FsCrawlerUtil.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/FsCrawlerUtil.java
@@ -41,18 +41,20 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
 import java.util.Set;
-import java.util.TimeZone;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.regex.Pattern;
@@ -247,31 +249,31 @@ public class FsCrawlerUtil {
         return result;
     }
 
-    private static LocalDateTime getFileTime(File file, Function<BasicFileAttributes, FileTime> timeFunction) {
+    private static Instant getFileTime(File file, Function<BasicFileAttributes, FileTime> timeFunction) {
         try {
             Path path = Paths.get(file.getAbsolutePath());
             BasicFileAttributes fileattr = Files.getFileAttributeView(path, BasicFileAttributeView.class)
                     .readAttributes();
-            return LocalDateTime.ofInstant(timeFunction.apply(fileattr).toInstant(), ZoneId.systemDefault());
+            return timeFunction.apply(fileattr).toInstant();
         } catch (Exception e) {
             return null;
         }
     }
 
-    public static LocalDateTime getCreationTime(File file) {
+    public static Instant getCreationTime(File file) {
         return getFileTime(file, BasicFileAttributes::creationTime);
     }
 
-    public static LocalDateTime getModificationTime(File file) {
+    public static Instant getModificationTime(File file) {
         return getFileTime(file, BasicFileAttributes::lastModifiedTime);
     }
 
-    public static LocalDateTime getLastAccessTime(File file) {
+    public static Instant getLastAccessTime(File file) {
         return getFileTime(file, BasicFileAttributes::lastAccessTime);
     }
 
-    public static LocalDateTime getModificationOrCreationTime(File file) {
-        LocalDateTime lastAccessTime = getFileTime(file, BasicFileAttributes::lastAccessTime);
+    public static Instant getModificationOrCreationTime(File file) {
+        Instant lastAccessTime = getFileTime(file, BasicFileAttributes::lastAccessTime);
         if (lastAccessTime != null) {
             return lastAccessTime;
         } else {
@@ -279,18 +281,33 @@ public class FsCrawlerUtil {
         }
     }
 
-    public static Date localDateTimeToDate(LocalDateTime ldt) {
-        if (ldt == null) {
+    /**
+     * Parse an ISO-8601 date/time into an {@link Instant}. Accepts:
+     *
+     * <ul>
+     *   <li>Instant / OffsetDateTime forms ({@code 2016-07-07T08:37:00Z}, {@code ...+02:00})
+     *   <li>Legacy zone-less {@code LocalDateTime} strings, interpreted in the JVM default zone (same assumption as
+     *       pre-3.0 checkpoint files)
+     * </ul>
+     */
+    public static Instant parseInstant(String sDate) {
+        if (sDate == null || sDate.isBlank()) {
             return null;
         }
-        return Date.from(ldt.atZone(TimeZone.getDefault().toZoneId()).toInstant());
-    }
-
-    public static Date localDateTimeToDate(String sDate) {
-        if (sDate == null) {
-            return null;
+        try {
+            return Instant.parse(sDate);
+        } catch (DateTimeParseException ignored) {
+            // Fall through to more flexible parsing
         }
-        return localDateTimeToDate(LocalDateTime.parse(sDate, DateTimeFormatter.ISO_DATE_TIME));
+        TemporalAccessor ta =
+                DateTimeFormatter.ISO_DATE_TIME.parseBest(sDate, OffsetDateTime::from, LocalDateTime::from);
+        if (ta instanceof OffsetDateTime offsetDateTime) {
+            return offsetDateTime.toInstant();
+        }
+        if (ta instanceof LocalDateTime localDateTime) {
+            return localDateTime.atZone(ZoneId.systemDefault()).toInstant();
+        }
+        throw new DateTimeParseException("Cannot parse instant from [" + sDate + "]", sDate, 0);
     }
 
     public static String getFileExtension(File file) {

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/InstantDeserializer.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/InstantDeserializer.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
+ */
+package fr.pilato.elasticsearch.crawler.fs.framework;
+
+import java.time.Instant;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.deser.std.StdDeserializer;
+
+/**
+ * Jackson deserializer for {@link Instant} that also accepts legacy zone-less {@code LocalDateTime} strings
+ * (interpreted in the JVM default zone) for backward compatibility with older checkpoint / status files.
+ */
+public class InstantDeserializer extends StdDeserializer<Instant> {
+    public InstantDeserializer() {
+        super(Instant.class);
+    }
+
+    @Override
+    public Instant deserialize(JsonParser p, DeserializationContext ctxt) {
+        JsonToken token = p.currentToken();
+        if (token != null && token.isNumeric()) {
+            return Instant.ofEpochMilli(p.getLongValue());
+        }
+        return FsCrawlerUtil.parseInstant(p.getValueAsString());
+    }
+}

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/JsonUtil.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/JsonUtil.java
@@ -64,6 +64,8 @@ public class JsonUtil {
         fscrawler.addDeserializer(Percentage.class, new PercentageDeserializer());
         fscrawler.addSerializer(new ByteSizeValueSerializer());
         fscrawler.addDeserializer(ByteSizeValue.class, new ByteSizeValueDeserializer());
+        // Accept Instant ISO-8601 and legacy zone-less LocalDateTime strings (checkpoints / _status.json).
+        fscrawler.addDeserializer(java.time.Instant.class, new InstantDeserializer());
 
         // Jackson 3 mappers are immutable: they are configured through their builder.
         // The java.time support is now built into jackson-databind, so no JavaTimeModule registration is needed.

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/FsCrawlerUtilTest.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/FsCrawlerUtilTest.java
@@ -32,10 +32,9 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.util.Date;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Set;
-import java.util.TimeZone;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.assertj.core.api.Assertions;
@@ -294,15 +293,18 @@ class FsCrawlerUtilTest extends AbstractFSCrawlerTestCase {
     }
 
     @Test
-    void localDateToDate() {
-        LocalDateTime now = LocalDateTime.now();
-        Date date = FsCrawlerUtil.localDateTimeToDate(now);
-        logger.info(
-                "Current Time [{}] in [{}] is actually [{}]",
-                now,
-                TimeZone.getDefault().getDisplayName(),
-                date);
-        Assertions.assertThat(date).isNotNull();
+    void parseInstantWithOffsetPreservesUtc() {
+        Instant instant = FsCrawlerUtil.parseInstant("2016-07-07T08:37:00Z");
+        Assertions.assertThat(instant).isEqualTo(Instant.parse("2016-07-07T08:37:00Z"));
+    }
+
+    @Test
+    void parseInstantZoneLessUsesSystemDefault() {
+        Instant instant = FsCrawlerUtil.parseInstant("2016-07-07T08:37:00");
+        Assertions.assertThat(instant)
+                .isEqualTo(LocalDateTime.parse("2016-07-07T08:37:00")
+                        .atZone(ZoneId.systemDefault())
+                        .toInstant());
     }
 
     /**

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/JsonUtilTest.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/JsonUtilTest.java
@@ -22,11 +22,17 @@ package fr.pilato.elasticsearch.crawler.fs.framework;
 
 import com.jayway.jsonpath.DocumentContext;
 import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 
@@ -98,6 +104,65 @@ class JsonUtilTest extends AbstractFSCrawlerTestCase {
         public void setCities(List<String> cities) {
             this.cities = cities;
         }
+    }
+
+    /** Minimal bean to exercise {@link InstantDeserializer} through JsonUtil mappers. */
+    public static class InstantHolder {
+        private Instant scanDate;
+
+        public Instant getScanDate() {
+            return scanDate;
+        }
+
+        public void setScanDate(Instant scanDate) {
+            this.scanDate = scanDate;
+        }
+    }
+
+    static Stream<ObjectMapper> instantMappers() {
+        return Stream.of(JsonUtil.mapper, JsonUtil.prettyMapper, JsonUtil.ymlMapper);
+    }
+
+    @ParameterizedTest
+    @MethodSource("instantMappers")
+    void deserializeInstantWithZ(ObjectMapper mapper) {
+        InstantHolder holder = mapper.readValue("{\"scan_date\":\"2016-07-07T08:37:00Z\"}", InstantHolder.class);
+        Assertions.assertThat(holder.getScanDate()).isEqualTo(Instant.parse("2016-07-07T08:37:00Z"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("instantMappers")
+    void deserializeInstantWithOffset(ObjectMapper mapper) {
+        InstantHolder holder =
+                mapper.readValue("{\"scan_date\":\"2022-02-08T21:57:51.000+00:00\"}", InstantHolder.class);
+        Assertions.assertThat(holder.getScanDate()).isEqualTo(Instant.parse("2022-02-08T21:57:51Z"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("instantMappers")
+    void deserializeLegacyLocalDateTimeAsInstant(ObjectMapper mapper) {
+        InstantHolder holder = mapper.readValue("{\"scan_date\":\"2026-07-02T12:10:57\"}", InstantHolder.class);
+        Assertions.assertThat(holder.getScanDate())
+                .isEqualTo(LocalDateTime.parse("2026-07-02T12:10:57")
+                        .atZone(ZoneId.systemDefault())
+                        .toInstant());
+    }
+
+    @ParameterizedTest
+    @MethodSource("instantMappers")
+    void deserializeInstantFromEpochMillis(ObjectMapper mapper) {
+        long epochMilli = Instant.parse("2016-07-07T08:37:00Z").toEpochMilli();
+        InstantHolder holder = mapper.readValue("{\"scan_date\":" + epochMilli + "}", InstantHolder.class);
+        Assertions.assertThat(holder.getScanDate()).isEqualTo(Instant.ofEpochMilli(epochMilli));
+    }
+
+    @ParameterizedTest
+    @MethodSource("instantMappers")
+    void roundTripInstantSerialization(ObjectMapper mapper) {
+        InstantHolder source = new InstantHolder();
+        source.setScanDate(Instant.parse("2016-07-07T08:37:00Z"));
+        InstantHolder roundTrip = mapper.readValue(mapper.writeValueAsString(source), InstantHolder.class);
+        Assertions.assertThat(roundTrip.getScanDate()).isEqualTo(source.getScanDate());
     }
 
     @Test

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestAddNewFilesIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestAddNewFilesIT.java
@@ -33,7 +33,7 @@ import fr.pilato.elasticsearch.crawler.fs.test.integration.AbstractFsCrawlerITCa
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.time.Duration;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -66,7 +66,7 @@ class FsCrawlerTestAddNewFilesIT extends AbstractFsCrawlerITCase {
 
         // Forcing a rescan by modifying the next scan date
         logger.info("  ---> changing next check date to now manually");
-        waitForFsJobAndSetDate(fsSettings.getName(), LocalDateTime.now());
+        waitForFsJobAndSetDate(fsSettings.getName(), Instant.now());
 
         // We expect to have two files
         countTestHelper(
@@ -168,7 +168,7 @@ class FsCrawlerTestAddNewFilesIT extends AbstractFsCrawlerITCase {
         });
     }
 
-    private void waitForFsJobAndSetDate(String jobName, LocalDateTime dateTime) {
+    private void waitForFsJobAndSetDate(String jobName, Instant dateTime) {
         Awaitility.await()
                 .pollInterval(ExponentialBackoffPollInterval.exponential(Duration.ofMillis(500), Duration.ofSeconds(5)))
                 .atMost(10, TimeUnit.SECONDS)

--- a/plugins/fs-ftp-plugin/src/main/java/fr/pilato/elasticsearch/crawler/plugins/fs/ftp/FsFtpPlugin.java
+++ b/plugins/fs-ftp-plugin/src/main/java/fr/pilato/elasticsearch/crawler/plugins/fs/ftp/FsFtpPlugin.java
@@ -33,8 +33,6 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -68,10 +66,7 @@ public class FsFtpPlugin extends FsCrawlerPlugin {
         private static final Comparator<FTPFile> FTP_FILE_COMPARATOR = Comparator.comparing(
                 file -> {
                     var timestamp = file.getTimestamp();
-                    return timestamp != null
-                            ? LocalDateTime.ofInstant(
-                                    Instant.ofEpochMilli(timestamp.getTimeInMillis()), ZoneId.systemDefault())
-                            : null;
+                    return timestamp != null ? Instant.ofEpochMilli(timestamp.getTimeInMillis()) : null;
                 },
                 Comparator.nullsLast(Comparator.naturalOrder()));
 
@@ -378,9 +373,7 @@ public class FsFtpPlugin extends FsCrawlerPlugin {
             return new FileAbstractModel(
                     filename,
                     file.isFile(),
-                    // Using local TimeZone as reference
-                    LocalDateTime.ofInstant(
-                            Instant.ofEpochMilli(file.getTimestamp().getTimeInMillis()), ZoneId.systemDefault()),
+                    Instant.ofEpochMilli(file.getTimestamp().getTimeInMillis()),
                     // Creation date not available
                     null,
                     // Access date not available

--- a/plugins/fs-ssh-plugin/src/main/java/fr/pilato/elasticsearch/crawler/plugins/fs/ssh/FsSshPlugin.java
+++ b/plugins/fs-ssh-plugin/src/main/java/fr/pilato/elasticsearch/crawler/plugins/fs/ssh/FsSshPlugin.java
@@ -30,8 +30,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Paths;
 import java.security.KeyPair;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -68,9 +66,7 @@ public class FsSshPlugin extends FsCrawlerPlugin {
                 file -> {
                     var attributes = file.getAttributes();
                     var modifyTime = attributes != null ? attributes.getModifyTime() : null;
-                    return modifyTime != null
-                            ? LocalDateTime.ofInstant(modifyTime.toInstant(), ZoneId.systemDefault())
-                            : null;
+                    return modifyTime != null ? modifyTime.toInstant() : null;
                 },
                 Comparator.nullsLast(Comparator.naturalOrder()));
 
@@ -240,12 +236,10 @@ public class FsSshPlugin extends FsCrawlerPlugin {
             return new FileAbstractModel(
                     file.getFilename(),
                     !file.getAttributes().isDirectory(),
-                    // Using local TimeZone as reference
-                    LocalDateTime.ofInstant(file.getAttributes().getModifyTime().toInstant(), ZoneId.systemDefault()),
+                    file.getAttributes().getModifyTime().toInstant(),
                     // Creation date not available
                     null,
-                    // Using local TimeZone as reference
-                    LocalDateTime.ofInstant(file.getAttributes().getAccessTime().toInstant(), ZoneId.systemDefault()),
+                    file.getAttributes().getAccessTime().toInstant(),
                     FilenameUtils.getExtension(file.getFilename()),
                     path,
                     path.equals("/")

--- a/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/CrawlerStatusResponse.java
+++ b/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/CrawlerStatusResponse.java
@@ -24,8 +24,6 @@ import fr.pilato.elasticsearch.crawler.fs.beans.CrawlerState;
 import fr.pilato.elasticsearch.crawler.fs.beans.FsCrawlerCheckpoint;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 
 /** Response object for the crawler status endpoint */
 public final class CrawlerStatusResponse extends RestResponse {
@@ -36,9 +34,9 @@ public final class CrawlerStatusResponse extends RestResponse {
     private int completedDirectories;
     private long filesProcessed;
     private long filesDeleted;
-    private LocalDateTime scanStartTime;
-    private LocalDateTime scanEndTime;
-    private LocalDateTime nextCheck;
+    private Instant scanStartTime;
+    private Instant scanEndTime;
+    private Instant nextCheck;
     private String elapsedTime;
     private int retryCount;
     private String lastError;
@@ -72,11 +70,10 @@ public final class CrawlerStatusResponse extends RestResponse {
         this.lastError = checkpoint.getLastError();
 
         if (checkpoint.getScanStartTime() != null) {
-            Instant start =
-                    checkpoint.getScanStartTime().atZone(ZoneId.systemDefault()).toInstant();
+            Instant start = checkpoint.getScanStartTime();
             Instant end;
             if (checkpoint.getState() == CrawlerState.COMPLETED && checkpoint.getScanEndTime() != null) {
-                end = checkpoint.getScanEndTime().atZone(ZoneId.systemDefault()).toInstant();
+                end = checkpoint.getScanEndTime();
             } else {
                 end = Instant.now();
             }
@@ -137,27 +134,27 @@ public final class CrawlerStatusResponse extends RestResponse {
         this.filesDeleted = filesDeleted;
     }
 
-    public LocalDateTime getScanStartTime() {
+    public Instant getScanStartTime() {
         return scanStartTime;
     }
 
-    public void setScanStartTime(LocalDateTime scanStartTime) {
+    public void setScanStartTime(Instant scanStartTime) {
         this.scanStartTime = scanStartTime;
     }
 
-    public LocalDateTime getScanEndTime() {
+    public Instant getScanEndTime() {
         return scanEndTime;
     }
 
-    public void setScanEndTime(LocalDateTime scanEndTime) {
+    public void setScanEndTime(Instant scanEndTime) {
         this.scanEndTime = scanEndTime;
     }
 
-    public LocalDateTime getNextCheck() {
+    public Instant getNextCheck() {
         return nextCheck;
     }
 
-    public void setNextCheck(LocalDateTime nextCheck) {
+    public void setNextCheck(Instant nextCheck) {
         this.nextCheck = nextCheck;
     }
 

--- a/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/DocumentApi.java
+++ b/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/DocumentApi.java
@@ -23,7 +23,6 @@ package fr.pilato.elasticsearch.crawler.fs.rest;
 import com.jayway.jsonpath.DocumentContext;
 import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
 import fr.pilato.elasticsearch.crawler.fs.beans.DocUtils;
-import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil;
 import fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil;
 import fr.pilato.elasticsearch.crawler.fs.framework.SignTool;
 import fr.pilato.elasticsearch.crawler.fs.service.FsCrawlerDocumentService;
@@ -47,8 +46,7 @@ import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.Instant;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -226,7 +224,7 @@ public class DocumentApi extends RestApi {
         doc.getFile()
                 .setExtension(
                         FilenameUtils.getExtension(doc.getFile().getFilename()).toLowerCase());
-        doc.getFile().setIndexingDate(FsCrawlerUtil.localDateTimeToDate(LocalDateTime.now(ZoneId.systemDefault())));
+        doc.getFile().setIndexingDate(Instant.now());
         // File
 
         // Read the file content

--- a/test-framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/framework/AbstractFSCrawlerTestCase.java
+++ b/test-framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/framework/AbstractFSCrawlerTestCase.java
@@ -95,7 +95,7 @@ public abstract class AbstractFSCrawlerTestCase {
      * parallel class execution enabled, randomizing them per class (with {@code @AfterAll} resets) races with other
      * classes running concurrently in the same JVM: a class finishing while others are still running would flip the
      * default {@code TimeZone} under their feet, breaking production code such as {@code FsParser} incremental-scan
-     * checkpoints that rely on {@link java.time.LocalDateTime#now()}.
+     * checkpoints that rely on {@link java.time.Instant#now()}.
      *
      * <p>The values are derived from the <b>root</b> seed rather than a per-class {@link Random}, so they remain fully
      * reproducible with {@code -Dtests.seed} regardless of which class is scheduled first, and can still be pinned

--- a/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
+++ b/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
@@ -273,7 +273,7 @@ public class TikaDocParser {
                             metadata,
                             TikaCoreProperties.MODIFIED,
                             doc.getMeta()::setDate,
-                            FsCrawlerUtil::localDateTimeToDate);
+                            FsCrawlerUtil::parseInstant);
 
                     setMeta(
                             doc.getPath().getReal(),
@@ -389,19 +389,19 @@ public class TikaDocParser {
                             metadata,
                             TikaCoreProperties.CREATED,
                             doc.getMeta()::setCreated,
-                            FsCrawlerUtil::localDateTimeToDate);
+                            FsCrawlerUtil::parseInstant);
                     setMeta(
                             doc.getPath().getReal(),
                             metadata,
                             TikaCoreProperties.PRINT_DATE,
                             doc.getMeta()::setPrintDate,
-                            FsCrawlerUtil::localDateTimeToDate);
+                            FsCrawlerUtil::parseInstant);
                     setMeta(
                             doc.getPath().getReal(),
                             metadata,
                             TikaCoreProperties.METADATA_DATE,
                             doc.getMeta()::setMetadataDate,
-                            FsCrawlerUtil::localDateTimeToDate);
+                            FsCrawlerUtil::parseInstant);
                     setMeta(
                             doc.getPath().getReal(),
                             metadata,

--- a/tika/src/test/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParserTest.java
+++ b/tika/src/test/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParserTest.java
@@ -22,7 +22,6 @@ package fr.pilato.elasticsearch.crawler.fs.tika;
 
 import com.carrotsearch.randomizedtesting.jupiter.RandomizedTest;
 import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
-import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettingsLoader;
 import fr.pilato.elasticsearch.crawler.fs.test.framework.Slow;
@@ -34,8 +33,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
-import java.time.LocalDateTime;
-import java.time.Month;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CyclicBarrier;
@@ -148,8 +146,7 @@ class TikaDocParserTest extends DocParserTestCase {
 
         // Metadata
         Assertions.assertThat(doc.getMeta().getAuthor()).isNotNull();
-        Assertions.assertThat(doc.getMeta().getDate())
-                .isEqualTo(FsCrawlerUtil.localDateTimeToDate(LocalDateTime.of(2016, Month.SEPTEMBER, 20, 9, 38, 56)));
+        Assertions.assertThat(doc.getMeta().getDate()).isEqualTo(Instant.parse("2016-09-20T09:38:56Z"));
         Assertions.assertThat(doc.getMeta().getKeywords()).isNotEmpty();
         Assertions.assertThat(doc.getMeta().getTitle()).contains("Recherche");
 
@@ -164,8 +161,7 @@ class TikaDocParserTest extends DocParserTestCase {
 
         // Metadata
         Assertions.assertThat(doc.getMeta().getAuthor()).isNull();
-        Assertions.assertThat(doc.getMeta().getDate())
-                .isEqualTo(FsCrawlerUtil.localDateTimeToDate(LocalDateTime.of(2016, Month.SEPTEMBER, 19, 14, 29, 37)));
+        Assertions.assertThat(doc.getMeta().getDate()).isEqualTo(Instant.parse("2016-09-19T14:29:37Z"));
         Assertions.assertThat(doc.getMeta().getKeywords()).isNull();
         Assertions.assertThat(doc.getMeta().getTitle()).isNull();
     }
@@ -213,8 +209,7 @@ class TikaDocParserTest extends DocParserTestCase {
 
         // Metadata
         Assertions.assertThat(doc.getMeta().getAuthor()).isEqualTo("David Pilato");
-        Assertions.assertThat(doc.getMeta().getDate())
-                .isEqualTo(FsCrawlerUtil.localDateTimeToDate(LocalDateTime.of(2016, Month.JULY, 7, 8, 37, 0)));
+        Assertions.assertThat(doc.getMeta().getDate()).isEqualTo(Instant.parse("2016-07-07T08:37:00Z"));
         Assertions.assertThat(doc.getMeta().getKeywords()).containsExactlyInAnyOrder("keyword1", " keyword2");
         Assertions.assertThat(doc.getMeta().getTitle()).isEqualTo("Test Tika title");
 
@@ -261,8 +256,7 @@ class TikaDocParserTest extends DocParserTestCase {
 
         // Metadata
         Assertions.assertThat(doc.getMeta().getAuthor()).isEqualTo("David Pilato");
-        Assertions.assertThat(doc.getMeta().getDate())
-                .isEqualTo(FsCrawlerUtil.localDateTimeToDate(LocalDateTime.of(2016, Month.JULY, 7, 8, 36, 0)));
+        Assertions.assertThat(doc.getMeta().getDate()).isEqualTo(Instant.parse("2016-07-07T08:36:00Z"));
         Assertions.assertThat(doc.getMeta().getKeywords()).containsExactlyInAnyOrder("keyword1", " keyword2");
         Assertions.assertThat(doc.getMeta().getTitle()).isEqualTo("Test Tika title");
 
@@ -397,8 +391,7 @@ class TikaDocParserTest extends DocParserTestCase {
 
         // Metadata
         Assertions.assertThat(doc.getMeta().getAuthor()).isEqualTo("David Pilato");
-        Assertions.assertThat(doc.getMeta().getDate())
-                .isEqualTo(FsCrawlerUtil.localDateTimeToDate(LocalDateTime.of(2016, Month.JULY, 7, 8, 37, 0)));
+        Assertions.assertThat(doc.getMeta().getDate()).isEqualTo(Instant.parse("2016-07-07T08:37:00Z"));
         Assertions.assertThat(doc.getMeta().getKeywords()).containsExactlyInAnyOrder("keyword1", "  keyword2");
         Assertions.assertThat(doc.getMeta().getTitle()).isEqualTo("Test Tika title");
 
@@ -441,8 +434,7 @@ class TikaDocParserTest extends DocParserTestCase {
 
         // Metadata
         Assertions.assertThat(doc.getMeta().getAuthor()).isEqualTo("David Pilato");
-        Assertions.assertThat(doc.getMeta().getDate())
-                .isEqualTo(FsCrawlerUtil.localDateTimeToDate(LocalDateTime.of(2016, Month.JULY, 7, 8, 37, 42)));
+        Assertions.assertThat(doc.getMeta().getDate()).isEqualTo(Instant.parse("2016-07-07T08:37:42Z"));
         Assertions.assertThat(doc.getMeta().getKeywords()).containsExactlyInAnyOrder("keyword1", " keyword2");
         Assertions.assertThat(doc.getMeta().getTitle()).isEqualTo("Test Tika title");
 


### PR DESCRIPTION
## Summary

- Replace `LocalDateTime` / `java.util.Date` with timezone-independent `java.time.Instant` across the scan checkpoint chain, filesystem model (`FileAbstractModel`), indexed documents (`File` / `Meta`), and REST status API.
- Fixes DST / host timezone sensitivity that could silently skip files or trigger spurious re-indexes (#2421).
- Removes Sonar `java:S2143` on date fields; Tika metadata timestamps with `Z` are now preserved correctly via `FsCrawlerUtil.parseInstant()`.
- Legacy zone-less `_checkpoint.json` / `_status.json` strings remain readable (interpreted in the JVM default zone, then rewritten as Instant).

### Breaking changes (3.0)

- Checkpoint JSON dates are now ISO-8601 with offset/`Z` instead of zone-less local datetimes.
- REST `/_status` date fields expose `Instant` (with zone) instead of `LocalDateTime`.
- Indexed document date JSON may use `Z` instead of `+0000` (ES `date_optional_time` accepts both).

## Test plan

- [x] `mvn -pl framework,beans,tika,cli -am test` — BUILD SUCCESS
- [ ] CI green on this PR
- [ ] Spot-check a job with an existing `_checkpoint.json` (legacy LocalDateTime) resumes correctly

Closes #2421


Made with [Cursor](https://cursor.com)