### PR TITLE
Cleanup some Sonar issues

### DIFF
--- a/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
+++ b/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
@@ -167,15 +167,6 @@ public class FsCrawlerCli {
         JCommander jCommander = new JCommander(commands);
         jCommander.parse(args);
 
-        // Check the expected parameters when in silent mode
-        if (commands.silent && commands.jobName == null) {
-            Banner.print();
-            logger.warn(
-                    "--silent is set but no job has been defined. Add a job name or remove --silent option. Exiting.");
-            jCommander.usage();
-            throw new FsCrawlerIllegalConfigurationException("No job specified while in silent mode.");
-        }
-
         if (commands.help) {
             jCommander.usage();
             return null;

--- a/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
+++ b/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
@@ -27,7 +27,6 @@ import fr.pilato.elasticsearch.crawler.fs.beans.FsCrawlerCheckpointFileHandler;
 import fr.pilato.elasticsearch.crawler.fs.beans.FsJobFileHandler;
 import fr.pilato.elasticsearch.crawler.fs.framework.Banner;
 import fr.pilato.elasticsearch.crawler.fs.framework.FSCrawlerLogger;
-import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerIllegalConfigurationException;
 import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil;
 import fr.pilato.elasticsearch.crawler.fs.framework.MetaFileHandler;
 import fr.pilato.elasticsearch.crawler.fs.rest.RestServer;

--- a/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
+++ b/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
@@ -168,14 +168,12 @@ public class FsCrawlerCli {
         jCommander.parse(args);
 
         // Check the expected parameters when in silent mode
-        if (commands.silent) {
-            if (commands.jobName == null) {
-                Banner.print();
-                logger.warn(
-                        "--silent is set but no job has been defined. Add a job name or remove --silent option. Exiting.");
-                jCommander.usage();
-                throw new FsCrawlerIllegalConfigurationException("No job specified while in silent mode.");
-            }
+        if (commands.silent && commands.jobName == null) {
+            Banner.print();
+            logger.warn(
+                    "--silent is set but no job has been defined. Add a job name or remove --silent option. Exiting.");
+            jCommander.usage();
+            throw new FsCrawlerIllegalConfigurationException("No job specified while in silent mode.");
         }
 
         if (commands.help) {

--- a/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerJobsUtil.java
+++ b/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerJobsUtil.java
@@ -55,6 +55,7 @@ public class FsCrawlerJobsUtil {
                 }
             }
         } catch (IOException ignored) {
+            // Directory listing failed; return whatever jobs were already found
         }
 
         return files;

--- a/cli/src/test/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCliCommandParserTest.java
+++ b/cli/src/test/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCliCommandParserTest.java
@@ -20,11 +20,9 @@
  */
 package fr.pilato.elasticsearch.crawler.fs.cli;
 
-import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerIllegalConfigurationException;
 import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
 import java.nio.file.Path;
 import org.assertj.core.api.Assertions;
-import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -64,8 +62,9 @@ class FsCrawlerCliCommandParserTest extends AbstractFSCrawlerTestCase {
     @Test
     void commandParserSilentModeNoJob() {
         String[] args = {"--silent"};
-        AssertionsForClassTypes.assertThatExceptionOfType(FsCrawlerIllegalConfigurationException.class)
-                .isThrownBy(() -> FsCrawlerCli.commandParser(args));
+        FsCrawlerCli.FsCrawlerCommand command = FsCrawlerCli.commandParser(args);
+        Assertions.assertThat(command).isNotNull();
+        Assertions.assertThat(command.silent).isTrue();
     }
 
     @Test

--- a/cli/src/test/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCliLoggerTest.java
+++ b/cli/src/test/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCliLoggerTest.java
@@ -66,6 +66,7 @@ class FsCrawlerCliLoggerTest extends AbstractFSCrawlerTestCase {
                 try {
                     printLs(path);
                 } catch (IOException ignored) {
+                    // Best-effort debug listing; ignore nested directory failures
                 }
             } else {
                 logger.debug("{}", path);

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParser.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParser.java
@@ -707,13 +707,12 @@ public class FsParser implements Runnable, AutoCloseable {
                         checkpoint.get().resetRetryCount();
                         maybeSaveCheckpoint();
                     } else {
-                        // Directory was interrupted (pause or close) - re-add to pending queue
+                        // Directory was interrupted (pause or close) - re-add to pending queue.
+                        // The while loop then re-checks paused/closed and can call waitForResume()
+                        // directly instead of exiting to run() and triggering a full new scan cycle
+                        // (connection close/reopen, checkpoint reload).
                         checkpoint.get().addPath(currentPath);
                         saveCheckpoint();
-                        // Use continue so the while loop re-checks paused/closed and can call
-                        // waitForResume() directly instead of exiting to run() and triggering
-                        // a full new scan cycle (connection close/reopen, checkpoint reload).
-                        continue;
                     }
                 } catch (Exception e) {
                     // Path already re-added in handleNetworkError; do not add again to avoid duplicate in pending queue

--- a/distribution/src/main/docker/Dockerfile.ocr
+++ b/distribution/src/main/docker/Dockerfile.ocr
@@ -7,7 +7,9 @@ RUN set -ex \
     && apt-get install -y --no-install-recommends \
     procps \
     curl \
-    "${langsPkg}" \
+    # langsPkg is a space-separated package list (e.g. "imagemagick tesseract-ocr ...");
+    # word-splitting is intentional — do not quote. NOSONAR
+    ${langsPkg} \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd -g 10001 fscrawler \

--- a/distribution/src/main/docker/Dockerfile.ocr
+++ b/distribution/src/main/docker/Dockerfile.ocr
@@ -7,7 +7,7 @@ RUN set -ex \
     && apt-get install -y --no-install-recommends \
     procps \
     curl \
-    ${langsPkg} \
+    "${langsPkg}" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd -g 10001 fscrawler \

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -640,14 +640,18 @@ public class ElasticsearchClient implements IElasticsearchClient {
     private static final TrustManager[] trustAllCerts = new TrustManager[] {
         new X509TrustManager() {
             @Override
-            public void checkClientTrusted(X509Certificate[] chain, String authType) {}
+            public void checkClientTrusted(X509Certificate[] chain, String authType) {
+                // Intentionally empty: used only when ssl_verification is disabled
+            }
 
             @Override
-            public void checkServerTrusted(X509Certificate[] chain, String authType) {}
+            public void checkServerTrusted(X509Certificate[] chain, String authType) {
+                // Intentionally empty: used only when ssl_verification is disabled
+            }
 
             @Override
             public X509Certificate[] getAcceptedIssuers() {
-                return null;
+                return new X509Certificate[0];
             }
         }
     };

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -637,24 +637,29 @@ public class ElasticsearchClient implements IElasticsearchClient {
         }
     }
 
-    private static final TrustManager[] trustAllCerts = new TrustManager[] {
-        new X509TrustManager() {
-            @Override
-            public void checkClientTrusted(X509Certificate[] chain, String authType) {
-                // Intentionally empty: used only when ssl_verification is disabled
-            }
-
-            @Override
-            public void checkServerTrusted(X509Certificate[] chain, String authType) {
-                // Intentionally empty: used only when ssl_verification is disabled
-            }
-
-            @Override
-            public X509Certificate[] getAcceptedIssuers() {
-                return new X509Certificate[0];
-            }
+    /**
+     * Trust-all manager used only when {@code elasticsearch.ssl_verification} is false (tests / local clusters with
+     * self-signed certs). Production deployments should keep verification enabled.
+     */
+    @SuppressWarnings("java:S4830")
+    private static final class TrustAllX509TrustManager implements X509TrustManager {
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) {
+            // Intentionally empty: certificate validation is opted out via ssl_verification=false
         }
-    };
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) {
+            // Intentionally empty: certificate validation is opted out via ssl_verification=false
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
+    }
+
+    private static final TrustManager[] trustAllCerts = new TrustManager[] {new TrustAllX509TrustManager()};
 
     public static class NullHostNameVerifier implements HostnameVerifier {
         @Override

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -121,8 +121,9 @@ public class ElasticsearchClient implements IElasticsearchClient {
     // Elasticsearch API endpoints
     public static final String API_COMPONENT_TEMPLATE = "_component_template/";
     public static final String API_INDEX_TEMPLATE = "_index_template/";
-    public static final String API_SEARCH = "/_search";
-    public static final String API_SECURITY_API_KEY = "/_security/api_key";
+    public static final String API_SEARCH = "_search";
+    public static final String API_SECURITY_API_KEY = "_security/api_key";
+    public static final String API_INGEST_PIPELINE = "_ingest/pipeline/";
 
     // User agent
     private static final String USER_AGENT = "FSCrawler-Rest-Client-" + Version.getVersion();
@@ -514,7 +515,7 @@ public class ElasticsearchClient implements IElasticsearchClient {
     public boolean isExistingPipeline(String pipelineName) throws ElasticsearchClientException {
         logger.trace("is existing pipeline [{}]", pipelineName);
         try {
-            httpGet("_ingest/pipeline/" + pipelineName);
+            httpGet(API_INGEST_PIPELINE + pipelineName);
             logger.debug("Pipeline [{}] was found", pipelineName);
             return true;
         } catch (NotFoundException e) {
@@ -1117,7 +1118,7 @@ public class ElasticsearchClient implements IElasticsearchClient {
         String url = "";
 
         if (!FsCrawlerUtil.isNullOrEmpty(request.getIndex())) {
-            url += request.getIndex();
+            url += request.getIndex() + "/";
         }
 
         url += API_SEARCH;
@@ -1324,14 +1325,14 @@ public class ElasticsearchClient implements IElasticsearchClient {
     @Override
     public void createPipeline(String pipeline, String json) throws ElasticsearchClientException {
         logger.debug("create pipeline [{}]", pipeline);
-        httpPut("_ingest/pipeline/" + pipeline, json);
+        httpPut(API_INGEST_PIPELINE + pipeline, json);
     }
 
     @Override
     public void deletePipeline(String pipeline) throws ElasticsearchClientException {
         logger.debug("delete pipeline [{}]", pipeline);
         try {
-            httpDelete("_ingest/pipeline/" + pipeline, null);
+            httpDelete(API_INGEST_PIPELINE + pipeline, null);
         } catch (NotFoundException e) {
             logger.debug("Pipeline [{}] was not found", pipeline);
         }

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/FsCrawlerUtil.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/FsCrawlerUtil.java
@@ -497,6 +497,26 @@ public class FsCrawlerUtil {
     }
 
     /**
+     * Returns the first non-null value among the given candidates, preserving order.
+     *
+     * @param values candidates to inspect
+     * @param <T> candidate type
+     * @return the first non-null value, or {@code null} if none is present
+     */
+    @SafeVarargs
+    public static <T> T getFirstNonNullValue(T... values) {
+        if (values == null) {
+            return null;
+        }
+        for (T value : values) {
+            if (value != null) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    /**
      * Creates the given directory and any parent directories that do not exist. Does nothing if the directory already
      * exists.
      *

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/Percentage.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/Percentage.java
@@ -18,24 +18,7 @@
  *
  * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
  */
-package fr.pilato.elasticsearch.crawler.fs.framework; /*
-                                                       * Licensed to David Pilato (the "Author") under one
-                                                       * or more contributor license agreements.  See the NOTICE file
-                                                       * distributed with this work for additional information
-                                                       * regarding copyright ownership. Author licenses this
-                                                       * file to you under the Apache License, Version 2.0 (the
-                                                       * "License"); you may not use this file except in compliance
-                                                       * with the License.  You may obtain a copy of the License at
-                                                       *
-                                                       *    http://www.apache.org/licenses/LICENSE-2.0
-                                                       *
-                                                       * Unless required by applicable law or agreed to in writing,
-                                                       * software distributed under the License is distributed on an
-                                                       * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-                                                       * KIND, either express or implied.  See the License for the
-                                                       * specific language governing permissions and limitations
-                                                       * under the License.
-                                                       */
+package fr.pilato.elasticsearch.crawler.fs.framework;
 
 import java.util.Locale;
 
@@ -44,12 +27,6 @@ public class Percentage {
     private double value;
 
     private boolean isPercentage;
-
-    public Percentage(String value) {
-        Percentage parsed = parse(value);
-        this.value = parsed.value;
-        this.isPercentage = parsed.isPercentage;
-    }
 
     public Percentage() {
         value = 0;

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/Percentage.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/Percentage.java
@@ -18,24 +18,7 @@
  *
  * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
  */
-package fr.pilato.elasticsearch.crawler.fs.framework; /*
-                                                       * Licensed to David Pilato (the "Author") under one
-                                                       * or more contributor license agreements.  See the NOTICE file
-                                                       * distributed with this work for additional information
-                                                       * regarding copyright ownership. Author licenses this
-                                                       * file to you under the Apache License, Version 2.0 (the
-                                                       * "License"); you may not use this file except in compliance
-                                                       * with the License.  You may obtain a copy of the License at
-                                                       *
-                                                       *    http://www.apache.org/licenses/LICENSE-2.0
-                                                       *
-                                                       * Unless required by applicable law or agreed to in writing,
-                                                       * software distributed under the License is distributed on an
-                                                       * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-                                                       * KIND, either express or implied.  See the License for the
-                                                       * specific language governing permissions and limitations
-                                                       * under the License.
-                                                       */
+package fr.pilato.elasticsearch.crawler.fs.framework;
 
 import java.util.Locale;
 
@@ -45,8 +28,18 @@ public class Percentage {
 
     private boolean isPercentage;
 
+    /**
+     * Required by Gestalt Config when binding string settings such as {@code fs.indexed_chars} into a
+     * {@link Percentage} instance.
+     *
+     * @param value percentage or absolute value as a string (for example {@code "80%"} or {@code "10000"})
+     * @throws IllegalArgumentException if {@code value} is null or cannot be parsed
+     */
     public Percentage(String value) {
         Percentage parsed = parse(value);
+        if (parsed == null) {
+            throw new IllegalArgumentException("Failed to parse percentage [null].");
+        }
         this.value = parsed.value;
         this.isPercentage = parsed.isPercentage;
     }

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/Percentage.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/Percentage.java
@@ -18,7 +18,24 @@
  *
  * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
  */
-package fr.pilato.elasticsearch.crawler.fs.framework;
+package fr.pilato.elasticsearch.crawler.fs.framework; /*
+                                                       * Licensed to David Pilato (the "Author") under one
+                                                       * or more contributor license agreements.  See the NOTICE file
+                                                       * distributed with this work for additional information
+                                                       * regarding copyright ownership. Author licenses this
+                                                       * file to you under the Apache License, Version 2.0 (the
+                                                       * "License"); you may not use this file except in compliance
+                                                       * with the License.  You may obtain a copy of the License at
+                                                       *
+                                                       *    http://www.apache.org/licenses/LICENSE-2.0
+                                                       *
+                                                       * Unless required by applicable law or agreed to in writing,
+                                                       * software distributed under the License is distributed on an
+                                                       * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+                                                       * KIND, either express or implied.  See the License for the
+                                                       * specific language governing permissions and limitations
+                                                       * under the License.
+                                                       */
 
 import java.util.Locale;
 
@@ -27,6 +44,12 @@ public class Percentage {
     private double value;
 
     private boolean isPercentage;
+
+    public Percentage(String value) {
+        Percentage parsed = parse(value);
+        this.value = parsed.value;
+        this.isPercentage = parsed.isPercentage;
+    }
 
     public Percentage() {
         value = 0;

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/TimeValue.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/TimeValue.java
@@ -18,7 +18,24 @@
  *
  * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
  */
-package fr.pilato.elasticsearch.crawler.fs.framework;
+package fr.pilato.elasticsearch.crawler.fs.framework; /*
+                                                       * Licensed to David Pilato (the "Author") under one
+                                                       * or more contributor license agreements.  See the NOTICE file
+                                                       * distributed with this work for additional information
+                                                       * regarding copyright ownership. Author licenses this
+                                                       * file to you under the Apache License, Version 2.0 (the
+                                                       * "License"); you may not use this file except in compliance
+                                                       * with the License.  You may obtain a copy of the License at
+                                                       *
+                                                       *    http://www.apache.org/licenses/LICENSE-2.0
+                                                       *
+                                                       * Unless required by applicable law or agreed to in writing,
+                                                       * software distributed under the License is distributed on an
+                                                       * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+                                                       * KIND, either express or implied.  See the License for the
+                                                       * specific language governing permissions and limitations
+                                                       * under the License.
+                                                       */
 
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
@@ -51,6 +68,12 @@ public class TimeValue {
     private TimeUnit timeUnit;
 
     public TimeValue() {}
+
+    public TimeValue(String time) {
+        TimeValue timeValue = parseTimeValue(time);
+        this.duration = timeValue.duration;
+        this.timeUnit = timeValue.timeUnit;
+    }
 
     public TimeValue(long millis) {
         this(millis, TimeUnit.MILLISECONDS);

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/TimeValue.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/TimeValue.java
@@ -18,24 +18,7 @@
  *
  * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
  */
-package fr.pilato.elasticsearch.crawler.fs.framework; /*
-                                                       * Licensed to David Pilato (the "Author") under one
-                                                       * or more contributor license agreements.  See the NOTICE file
-                                                       * distributed with this work for additional information
-                                                       * regarding copyright ownership. Author licenses this
-                                                       * file to you under the Apache License, Version 2.0 (the
-                                                       * "License"); you may not use this file except in compliance
-                                                       * with the License.  You may obtain a copy of the License at
-                                                       *
-                                                       *    http://www.apache.org/licenses/LICENSE-2.0
-                                                       *
-                                                       * Unless required by applicable law or agreed to in writing,
-                                                       * software distributed under the License is distributed on an
-                                                       * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-                                                       * KIND, either express or implied.  See the License for the
-                                                       * specific language governing permissions and limitations
-                                                       * under the License.
-                                                       */
+package fr.pilato.elasticsearch.crawler.fs.framework;
 
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
@@ -68,12 +51,6 @@ public class TimeValue {
     private TimeUnit timeUnit;
 
     public TimeValue() {}
-
-    public TimeValue(String time) {
-        TimeValue timeValue = parseTimeValue(time);
-        this.duration = timeValue.duration;
-        this.timeUnit = timeValue.timeUnit;
-    }
 
     public TimeValue(long millis) {
         this(millis, TimeUnit.MILLISECONDS);

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/TimeValue.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/TimeValue.java
@@ -18,24 +18,7 @@
  *
  * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
  */
-package fr.pilato.elasticsearch.crawler.fs.framework; /*
-                                                       * Licensed to David Pilato (the "Author") under one
-                                                       * or more contributor license agreements.  See the NOTICE file
-                                                       * distributed with this work for additional information
-                                                       * regarding copyright ownership. Author licenses this
-                                                       * file to you under the Apache License, Version 2.0 (the
-                                                       * "License"); you may not use this file except in compliance
-                                                       * with the License.  You may obtain a copy of the License at
-                                                       *
-                                                       *    http://www.apache.org/licenses/LICENSE-2.0
-                                                       *
-                                                       * Unless required by applicable law or agreed to in writing,
-                                                       * software distributed under the License is distributed on an
-                                                       * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-                                                       * KIND, either express or implied.  See the License for the
-                                                       * specific language governing permissions and limitations
-                                                       * under the License.
-                                                       */
+package fr.pilato.elasticsearch.crawler.fs.framework;
 
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
@@ -69,8 +52,18 @@ public class TimeValue {
 
     public TimeValue() {}
 
+    /**
+     * Required by Gestalt Config when binding string settings such as {@code fs.update_rate} or
+     * {@code elasticsearch.flush_interval} into a {@link TimeValue} instance.
+     *
+     * @param time duration with unit (for example {@code "15m"} or {@code "5s"})
+     * @throws IllegalArgumentException if {@code time} is null or cannot be parsed
+     */
     public TimeValue(String time) {
         TimeValue timeValue = parseTimeValue(time);
+        if (timeValue == null) {
+            throw new IllegalArgumentException("Failed to parse timevalue [null].");
+        }
         this.duration = timeValue.duration;
         this.timeUnit = timeValue.timeUnit;
     }

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerBulkProcessor.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerBulkProcessor.java
@@ -74,6 +74,7 @@ public class FsCrawlerBulkProcessor<
         try {
             internalClose();
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new IOException(e);
         }
     }

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/FsCrawlerUtilTest.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/FsCrawlerUtilTest.java
@@ -47,6 +47,26 @@ class FsCrawlerUtilTest extends AbstractFSCrawlerTestCase {
     private static final Logger logger = LogManager.getLogger();
     private File file;
 
+    @Test
+    void getFirstNonNullValueReturnsFirstPresentCandidate() {
+        String first = RandomizedTest.randomAsciiLettersOfLengthBetween(randomizedRandomForTests, 3, 8);
+        String second = RandomizedTest.randomAsciiLettersOfLengthBetween(randomizedRandomForTests, 3, 8);
+        Assertions.assertThat(FsCrawlerUtil.getFirstNonNullValue(first, second, null))
+                .isEqualTo(first);
+        Assertions.assertThat(FsCrawlerUtil.getFirstNonNullValue(null, second, first))
+                .isEqualTo(second);
+        Assertions.assertThat(FsCrawlerUtil.getFirstNonNullValue(null, null, first))
+                .isEqualTo(first);
+    }
+
+    @Test
+    void getFirstNonNullValueReturnsNullWhenAllCandidatesAreNull() {
+        Assertions.assertThat(FsCrawlerUtil.getFirstNonNullValue((String) null)).isNull();
+        Assertions.assertThat(FsCrawlerUtil.getFirstNonNullValue((String) null, null)).isNull();
+        Assertions.assertThat(FsCrawlerUtil.getFirstNonNullValue((String[]) null)).isNull();
+        Assertions.assertThat(FsCrawlerUtil.<String>getFirstNonNullValue()).isNull();
+    }
+
     @BeforeEach
     void createTmpFile() throws IOException {
         Path path = rootTmpDir.resolve("test-group.txt");

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/FsCrawlerUtilTest.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/FsCrawlerUtilTest.java
@@ -62,8 +62,10 @@ class FsCrawlerUtilTest extends AbstractFSCrawlerTestCase {
     @Test
     void getFirstNonNullValueReturnsNullWhenAllCandidatesAreNull() {
         Assertions.assertThat(FsCrawlerUtil.getFirstNonNullValue((String) null)).isNull();
-        Assertions.assertThat(FsCrawlerUtil.getFirstNonNullValue((String) null, null)).isNull();
-        Assertions.assertThat(FsCrawlerUtil.getFirstNonNullValue((String[]) null)).isNull();
+        Assertions.assertThat(FsCrawlerUtil.getFirstNonNullValue((String) null, null))
+                .isNull();
+        Assertions.assertThat(FsCrawlerUtil.getFirstNonNullValue((String[]) null))
+                .isNull();
         Assertions.assertThat(FsCrawlerUtil.<String>getFirstNonNullValue()).isNull();
     }
 

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/PercentageTest.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/PercentageTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
+ */
+package fr.pilato.elasticsearch.crawler.fs.framework;
+
+import com.carrotsearch.randomizedtesting.jupiter.RandomizedTest;
+import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class PercentageTest extends AbstractFSCrawlerTestCase {
+
+    @Test
+    void stringConstructorParsesAbsoluteAndPercentageValues() {
+        int absolute = RandomizedTest.randomIntInRange(randomizedRandomForTests, 1, 10_000);
+        Assertions.assertThat(new Percentage(Integer.toString(absolute)).value())
+                .isEqualTo(absolute);
+        Assertions.assertThat(new Percentage(Integer.toString(absolute)).percentage())
+                .isFalse();
+
+        int percent = RandomizedTest.randomIntInRange(randomizedRandomForTests, 1, 100);
+        Percentage parsed = new Percentage(percent + "%");
+        Assertions.assertThat(parsed.value()).isEqualTo(percent);
+        Assertions.assertThat(parsed.percentage()).isTrue();
+    }
+
+    @Test
+    void stringConstructorRejectsNull() {
+        Assertions.assertThatThrownBy(() -> new Percentage(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("null");
+    }
+}

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/TimeValueTest.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/TimeValueTest.java
@@ -55,4 +55,17 @@ class TimeValueTest extends AbstractFSCrawlerTestCase {
         Assertions.assertThat(TimeValue.parseTimeValue("2d")).hasToString("2d");
         Assertions.assertThat(TimeValue.parseTimeValue("30d")).hasToString("30d");
     }
+
+    @Test
+    void stringConstructorParsesValues() {
+        Assertions.assertThat(new TimeValue("15m").minutes()).isEqualTo(15L);
+        Assertions.assertThat(new TimeValue("5s").millis()).isEqualTo(5000L);
+    }
+
+    @Test
+    void stringConstructorRejectsNull() {
+        Assertions.assertThatThrownBy(() -> new TimeValue((String) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("null");
+    }
 }

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractRestITCase.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractRestITCase.java
@@ -198,7 +198,6 @@ public abstract class AbstractRestITCase extends AbstractFsCrawlerITCase {
             builder.header(k + "*", "UTF-8''" + URLEncoder.encode((String) v, StandardCharsets.UTF_8));
         });
 
-        // params.forEach(builder::property);
         return builder.delete(clazz);
     }
 
@@ -279,30 +278,10 @@ public abstract class AbstractRestITCase extends AbstractFsCrawlerITCase {
 
         if (index != null) {
             mp.field("index", index);
-            // Sadly this does not work
-            /*
-            if (RandomizedTest.rarely()) {
-                logger.info("Force index name to {} using a form field", index);
-                mp.field("index", index);
-            } else {
-                logger.info("Force index name to {} using a query string parameter", index);
-                params.put("index", index);
-            }
-            */
         }
 
         if (id != null) {
             mp.field("id", id);
-            // Sadly this does not work
-            /*
-            if (RandomizedTest.rarely()) {
-                logger.info("Force id to {} using a form field", id);
-                mp.field("id", id);
-            } else {
-                logger.info("Force id to {} using a query string parameter", id);
-                params.put("id", id);
-            }
-             */
         }
 
         if (tagsFile != null) {

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestDatesIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestDatesIT.java
@@ -138,8 +138,7 @@ class FsCrawlerTestDatesIT extends AbstractFsCrawlerITCase {
         String hitAfterLastAccessed = documentAfter.read("$.file.last_accessed");
 
         // Apparently on some FS, the creation date may be modified when changing the
-        // modification date... So we can't really compare.
-        // assertThat(hitBeforeCreated, equalTo(hitAfterCreated));
+        // modification date... So we can't really compare; only warn when it changes.
         if (!hitBeforeCreated.equals(hitAfterCreated)) {
             logger.warn(
                     "OS is [{}]. Creation date changed from [{}] to [{}].",

--- a/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/CrawlerApi.java
+++ b/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/CrawlerApi.java
@@ -36,7 +36,7 @@ import org.apache.logging.log4j.Logger;
 
 /** REST API for controlling the crawler (pause, resume, status) */
 @Path("/_crawler")
-public class CrawlerApi extends RestApi {
+public class CrawlerApi implements RestApi {
     private static final Logger logger = LogManager.getLogger();
 
     private final FsParser fsParser;

--- a/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/DocumentApi.java
+++ b/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/DocumentApi.java
@@ -23,6 +23,7 @@ package fr.pilato.elasticsearch.crawler.fs.rest;
 import com.jayway.jsonpath.DocumentContext;
 import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
 import fr.pilato.elasticsearch.crawler.fs.beans.DocUtils;
+import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil;
 import fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil;
 import fr.pilato.elasticsearch.crawler.fs.framework.SignTool;
 import fr.pilato.elasticsearch.crawler.fs.service.FsCrawlerDocumentService;
@@ -86,22 +87,8 @@ public class DocumentApi implements RestApi {
             @FormDataParam("file") InputStream filecontent,
             @FormDataParam("file") FormDataContentDisposition d)
             throws IOException, NoSuchAlgorithmException {
-        String id;
-        if (formId != null) {
-            id = formId;
-        } else if (headerId != null) {
-            id = headerId;
-        } else {
-            id = queryParamId;
-        }
-        String index;
-        if (formIndex != null) {
-            index = formIndex;
-        } else if (headerIndex != null) {
-            index = headerIndex;
-        } else {
-            index = queryParamIndex;
-        }
+        String id = FsCrawlerUtil.getFirstNonNullValue(formId, headerId, queryParamId);
+        String index = FsCrawlerUtil.getFirstNonNullValue(formIndex, headerIndex, queryParamIndex);
         return uploadToDocumentService(debug, simulate, id, index, tags, filecontent, d);
     }
 
@@ -120,14 +107,7 @@ public class DocumentApi implements RestApi {
             @FormDataParam("file") InputStream filecontent,
             @FormDataParam("file") FormDataContentDisposition d)
             throws IOException, NoSuchAlgorithmException {
-        String index;
-        if (formIndex != null) {
-            index = formIndex;
-        } else if (headerIndex != null) {
-            index = headerIndex;
-        } else {
-            index = queryParamIndex;
-        }
+        String index = FsCrawlerUtil.getFirstNonNullValue(formIndex, headerIndex, queryParamIndex);
         return uploadToDocumentService(debug, simulate, id, index, tags, filecontent, d);
     }
 
@@ -142,8 +122,8 @@ public class DocumentApi implements RestApi {
             @HeaderParam("id") String headerId,
             @HeaderParam("index") String headerIndex,
             InputStream json) {
-        String id = headerId != null ? headerId : queryParamId;
-        String index = headerIndex != null ? headerIndex : queryParamIndex;
+        String id = FsCrawlerUtil.getFirstNonNullValue(headerId, queryParamId);
+        String index = FsCrawlerUtil.getFirstNonNullValue(headerIndex, queryParamIndex);
 
         DocumentContext document = JsonUtil.parseJsonAsDocumentContext(json);
         String type = document.read("$.type");

--- a/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/DocumentApi.java
+++ b/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/DocumentApi.java
@@ -86,8 +86,22 @@ public class DocumentApi extends RestApi {
             @FormDataParam("file") InputStream filecontent,
             @FormDataParam("file") FormDataContentDisposition d)
             throws IOException, NoSuchAlgorithmException {
-        String id = formId != null ? formId : headerId != null ? headerId : queryParamId;
-        String index = formIndex != null ? formIndex : headerIndex != null ? headerIndex : queryParamIndex;
+        String id;
+        if (formId != null) {
+            id = formId;
+        } else if (headerId != null) {
+            id = headerId;
+        } else {
+            id = queryParamId;
+        }
+        String index;
+        if (formIndex != null) {
+            index = formIndex;
+        } else if (headerIndex != null) {
+            index = headerIndex;
+        } else {
+            index = queryParamIndex;
+        }
         return uploadToDocumentService(debug, simulate, id, index, tags, filecontent, d);
     }
 
@@ -106,7 +120,14 @@ public class DocumentApi extends RestApi {
             @FormDataParam("file") InputStream filecontent,
             @FormDataParam("file") FormDataContentDisposition d)
             throws IOException, NoSuchAlgorithmException {
-        String index = formIndex != null ? formIndex : headerIndex != null ? headerIndex : queryParamIndex;
+        String index;
+        if (formIndex != null) {
+            index = formIndex;
+        } else if (headerIndex != null) {
+            index = headerIndex;
+        } else {
+            index = queryParamIndex;
+        }
         return uploadToDocumentService(debug, simulate, id, index, tags, filecontent, d);
     }
 

--- a/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/DocumentApi.java
+++ b/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/DocumentApi.java
@@ -54,7 +54,7 @@ import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 
 @Path("/_document")
-public class DocumentApi extends RestApi {
+public class DocumentApi implements RestApi {
     private static final Logger logger = LogManager.getLogger();
 
     private final FsCrawlerDocumentService documentService;

--- a/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/RestApi.java
+++ b/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/RestApi.java
@@ -20,4 +20,5 @@
  */
 package fr.pilato.elasticsearch.crawler.fs.rest;
 
-class RestApi {}
+/** Marker type for FSCrawler REST resource classes. */
+interface RestApi {}

--- a/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/ServerStatusApi.java
+++ b/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/ServerStatusApi.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 
 /** Root resource (exposed at "/" path) */
 @Path("/")
-public class ServerStatusApi extends RestApi {
+public class ServerStatusApi implements RestApi {
 
     private final FsCrawlerManagementService managementService;
     private final FsSettings settings;

--- a/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/TimeBasedUUIDGenerator.java
+++ b/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/TimeBasedUUIDGenerator.java
@@ -51,7 +51,7 @@ public class TimeBasedUUIDGenerator {
             }
         }
         // Could not find a mac address
-        return null;
+        return new byte[0];
     }
 
     private static boolean isValidAddress(byte[] address) {

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Server.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Server.java
@@ -29,6 +29,10 @@ import org.github.gestalt.config.annotations.Config;
 public class Server {
 
     public static final class PROTOCOL {
+        private PROTOCOL() {
+            // Constants holder
+        }
+
         public static final String LOCAL = "local";
         public static final String SSH = "ssh";
         public static final String FTP = "ftp";

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/ServerUrl.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/ServerUrl.java
@@ -37,7 +37,8 @@ public class ServerUrl {
 
     public void setUrl(String url) {
         logger.fatal(
-                "Setting elasticsearch.nodes.url has been removed in favor of elasticsearch.urls. "
-                        + "Please update your configuration. See https://fscrawler.readthedocs.io/en/latest/admin/fs/elasticsearch.html#node-settings.");
+                "Setting elasticsearch.nodes.url [{}] has been removed in favor of elasticsearch.urls. "
+                        + "Please update your configuration. See https://fscrawler.readthedocs.io/en/latest/admin/fs/elasticsearch.html#node-settings.",
+                url);
     }
 }

--- a/test-framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/framework/TestContainerHelper.java
+++ b/test-framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/framework/TestContainerHelper.java
@@ -170,7 +170,11 @@ public class TestContainerHelper {
         if (Integer.parseInt(elasticsearchVersion.split("\\.")[0]) > 8) {
             log.warn("From 9.0.0, we need to wait a bit before all security indices are allocated");
             try {
-                wait(2000);
+                long deadline = System.currentTimeMillis() + 2000L;
+                long remaining;
+                while ((remaining = deadline - System.currentTimeMillis()) > 0) {
+                    wait(remaining);
+                }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }

--- a/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
+++ b/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
@@ -222,6 +222,7 @@ public class TikaDocParser {
                                             doc.getPath().getReal()),
                                     sb.toString());
                         } catch (NoSuchAlgorithmException ignored) {
+                            // Error is already logged below; hash algorithm failure must not hide it
                         }
                         logger.warn(
                                 "Failed to extract [{}] characters of text for [{}]: {}",

--- a/tika/src/test/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParserTest.java
+++ b/tika/src/test/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParserTest.java
@@ -980,8 +980,7 @@ class TikaDocParserTest extends DocParserTestCase {
         Assertions.assertThat(doc.getContent()).contains("This file contains some words.");
         doc = extractFromFile("test-ocr.pdf", fsSettings);
         Assertions.assertThat(doc.getContent()).contains("This file contains some words.");
-        // TODO: for a strange reason ocr_only also extracts text.
-        // Assertions.assertThat(doc.getContent(), not(containsString("This file also contains text.")));
+        // ocr_only currently also extracts embedded text; keep assertion soft for now.
         doc = extractFromFile("test-ocr.docx", fsSettings);
         Assertions.assertThat(doc.getContent()).contains("This file contains some words.");
         Assertions.assertThat(doc.getContent()).contains("This file also contains text.");


### PR DESCRIPTION
Sonar is reporting some issues that we need to clean up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly style, comments, and refactors; the only user-visible CLI change is relaxed `--silent` parsing, and ES search URL assembly is a small fix aligned with other endpoints.
> 
> **Overview**
> This PR is mostly **Sonar-driven cleanup** with a few small behavior tweaks and tests.
> 
> **CLI:** `--silent` no longer fails at parse time when no job name is given; the default job still applies in `runner()`. Empty `catch` blocks get explanatory comments.
> 
> **Elasticsearch client:** Search URLs are built as `index/_search` (trailing slash on the index segment). Ingest pipeline calls use a shared `API_INGEST_PIPELINE` constant. The opt-out SSL trust manager is refactored into a named class with Sonar suppressions and documentation.
> 
> **REST / framework:** `RestApi` becomes a marker interface; upload endpoints resolve `id`/`index` via new `FsCrawlerUtil.getFirstNonNullValue`. `Percentage` and `TimeValue` string constructors reject null and document Gestalt binding. `FsCrawlerBulkProcessor` restores interrupt status on close. `TimeBasedUUIDGenerator` returns an empty byte array instead of null when no MAC is found.
> 
> **Misc:** License header cleanup on `Percentage`/`TimeValue`, `Server.PROTOCOL` private constructor, deprecated `ServerUrl` fatal log includes the bad URL, test container wait uses a deadline loop, Dockerfile OCR comment for intentional word-splitting, dead comments removed from ITs, and new unit tests for the helpers above.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab066ef2a11ce2cf56afe281275630ff62adcf3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->