### PR TITLE
Set up Cursor Cloud dev environment for FSCrawler

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+FSCrawler is a Java 17+ Maven multi-module project (a file system crawler that parses
+documents with Apache Tika and indexes them into Elasticsearch). The VM snapshot already
+has **JDK 21** and **Maven** installed, and the update script pre-fetches Maven dependencies
+(`mvn dependency:go-offline`). Standard build/test/run commands are already documented — see
+`.claude/rules/build-commands.md`, `.claude/rules/testing.md`, and `docs/source/dev/build.md`.
+Quick reference: build `mvn clean package -DskipTests -Ddocker.skip`, lint
+`mvn spotless:check` (use `-DratchetFrom=NONE` for the whole tree, `mvn spotless:apply` to fix),
+unit tests `mvn test -DskipIntegTests`.
+
+### Docker is required for integration tests and local Elasticsearch (start it each session)
+
+Docker is installed in the snapshot, but the daemon does **not** start automatically. Before
+running integration tests (they use TestContainers) or starting a local Elasticsearch, start it:
+
+```bash
+sudo dockerd    # run in the background (e.g. a tmux session); leave it running
+sudo chmod 666 /var/run/docker.sock   # so the non-root `ubuntu` user can reach the socket
+```
+
+Notes:
+- The daemon is configured for `fuse-overlayfs` with the containerd-snapshotter feature disabled
+  (`/etc/docker/daemon.json`) and uses iptables-legacy — this is required for Docker-in-Docker
+  in this VM. Do not switch the storage driver back to `overlay2`.
+- Integration tests (`*IT.java`, run with `mvn verify ... -Dit.test=...`) auto-start an
+  Elasticsearch container via TestContainers when no external cluster is provided.
+
+### Running the app / integration tests against a local Elasticsearch
+
+Use the `start-elasticsearch` skill (`.claude/skills/start-elasticsearch/SKILL.md`), which runs
+Elastic's `start-local` (needs Docker). Run it inside the git-ignored `IGNORE_ME/` directory so
+nothing is committed. It brings up Elasticsearch on `http://localhost:9200` (user `elastic`,
+password `changeme`) plus Kibana on `http://localhost:5601`, and writes an API key to
+`IGNORE_ME/elastic-start-local/.env` (`ES_LOCAL_API_KEY`).
+
+Run integration tests against that cluster instead of TestContainers with:
+`-Dtests.cluster.url=http://localhost:9200 -Dtests.cluster.apiKey=<ES_LOCAL_API_KEY>`.
+
+### FSCrawler job settings gotchas (non-obvious)
+
+When writing a job `_settings.yaml` to point FSCrawler at a local `start-local` cluster:
+- Use the `elasticsearch.urls` **list** key (not `nodes:`). An invalid/unknown key is silently
+  ignored and FSCrawler falls back to the default `https://127.0.0.1:9200`, which fails against
+  the HTTP-only `start-local` endpoint with `SSLException: Unsupported or unrecognized SSL message`.
+- Use `http://` (not `https://`) for `start-local`.
+- Do **not** set `elasticsearch.index` to the same value as the job `name`. FSCrawler creates an
+  alias named after the job, so a custom index with that name fails with
+  `alias name [...] self-conflicts with index name`. Leave `index` unset to use the defaults
+  (`<name>_docs` and `<name>_folder`).
+
+Example minimal run (crawl once and exit):
+
+```bash
+# distribution ZIP is produced at distribution/target/fscrawler-distribution-3.0-SNAPSHOT.zip
+bin/fscrawler --config_dir <config_dir> <job-name> --loop 1
+```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for FSCrawler (Java 17+ Maven multi-module crawler that parses documents with Apache Tika and indexes them into Elasticsearch). No application code was changed — this only adds `AGENTS.md` with durable Cursor Cloud instructions and configures the VM update script.

## What was installed
- **Maven** (build tool; JDK 21 was already present, matching CI which uses JDK 21)
- **Docker CE** (for TestContainers integration tests and local Elasticsearch via `start-local`), configured for Docker-in-Docker (`fuse-overlayfs` storage driver, containerd-snapshotter disabled for Docker 29, iptables-legacy)

## Update script (runs on VM startup)
```
mvn -B -q -Dossindex.skip -Ddocker.skip dependency:go-offline
```
Minimal, idempotent Maven dependency pre-fetch. Docker/Maven persist via the VM snapshot; the Docker daemon and Elasticsearch are startup steps documented in `AGENTS.md` (kept out of the update script).

## Verified

| Step | Command | Result |
|------|---------|--------|
| Build | `mvn clean package -DskipTests -Ddocker.skip -Dossindex.skip` | BUILD SUCCESS |
| Lint | `mvn spotless:check -DratchetFrom=NONE` | BUILD SUCCESS |
| Unit tests | `mvn test -DskipIntegTests -Dossindex.skip` | BUILD SUCCESS |
| Integration test (local ES) | `mvn verify -pl integration-tests -am -DskipUnitTests -Dtests.cluster.url=http://localhost:9200 -Dit.test=FsCrawlerTestAddNewFilesIT#add_new_files_and_force_rescan` | Tests run: 1, Failures: 0 |
| Integration test (TestContainers) | same, without `-Dtests.cluster.url` | auto-started ES 9.4.3, Tests run: 1, Failures: 0 |
| Run app (hello-world) | `bin/fscrawler --config_dir <dir> hello-world --loop 1` | Indexed `hello.txt` into ES; document is full-text searchable |

## Hello-world demo

FSCrawler crawled a local folder, extracted text via Tika, and indexed it into Elasticsearch (9.4.3, started with `start-local`). The document is then full-text searchable:

```
== Elasticsearch indices created by FSCrawler ==
health index              docs.count store.size
yellow hello-world_docs            1     ...
yellow hello-world_folder          1     ...

== Full-text search for the indexed document ==
{ "matches": 1, "results": [ { "filename": "hello.txt", "content": "Hello World from FSCrawler! ..." } ] }
```

Full demo log artifact:

[FSCrawler e2e demo log](https://cursor.com/agents/bc-a7aaca2b-58de-47dc-b2f0-ea291b426fd8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffscrawler-e2e-demo.txt)

## Notes for reviewers
`AGENTS.md` captures non-obvious startup caveats for future agents: the Docker daemon must be started each session (`sudo dockerd`); local ES uses HTTP on :9200; job settings must use the `elasticsearch.urls` list key (not `nodes:`) and must not set a custom `index` equal to the job name (alias conflict). Please merge the `AGENTS.md` changes so future agents remember these.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7aaca2b-58de-47dc-b2f0-ea291b426fd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7aaca2b-58de-47dc-b2f0-ea291b426fd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

