### PR TITLE
test: reproduce #1300 move file without touch

### DIFF
--- a/.agents/CURSOR.md
+++ b/.agents/CURSOR.md
@@ -1,0 +1,42 @@
+# FSCrawler — Cursor / agent reference
+
+This is the main project reference for Cursor and other coding agents. Keep it in sync with
+`.claude/rules/` when conventions change.
+
+## Project
+
+Java 17+ Maven multi-module file system crawler (Apache Tika → Elasticsearch).
+See `CLAUDE.md` and `AGENTS.md` for environment-specific notes.
+
+## Standing rules (all agents)
+
+These apply at the same priority level — do not skip them:
+
+1. **TDD** — write a failing test first, confirm red, then fix, then confirm green.
+   Details: `.claude/rules/testing.md` → *Test-First Workflow*.
+2. **RandomizedTesting** — prefer `RandomizedTest.*(…, randomizedRandomForTests)` over
+   incidental hardcoded fixture values. Reproduce with `-Dtests.seed=…`.
+   Details: `.claude/rules/testing.md` → *RandomizedTesting*.
+3. **Commit messages** — `type(scope): emoji description` with bullet details.
+   Details: `.claude/rules/git-workflow.md` → *Commit Message Format*.
+
+## Rule files
+
+| Topic | Path |
+|-------|------|
+| Architecture / modules | `.claude/rules/architecture.md` |
+| Build commands | `.claude/rules/build-commands.md` |
+| Testing, TDD, RandomizedTesting | `.claude/rules/testing.md` |
+| Code style / Spotless | `.claude/rules/code-style.md` |
+| Git / commits / PRs | `.claude/rules/git-workflow.md` |
+
+## Quick commands
+
+```bash
+mvn clean package -DskipTests -Ddocker.skip
+mvn spotless:apply
+mvn test -DskipIntegTests
+mvn verify -pl integration-tests -am -DskipUnitTests -Dit.test=ClassName#method
+```
+
+Cloud VM notes (Docker, local Elasticsearch): see `AGENTS.md`.

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -8,7 +8,10 @@
 
 Always create a dedicated branch before starting any implementation work.
 
-## Commit Message Format
+## Commit Message Format (MANDATORY)
+
+Every commit **must** follow this format (Conventional Commits + emoji). No exceptions for
+agents or humans:
 
 ```
 type(scope): emoji description
@@ -36,6 +39,8 @@ fix(core): 🐛 re-check checkpoint nextCheck in between-runs wait
 - Allow forced rescan when checkpoint file is updated externally
 - Read checkpoint from disk each wait chunk when !userStopped
 ```
+
+Subject line under ~72 chars. Use an accurate `scope` (`core`, `test`, `docs`, module name, …).
 
 ## Documentation Requirement
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -73,10 +73,35 @@ Use the skills in `.claude/skills/`:
 
 ## Test-First Workflow (MANDATORY)
 
-When fixing a bug:
+Applies to **bug fixes, new features, and behaviour changes**. Same rule for every agent
+working in this repository:
+
 1. **Reproduce first** — write/adjust a test that **fails** with the current behaviour
-2. **Confirm red** — run the test, verify it fails
+2. **Confirm red** — run the test, verify it fails for the expected reason
 3. **Fix the code** — change production code to make the test pass
 4. **Confirm green** — run the test again, verify it passes
 
 **Never fix code first and then write a test that already passes.**
+
+## RandomizedTesting (MANDATORY)
+
+Prefer **randomizedtesting-jupiter** helpers over hardcoded fixture values whenever the
+exact value is not part of the behaviour under test.
+
+- Use `RandomizedTest.*(..., randomizedRandomForTests)` from `AbstractFSCrawlerTestCase`
+  (`randomAsciiLettersOfLengthBetween`, `randomIntInRange`, `randomBoolean`, …)
+- Randomize names, sizes, counts, content, and optional branches when they are incidental
+- Keep literals only when the test asserts that exact value (protocol constants, mapping
+  field names, documented defaults, …)
+- Failures are reproducible with `-Dtests.seed=<SEED>` (printed by the reproduce-info extension)
+
+```java
+// Good — incidental fixture data is randomized
+String filename = RandomizedTest.randomAsciiLettersOfLengthBetween(randomizedRandomForTests, 6, 12)
+        .toLowerCase(Locale.ROOT) + ".txt";
+int count = RandomizedTest.randomIntInRange(randomizedRandomForTests, 3, 10);
+
+// Bad — arbitrary hardcoded values that are not part of the assertion
+String filename = "foo.txt";
+int count = 5;
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,18 @@
 # AGENTS.md
 
+## Standing rules (all agents)
+
+Follow these on every change — same weight as build/test commands:
+
+1. **TDD** — failing test first, confirm red, then implement, then confirm green
+   (`.claude/rules/testing.md`).
+2. **RandomizedTesting** — avoid incidental hardcoded fixture values; use
+   `RandomizedTest.*(…, randomizedRandomForTests)` (`.claude/rules/testing.md`).
+3. **Commit messages** — `type(scope): emoji description` with detail bullets
+   (`.claude/rules/git-workflow.md`).
+
+Cursor agents: also read `.agents/CURSOR.md`.
+
 ## Cursor Cloud specific instructions
 
 FSCrawler is a Java 17+ Maven multi-module project (a file system crawler that parses

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Plugin system**: PF4J
 - **Testing**: JUnit Jupiter 6 + randomizedtesting-jupiter 0.2.0 + TestContainers
 
+## Standing rules (all agents)
+
+1. **TDD** — failing test first (`testing.md`)
+2. **RandomizedTesting** — no incidental hardcoded fixtures (`testing.md`)
+3. **Commit messages** — `type(scope): emoji description` (`git-workflow.md`)
+
 ## Detailed Instructions
 
 @.claude/rules/architecture.md

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRemoveDeletedIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRemoveDeletedIT.java
@@ -20,20 +20,30 @@
  */
 package fr.pilato.elasticsearch.crawler.fs.test.integration.elasticsearch;
 
+import com.carrotsearch.randomizedtesting.jupiter.RandomizedTest;
+import com.jayway.jsonpath.DocumentContext;
 import fr.pilato.elasticsearch.crawler.fs.client.ESSearchRequest;
+import fr.pilato.elasticsearch.crawler.fs.client.ESSearchResponse;
 import fr.pilato.elasticsearch.crawler.fs.client.ESTermQuery;
 import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil;
+import fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil;
+import fr.pilato.elasticsearch.crawler.fs.framework.OsValidator;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
+import fr.pilato.elasticsearch.crawler.fs.test.framework.VerySlow;
 import fr.pilato.elasticsearch.crawler.fs.test.integration.AbstractFsCrawlerITCase;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.FileTime;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Locale;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /** Test moving/removing/adding files */
@@ -238,5 +248,83 @@ class FsCrawlerTestRemoveDeletedIT extends AbstractFsCrawlerITCase {
 
         // We expect to have 2 docs now
         countTestHelper(new ESSearchRequest().withIndex(getCrawlerName() + FsCrawlerUtil.INDEX_SUFFIX_DOCS), 2L, null);
+    }
+
+    /**
+     * Test case for <a
+     * href="https://github.com/dadoonet/fscrawler/issues/1300">https://github.com/dadoonet/fscrawler/issues/1300</a>:
+     * moving a file between directories inside the watched tree must remove the old document and index the file at its
+     * new location.
+     *
+     * <p>Unlike {@link #move_file()} and {@link #rename_file()}, this test deliberately does <strong>not</strong>
+     * {@code touch} the file after the move, which matches real {@code mv} behaviour where mtime (and creation time)
+     * are preserved. That is the scenario reported in #1300.
+     */
+    @Test
+    @VerySlow
+    void move_file_between_directories_without_touch() throws Exception {
+        // Drop the default _common sample so only our randomized fixture is crawled
+        try (var children = Files.list(currentTestResourceDir)) {
+            for (Path child : children.toList()) {
+                deleteRecursively(child);
+            }
+        }
+
+        String sourceDirName = "src_"
+                + RandomizedTest.randomAsciiLettersOfLengthBetween(randomizedRandomForTests, 4, 8)
+                        .toLowerCase(Locale.ROOT);
+        String destDirName = "dst_"
+                + RandomizedTest.randomAsciiLettersOfLengthBetween(randomizedRandomForTests, 4, 8)
+                        .toLowerCase(Locale.ROOT);
+        String filename = RandomizedTest.randomAsciiLettersOfLengthBetween(randomizedRandomForTests, 6, 12)
+                        .toLowerCase(Locale.ROOT)
+                + ".txt";
+        String content = RandomizedTest.randomAsciiLettersOfLengthBetween(randomizedRandomForTests, 20, 80);
+
+        Path sourceDir = Files.createDirectories(currentTestResourceDir.resolve(sourceDirName));
+        Path destDir = Files.createDirectories(currentTestResourceDir.resolve(destDirName));
+        Path sourceFile = sourceDir.resolve(filename);
+        Files.writeString(sourceFile, content, StandardCharsets.UTF_8);
+        // Ensure timestamps are clearly older than the next scan after the move
+        Files.setLastModifiedTime(sourceFile, FileTime.from(Instant.now().minus(1, ChronoUnit.DAYS)));
+
+        FsSettings fsSettings = createTestSettings();
+        fsSettings.getFs().setRemoveDeleted(true);
+        crawler = startCrawler(fsSettings);
+
+        countTestHelper(
+                new ESSearchRequest().withIndex(getCrawlerName() + FsCrawlerUtil.INDEX_SUFFIX_DOCS),
+                1L,
+                currentTestResourceDir);
+
+        Path destFile = destDir.resolve(filename);
+        logger.info(" ---> Moving [{}] to [{}] without touching timestamps", sourceFile, destFile);
+        Files.move(sourceFile, destFile, StandardCopyOption.ATOMIC_MOVE);
+
+        // remove_deleted should drop the document for the old path
+        countTestHelper(
+                new ESSearchRequest()
+                        .withIndex(getCrawlerName() + FsCrawlerUtil.INDEX_SUFFIX_DOCS)
+                        .withESQuery(new ESTermQuery("path.virtual.fulltext", sourceDirName)),
+                0L,
+                currentTestResourceDir);
+
+        // The file must still be searchable at the new location (desired behaviour for #1300).
+        // Use a bounded wait: the scan that removed the old path already ran, so either the new
+        // document is present now or #1300 is still open on this OS.
+        ESSearchResponse response = countTestHelper(
+                new ESSearchRequest()
+                        .withIndex(getCrawlerName() + FsCrawlerUtil.INDEX_SUFFIX_DOCS)
+                        .withESQuery(new ESTermQuery("file.filename", filename)),
+                1L,
+                currentTestResourceDir,
+                Duration.ofMinutes(1));
+
+        Assertions.assertThat(response.getHits()).hasSize(1);
+        DocumentContext document =
+                JsonUtil.parseJsonAsDocumentContext(response.getHits().get(0).getSource());
+        String expectedVirtual =
+                OsValidator.WINDOWS ? "\\" + destDirName + "\\" + filename : "/" + destDirName + "/" + filename;
+        Assertions.assertThat((String) document.read("$.path.virtual")).isEqualTo(expectedVirtual);
     }
 }

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRemoveDeletedIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRemoveDeletedIT.java
@@ -48,6 +48,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /** Test moving/removing/adding files */
@@ -263,8 +264,11 @@ class FsCrawlerTestRemoveDeletedIT extends AbstractFsCrawlerITCase {
      * <p>Unlike {@link #move_file()} and {@link #rename_file()}, this test deliberately does <strong>not</strong>
      * {@code touch} the file after the move, which matches real {@code mv} behaviour where mtime (and creation time)
      * are preserved. That is the scenario reported in #1300.
+     *
+     * <p>Disabled until #1300 is fixed: CI confirmed the failure on Linux and Windows.
      */
     @Test
+    @Disabled("Known issue https://github.com/dadoonet/fscrawler/issues/1300 — move without touch is not detected")
     void move_file_between_directories_without_touch() throws Exception {
         String sourceDirName = "src_"
                 + RandomizedTest.randomAsciiLettersOfLengthBetween(randomizedRandomForTests, 4, 8)

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRemoveDeletedIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRemoveDeletedIT.java
@@ -22,9 +22,12 @@ package fr.pilato.elasticsearch.crawler.fs.test.integration.elasticsearch;
 
 import com.carrotsearch.randomizedtesting.jupiter.RandomizedTest;
 import com.jayway.jsonpath.DocumentContext;
+import fr.pilato.elasticsearch.crawler.fs.beans.FsCrawlerCheckpoint;
+import fr.pilato.elasticsearch.crawler.fs.beans.FsCrawlerCheckpointFileHandler;
 import fr.pilato.elasticsearch.crawler.fs.client.ESSearchRequest;
 import fr.pilato.elasticsearch.crawler.fs.client.ESSearchResponse;
 import fr.pilato.elasticsearch.crawler.fs.client.ESTermQuery;
+import fr.pilato.elasticsearch.crawler.fs.framework.ExponentialBackoffPollInterval;
 import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil;
 import fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil;
 import fr.pilato.elasticsearch.crawler.fs.framework.OsValidator;
@@ -35,6 +38,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 import java.time.Duration;
 import java.time.Instant;
@@ -44,6 +48,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
 /** Test moving/removing/adding files */
@@ -285,8 +290,11 @@ class FsCrawlerTestRemoveDeletedIT extends AbstractFsCrawlerITCase {
         Path destDir = Files.createDirectories(currentTestResourceDir.resolve(destDirName));
         Path sourceFile = sourceDir.resolve(filename);
         Files.writeString(sourceFile, content, StandardCharsets.UTF_8);
-        // Ensure timestamps are clearly older than the next scan after the move
+        // Ensure mtime is older than any later scan (creation time is handled below via checkpoint wait)
         Files.setLastModifiedTime(sourceFile, FileTime.from(Instant.now().minus(1, ChronoUnit.DAYS)));
+        Instant fileCreation = Files.readAttributes(sourceFile, BasicFileAttributes.class)
+                .creationTime()
+                .toInstant();
 
         FsSettings fsSettings = createTestSettings();
         fsSettings.getFs().setRemoveDeleted(true);
@@ -296,6 +304,20 @@ class FsCrawlerTestRemoveDeletedIT extends AbstractFsCrawlerITCase {
                 new ESSearchRequest().withIndex(getCrawlerName() + FsCrawlerUtil.INDEX_SUFFIX_DOCS),
                 1L,
                 currentTestResourceDir);
+
+        // Scan dates are rounded to startDate-2s (#82). Wait until the checkpoint scanDate is strictly
+        // after the file creation time, otherwise a move that preserves birthtime would still look "new".
+        FsCrawlerCheckpointFileHandler checkpointHandler = new FsCrawlerCheckpointFileHandler(metadataDir);
+        Awaitility.await()
+                .alias("checkpoint scanDate after file creation")
+                .atMost(Duration.ofMinutes(1))
+                .pollInterval(ExponentialBackoffPollInterval.exponential(Duration.ofMillis(500), Duration.ofSeconds(5)))
+                .until(() -> {
+                    FsCrawlerCheckpoint checkpoint = checkpointHandler.read(fsSettings.getName());
+                    Instant scanDate = checkpoint == null ? null : checkpoint.getScanDate();
+                    logger.debug("Waiting for scanDate {} to be after file creation {}", scanDate, fileCreation);
+                    return scanDate != null && scanDate.isAfter(fileCreation);
+                });
 
         Path destFile = destDir.resolve(filename);
         logger.info(" ---> Moving [{}] to [{}] without touching timestamps", sourceFile, destFile);
@@ -309,18 +331,17 @@ class FsCrawlerTestRemoveDeletedIT extends AbstractFsCrawlerITCase {
                 0L,
                 currentTestResourceDir);
 
-        // The file must still be searchable at the new location (desired behaviour for #1300).
-        // Use a bounded wait: the scan that removed the old path already ran, so either the new
-        // document is present now or #1300 is still open on this OS.
-        ESSearchResponse response = countTestHelper(
-                new ESSearchRequest()
-                        .withIndex(getCrawlerName() + FsCrawlerUtil.INDEX_SUFFIX_DOCS)
-                        .withESQuery(new ESTermQuery("file.filename", filename)),
-                1L,
-                currentTestResourceDir,
-                Duration.ofMinutes(1));
+        // The scan that removed the old path already ran in the same pass as the new-path check
+        // (see FsParser.processDirectory). If #1300 is fixed, the document is already at the new path;
+        // if not, waiting longer will not help. Assert immediately with a clear message for CI.
+        String docsIndex = getCrawlerName() + FsCrawlerUtil.INDEX_SUFFIX_DOCS;
+        refresh(docsIndex);
+        ESSearchResponse response = client.search(
+                new ESSearchRequest().withIndex(docsIndex).withESQuery(new ESTermQuery("file.filename", filename)));
+        Assertions.assertThat(response.getTotalHits())
+                .as("#1300: file moved between watched dirs without touch must stay indexed (OS=%s)", OsValidator.OS)
+                .isEqualTo(1L);
 
-        Assertions.assertThat(response.getHits()).hasSize(1);
         DocumentContext document =
                 JsonUtil.parseJsonAsDocumentContext(response.getHits().get(0).getSource());
         String expectedVirtual =

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRemoveDeletedIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRemoveDeletedIT.java
@@ -32,7 +32,6 @@ import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil;
 import fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil;
 import fr.pilato.elasticsearch.crawler.fs.framework.OsValidator;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
-import fr.pilato.elasticsearch.crawler.fs.test.framework.VerySlow;
 import fr.pilato.elasticsearch.crawler.fs.test.integration.AbstractFsCrawlerITCase;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -266,7 +265,6 @@ class FsCrawlerTestRemoveDeletedIT extends AbstractFsCrawlerITCase {
      * are preserved. That is the scenario reported in #1300.
      */
     @Test
-    @VerySlow
     void move_file_between_directories_without_touch() throws Exception {
         // Drop the default _common sample so only our randomized fixture is crawled
         try (var children = Files.list(currentTestResourceDir)) {

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRemoveDeletedIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRemoveDeletedIT.java
@@ -266,13 +266,6 @@ class FsCrawlerTestRemoveDeletedIT extends AbstractFsCrawlerITCase {
      */
     @Test
     void move_file_between_directories_without_touch() throws Exception {
-        // Drop the default _common sample so only our randomized fixture is crawled
-        try (var children = Files.list(currentTestResourceDir)) {
-            for (Path child : children.toList()) {
-                deleteRecursively(child);
-            }
-        }
-
         String sourceDirName = "src_"
                 + RandomizedTest.randomAsciiLettersOfLengthBetween(randomizedRandomForTests, 4, 8)
                         .toLowerCase(Locale.ROOT);
@@ -298,9 +291,10 @@ class FsCrawlerTestRemoveDeletedIT extends AbstractFsCrawlerITCase {
         fsSettings.getFs().setRemoveDeleted(true);
         crawler = startCrawler(fsSettings);
 
+        // Default _common sample (roottxtfile.txt) + our randomized file
         countTestHelper(
                 new ESSearchRequest().withIndex(getCrawlerName() + FsCrawlerUtil.INDEX_SUFFIX_DOCS),
-                1L,
+                2L,
                 currentTestResourceDir);
 
         // Scan dates are rounded to startDate-2s (#82). Wait until the checkpoint scanDate is strictly


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds `move_file_between_directories_without_touch` to `FsCrawlerTestRemoveDeletedIT` to reproduce [#1300](https://github.com/dadoonet/fscrawler/issues/1300): move a file between two watched directories **without** `touch`ing it afterwards.
- CI confirmed the failure on **Linux and Windows** — the bug is still present on both platforms.
- The test is now `@Disabled` with a link to #1300 so CI stays green; re-enable when the fix lands.
- Documents standing agent rules: TDD, RandomizedTesting, and commit-message norms.

## Local / CI result

```
[#1300: file moved between watched dirs without touch must stay indexed (OS=…)]
expected: 1L but was: 0L
```

After a move without `touch`, `remove_deleted` drops the old path and the new location is never indexed.

## Test plan

- [x] New IT in `FsCrawlerTestRemoveDeletedIT`
- [x] Confirmed red on Linux (local) and on CI (Linux + Windows)
- [x] `@Disabled` with link to #1300
- [ ] Comment on #1300 (agent token lacks `addComment`; please post or grant permission)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc5f39ee-46e5-499a-9944-a4d732f1d06d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc5f39ee-46e5-499a-9944-a4d732f1d06d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

