### PR TITLE
Migrate release-drafter config and draft FSCrawler 3.0

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,18 +1,26 @@
-name-template: 'fscrawler-$RESOLVED_VERSION'
+name-template: 'FSCrawler $RESOLVED_VERSION 🌈'
 tag-template: 'fscrawler-$RESOLVED_VERSION'
+version-template: '$MAJOR.$MINOR'
+tag-prefix: 'fscrawler-'
 categories:
   - title: 🚀 New features
-    label: new
+    when:
+      label: new
   - title: 🚨 Bug Fixes
-    label: bug
+    when:
+      label: bug
   - title: 💉 Updated features
-    label: update
+    when:
+      label: update
   - title: 🧹 Cleaned or removed features
-    label: remove
+    when:
+      label: remove
   - title: 📝 Documentation updates
-    label: doc
+    when:
+      label: doc
   - title: 🚦 Tests
-    label: test
+    when:
+      label: test
 change-template: '- #$NUMBER: $TITLE (thanks to @$AUTHOR)'
 template: |
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,10 +15,23 @@ jobs:
       pull-requests: read
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
+      - name: Read version from pom.xml
+        id: pom
+        run: |
+          VERSION="$(python3 - <<'PY'
+          import xml.etree.ElementTree as ET
+          ns = {"m": "http://maven.apache.org/POM/4.0.0"}
+          version = ET.parse("pom.xml").getroot().find("m:version", ns).text
+          if version.endswith("-SNAPSHOT"):
+              version = version[: -len("-SNAPSHOT")]
+          print(version)
+          PY
+          )"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Using pom version (without -SNAPSHOT): $VERSION"
       - uses: release-drafter/release-drafter@v7
         with:
-          # Force the next draft to 3.0 (pom is already 3.0-SNAPSHOT; last tag is fscrawler-2.9).
-          # Remove this input after FSCrawler 3.0 is published so later releases resolve from tags.
-          version: '3.0'
+          version: ${{ steps.pom.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,20 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
       - name: Read version from pom.xml
         id: pom
-        run: |
-          VERSION="$(python3 - <<'PY'
-          import xml.etree.ElementTree as ET
-          ns = {"m": "http://maven.apache.org/POM/4.0.0"}
-          version = ET.parse("pom.xml").getroot().find("m:version", ns).text
-          if version.endswith("-SNAPSHOT"):
-              version = version[: -len("-SNAPSHOT")]
-          print(version)
-          PY
-          )"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Using pom version (without -SNAPSHOT): $VERSION"
+        run: echo "version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | sed 's/-SNAPSHOT//')" >> "$GITHUB_OUTPUT"
       - uses: release-drafter/release-drafter@v7
         with:
           version: ${{ steps.pom.outputs.version }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,5 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v7
+        with:
+          # Force the next draft to 3.0 (pom is already 3.0-SNAPSHOT; last tag is fscrawler-2.9).
+          # Remove this input after FSCrawler 3.0 is published so later releases resolve from tags.
+          version: '3.0'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Migrate deprecated `categories[*].label` fields to the v7 `when.label` syntax (removes Release Drafter warnings)
- Align draft naming with published releases: `FSCrawler $RESOLVED_VERSION 🌈` / tag `fscrawler-$RESOLVED_VERSION`
- Use `version-template: $MAJOR.$MINOR` and `tag-prefix: fscrawler-` (matches tags like `fscrawler-2.9`)
- Derive the draft version from the root `pom.xml` (`project.version`, strip `-SNAPSHOT`) so it stays in sync with Maven (currently → `3.0` → draft **FSCrawler 3.0 🌈**)

## Why 2.9.1 appeared

Last published tag is `fscrawler-2.9`. With the old `name-template: fscrawler-$RESOLVED_VERSION` and default patch bump, Release Drafter drafted `fscrawler-2.9.1`. It does not read the pom unless we pass `version` explicitly — which this PR now does from Maven.

## Test plan

- [ ] Merge to `master` (or re-run Release Drafter workflow)
- [ ] Confirm workflow annotations no longer warn about deprecated `categories[*].label`
- [ ] Confirm the “Read version from pom.xml” step logs `3.0`
- [ ] Confirm draft release name/tag are `FSCrawler 3.0 🌈` / `fscrawler-3.0`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ca7a0b9-812f-4721-8148-3ff831f96d01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ca7a0b9-812f-4721-8148-3ff831f96d01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

