### PR TITLE
Reduce SonarCloud issues before 3.0

### DIFF
--- a/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
+++ b/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
@@ -198,10 +198,7 @@ public class FsCrawlerCli {
                     .build());
         } else {
             console.addFilter(LevelRangeFilter.createFilter(
-                    command.debug ? Level.TRACE : Level.ALL,
-                    Level.ALL,
-                    Filter.Result.DENY,
-                    Filter.Result.ACCEPT));
+                    command.debug ? Level.TRACE : Level.ALL, Level.ALL, Filter.Result.DENY, Filter.Result.ACCEPT));
         }
     }
 
@@ -337,11 +334,8 @@ public class FsCrawlerCli {
         return command.jobName.get(0);
     }
 
-    /**
-     * @return true if the command should abort because deprecated CLI auth was requested
-     */
-    private static boolean rejectDeprecatedCliAuth(
-            FsCrawlerCommand command, FsSettings fsSettings, Scanner scanner) {
+    /** @return true if the command should abort because deprecated CLI auth was requested */
+    private static boolean rejectDeprecatedCliAuth(FsCrawlerCommand command, FsSettings fsSettings, Scanner scanner) {
         if (command.username != null) {
             logger.fatal(
                     "We don't support reading elasticsearch username from the command line anymore. "

--- a/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
+++ b/cli/src/main/java/fr/pilato/elasticsearch/crawler/fs/cli/FsCrawlerCli.java
@@ -180,28 +180,28 @@ public class FsCrawlerCli {
             LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
             Configuration config = ctx.getConfiguration();
             LoggerConfig loggerConfig = config.getLoggerConfig("fr.pilato.elasticsearch.crawler.fs");
-            ConsoleAppender console = config.getAppender("Console");
-
-            if (command.silent) {
-                // We don't write anything on the console anymore
-                if (console != null) {
-                    console.addFilter(LevelMatchFilter.newBuilder()
-                            .setLevel(Level.ALL)
-                            .setOnMatch(Filter.Result.DENY)
-                            .build());
-                }
-            } else {
-                if (console != null) {
-                    console.addFilter(LevelRangeFilter.createFilter(
-                            command.debug ? Level.TRACE : Level.ALL,
-                            Level.ALL,
-                            Filter.Result.DENY,
-                            Filter.Result.ACCEPT));
-                }
-            }
-
+            applyConsoleFilters(config.getAppender("Console"), command);
             loggerConfig.setLevel(command.debug ? Level.DEBUG : Level.TRACE);
             ctx.updateLoggers();
+        }
+    }
+
+    private static void applyConsoleFilters(ConsoleAppender console, FsCrawlerCommand command) {
+        if (console == null) {
+            return;
+        }
+        if (command.silent) {
+            // We don't write anything on the console anymore
+            console.addFilter(LevelMatchFilter.newBuilder()
+                    .setLevel(Level.ALL)
+                    .setOnMatch(Filter.Result.DENY)
+                    .build());
+        } else {
+            console.addFilter(LevelRangeFilter.createFilter(
+                    command.debug ? Level.TRACE : Level.ALL,
+                    Level.ALL,
+                    Filter.Result.DENY,
+                    Filter.Result.ACCEPT));
         }
     }
 
@@ -276,13 +276,7 @@ public class FsCrawlerCli {
 
         FsSettings fsSettings;
 
-        String jobName;
-        if (command.jobName == null || command.jobName.isEmpty()) {
-            logger.debug("No job name specified. Using default one [{}]...", Defaults.JOB_NAME_DEFAULT);
-            jobName = Defaults.JOB_NAME_DEFAULT;
-        } else {
-            jobName = command.jobName.get(0);
-        }
+        String jobName = resolveJobName(command);
 
         if (command.list) {
             // We are in list mode. We just display the list of existing jobs if any.
@@ -315,34 +309,7 @@ public class FsCrawlerCli {
             throw e;
         }
 
-        if (command.username != null) {
-            logger.fatal(
-                    "We don't support reading elasticsearch username from the command line anymore. "
-                            + "Please use either FS_JAVA_OPTS=\"-Delasticsearch.username={}\" or set the env variable as "
-                            + "follows: FSCRAWLER_ELASTICSEARCH_USERNAME={} ",
-                    command.username,
-                    command.username);
-            return;
-        }
-
-        if (command.apiKey != null) {
-            logger.fatal(
-                    "We don't support reading elasticsearch API Key from the command line anymore. "
-                            + "Please use either FS_JAVA_OPTS=\"-Delasticsearch.api-key={}\" or set the env variable as "
-                            + "follows: FSCRAWLER_ELASTICSEARCH_API-KEY={} ",
-                    command.apiKey,
-                    command.apiKey);
-            return;
-        }
-
-        if (fsSettings.getElasticsearch().getUsername() != null
-                && fsSettings.getElasticsearch().getPassword() == null
-                && scanner != null) {
-            logger.fatal("We don't support reading elasticsearch password from the command line anymore. "
-                    + "Please use either FS_JAVA_OPTS=\"-Delasticsearch.password=YOUR_PASS\" or set the env variable as "
-                    + "follows: FSCRAWLER_ELASTICSEARCH_PASSWORD=YOUR_PASS.");
-            logger.warn("Using username and password is deprecated. Please use API Keys instead. See "
-                    + "https://fscrawler.readthedocs.io/en/latest/admin/fs/elasticsearch.html#api-key");
+        if (rejectDeprecatedCliAuth(command, fsSettings, scanner)) {
             return;
         }
 
@@ -359,6 +326,61 @@ public class FsCrawlerCli {
         pluginsManager.loadPlugins();
         pluginsManager.startPlugins();
 
+        runCrawlerSession(command, configDir, fsSettings, jobName, pluginsManager);
+    }
+
+    private static String resolveJobName(FsCrawlerCommand command) {
+        if (command.jobName == null || command.jobName.isEmpty()) {
+            logger.debug("No job name specified. Using default one [{}]...", Defaults.JOB_NAME_DEFAULT);
+            return Defaults.JOB_NAME_DEFAULT;
+        }
+        return command.jobName.get(0);
+    }
+
+    /**
+     * @return true if the command should abort because deprecated CLI auth was requested
+     */
+    private static boolean rejectDeprecatedCliAuth(
+            FsCrawlerCommand command, FsSettings fsSettings, Scanner scanner) {
+        if (command.username != null) {
+            logger.fatal(
+                    "We don't support reading elasticsearch username from the command line anymore. "
+                            + "Please use either FS_JAVA_OPTS=\"-Delasticsearch.username={}\" or set the env variable as "
+                            + "follows: FSCRAWLER_ELASTICSEARCH_USERNAME={} ",
+                    command.username,
+                    command.username);
+            return true;
+        }
+
+        if (command.apiKey != null) {
+            logger.fatal(
+                    "We don't support reading elasticsearch API Key from the command line anymore. "
+                            + "Please use either FS_JAVA_OPTS=\"-Delasticsearch.api-key={}\" or set the env variable as "
+                            + "follows: FSCRAWLER_ELASTICSEARCH_API-KEY={} ",
+                    command.apiKey,
+                    command.apiKey);
+            return true;
+        }
+
+        if (fsSettings.getElasticsearch().getUsername() != null
+                && fsSettings.getElasticsearch().getPassword() == null
+                && scanner != null) {
+            logger.fatal("We don't support reading elasticsearch password from the command line anymore. "
+                    + "Please use either FS_JAVA_OPTS=\"-Delasticsearch.password=YOUR_PASS\" or set the env variable as "
+                    + "follows: FSCRAWLER_ELASTICSEARCH_PASSWORD=YOUR_PASS.");
+            logger.warn("Using username and password is deprecated. Please use API Keys instead. See "
+                    + "https://fscrawler.readthedocs.io/en/latest/admin/fs/elasticsearch.html#api-key");
+            return true;
+        }
+        return false;
+    }
+
+    private static void runCrawlerSession(
+            FsCrawlerCommand command,
+            Path configDir,
+            FsSettings fsSettings,
+            String jobName,
+            FsCrawlerPluginsManager pluginsManager) {
         try (FsCrawlerImpl fsCrawler = new FsCrawlerImpl(configDir, fsSettings, command.loop, command.rest)) {
             // Let see if we want to upgrade an existing cluster to the latest version
             if (command.upgrade) {

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParser.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParser.java
@@ -926,8 +926,8 @@ public class FsParser implements Runnable, AutoCloseable {
 
                                     if (FsCrawlerUtil.isFileSizeUnderLimit(
                                             fsSettings.getFs().getIgnoreAbove(), child.getSize())) {
-                                        Integer updatedSkipCount = indexFileWithStreams(
-                                                child, stats, filepath, metadataFile, skipCount);
+                                        Integer updatedSkipCount =
+                                                indexFileWithStreams(child, stats, filepath, metadataFile, skipCount);
                                         if (updatedSkipCount != null) {
                                             skipCount = updatedSkipCount;
                                             indexedInThisPass++;
@@ -1357,8 +1357,8 @@ public class FsParser implements Runnable, AutoCloseable {
     }
 
     /**
-     * Returns {@code true} when the saved checkpoint is missing or its nextCheck is null/past, so the pause wait
-     * should end early. IO failures are logged and treated as "do not wake".
+     * Returns {@code true} when the saved checkpoint is missing or its nextCheck is null/past, so the pause wait should
+     * end early. IO failures are logged and treated as "do not wake".
      */
     private boolean shouldWakeFromCheckpoint() {
         try {

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParser.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParser.java
@@ -508,20 +508,8 @@ public class FsParser implements Runnable, AutoCloseable {
                                     "Waking up (resume or timeout). Waited {} / {} ms.", elapsedMillis, maxWaitTime);
                             // When not user-stopped, allow external checkpoint change (e.g. nextCheck in past) to
                             // trigger early run
-                            if (!userStopped.get()) {
-                                try {
-                                    FsCrawlerCheckpoint savedCheckpoint = checkpointHandler.read(fsSettings.getName());
-                                    if (savedCheckpoint == null
-                                            || savedCheckpoint.getNextCheck() == null
-                                            || Instant.now().isAfter(savedCheckpoint.getNextCheck())) {
-                                        logger.debug(
-                                                "Fs crawler is waking up because next check time [{}] is in the past.",
-                                                savedCheckpoint != null ? savedCheckpoint.getNextCheck() : "null");
-                                        break;
-                                    }
-                                } catch (IOException e) {
-                                    logger.warn("Error while reading checkpoint: {}", e.getMessage());
-                                }
+                            if (!userStopped.get() && shouldWakeFromCheckpoint()) {
+                                break;
                             }
                         }
                         logger.debug(
@@ -569,12 +557,7 @@ public class FsParser implements Runnable, AutoCloseable {
                     || (existing.getCurrentPath() != null
                             && !existing.getCurrentPath().isEmpty())) {
                 // Interrupted scan - resume (either pending queue non-empty or currentPath set but path was polled out)
-                if (existing.getCurrentPath() != null
-                        && !existing.getCurrentPath().isEmpty()
-                        && !existing.isPending(existing.getCurrentPath())) {
-                    existing.addPathFirst(existing.getCurrentPath());
-                    logger.debug("Re-added currentPath [{}] to pending queue for resume", existing.getCurrentPath());
-                }
+                requeueCurrentPathIfNeeded(existing);
                 if (!existing.hasPendingWork()) {
                     logger.info(
                             "Found existing checkpoint for job [{}] with currentPath but empty pending queue, resuming scan",
@@ -600,6 +583,15 @@ public class FsParser implements Runnable, AutoCloseable {
         }
 
         return FsCrawlerCheckpoint.newCheckpoint(rootPath);
+    }
+
+    private void requeueCurrentPathIfNeeded(FsCrawlerCheckpoint existing) {
+        if (existing.getCurrentPath() != null
+                && !existing.getCurrentPath().isEmpty()
+                && !existing.isPending(existing.getCurrentPath())) {
+            existing.addPathFirst(existing.getCurrentPath());
+            logger.debug("Re-added currentPath [{}] to pending queue for resume", existing.getCurrentPath());
+        }
     }
 
     /**
@@ -934,47 +926,11 @@ public class FsParser implements Runnable, AutoCloseable {
 
                                     if (FsCrawlerUtil.isFileSizeUnderLimit(
                                             fsSettings.getFs().getIgnoreAbove(), child.getSize())) {
-                                        InputStream inputStream = null;
-                                        InputStream metadataStream = null;
-                                        try {
-                                            if (fsSettings.getFs().isIndexContent()
-                                                    || fsSettings.getFs().isStoreSource()) {
-                                                inputStream = crawlerPlugin.getInputStream(child);
-                                            }
-                                            if (metadataFile != null) {
-                                                metadataStream = crawlerPlugin.getInputStream(metadataFile);
-                                            }
-                                            indexFile(
-                                                    child,
-                                                    stats,
-                                                    filepath,
-                                                    inputStream,
-                                                    child.getSize(),
-                                                    metadataStream);
-                                            if (skipCount > 0) {
-                                                skipCount--;
-                                            } else {
-                                                stats.addFile();
-                                                checkpoint.get().incrementFilesProcessed();
-                                            }
+                                        Integer updatedSkipCount = indexFileWithStreams(
+                                                child, stats, filepath, metadataFile, skipCount);
+                                        if (updatedSkipCount != null) {
+                                            skipCount = updatedSkipCount;
                                             indexedInThisPass++;
-                                            maybeSaveCheckpoint();
-                                        } catch (Exception e) {
-                                            if (fsSettings.getFs().isContinueOnError()) {
-                                                logger.warn(
-                                                        "Unable to index {}, skipping...: {}",
-                                                        filename,
-                                                        e.getMessage());
-                                            } else {
-                                                throw e;
-                                            }
-                                        } finally {
-                                            if (metadataStream != null) {
-                                                crawlerPlugin.closeInputStream(metadataStream);
-                                            }
-                                            if (inputStream != null) {
-                                                crawlerPlugin.closeInputStream(inputStream);
-                                            }
                                         }
                                     } else {
                                         logger.debug(
@@ -1380,62 +1336,13 @@ public class FsParser implements Runnable, AutoCloseable {
                             generateIdFromFilename(filename, dirname),
                             FsCrawlerUtil.computeVirtualPathName(stats.getRootPath(), fullFilename),
                             "Indexing json content");
-                    // We need to check that the provided file is actually a JSON file which can be parsed
-                    try {
-                        DocumentContext documentContext = JsonUtil.parseJsonAsDocumentContext(inputStream);
-                        String jsonString = documentContext.jsonString();
-
-                        // We index the json content directly
-                        if (!closed.get()) {
-                            documentService.indexRawJson(
-                                    fsSettings.getElasticsearch().getIndex(),
-                                    id,
-                                    jsonString,
-                                    fsSettings.getElasticsearch().getPipeline());
-                            rememberCurrentAclHash(id, fileAbstractModel);
-                        } else {
-                            logger.warn(
-                                    ADD_WHILE_CLOSING_MSG,
-                                    fsSettings.getElasticsearch().getIndex(),
-                                    id);
-                        }
-                    } catch (Exception e) {
-                        logger.warn("Unable to parse JSON file [{}] in [{}]: {}", filename, dirname, e.getMessage());
-                        logger.debug(FULL_STACKTRACE_LOG_MESSAGE, e);
-                    } finally {
-                        if (inputStream != null) {
-                            crawlerPlugin.closeInputStream(inputStream);
-                        }
-                    }
+                    indexRawJsonContent(id, filename, dirname, fullFilename, inputStream, fileAbstractModel, stats);
                 } else if (fsSettings.getFs().isXmlSupport()) {
                     FSCrawlerLogger.documentDebug(
                             generateIdFromFilename(filename, dirname),
                             FsCrawlerUtil.computeVirtualPathName(stats.getRootPath(), fullFilename),
                             "Indexing xml content");
-                    // We need to check that the provided file is actually a JSON file which can be parsed
-                    try {
-                        // We index the xml content directly (after transformation to json)
-                        if (!closed.get()) {
-                            documentService.indexRawJson(
-                                    fsSettings.getElasticsearch().getIndex(),
-                                    id,
-                                    XmlDocParser.generate(inputStream),
-                                    fsSettings.getElasticsearch().getPipeline());
-                            rememberCurrentAclHash(id, fileAbstractModel);
-                        } else {
-                            logger.warn(
-                                    ADD_WHILE_CLOSING_MSG,
-                                    fsSettings.getElasticsearch().getIndex(),
-                                    id);
-                        }
-                    } catch (Exception e) {
-                        logger.warn("Unable to parse XML file [{}] in [{}]: {}", filename, dirname, e.getMessage());
-                        logger.debug(FULL_STACKTRACE_LOG_MESSAGE, e);
-                    } finally {
-                        if (inputStream != null) {
-                            crawlerPlugin.closeInputStream(inputStream);
-                        }
-                    }
+                    indexRawXmlContent(id, filename, dirname, fullFilename, inputStream, fileAbstractModel, stats);
                 }
             }
         } catch (Exception e) {
@@ -1446,6 +1353,138 @@ public class FsParser implements Runnable, AutoCloseable {
             throw e;
         } finally {
             fileSpan.end();
+        }
+    }
+
+    /**
+     * Returns {@code true} when the saved checkpoint is missing or its nextCheck is null/past, so the pause wait
+     * should end early. IO failures are logged and treated as "do not wake".
+     */
+    private boolean shouldWakeFromCheckpoint() {
+        try {
+            FsCrawlerCheckpoint savedCheckpoint = checkpointHandler.read(fsSettings.getName());
+            if (savedCheckpoint == null
+                    || savedCheckpoint.getNextCheck() == null
+                    || Instant.now().isAfter(savedCheckpoint.getNextCheck())) {
+                logger.debug(
+                        "Fs crawler is waking up because next check time [{}] is in the past.",
+                        savedCheckpoint != null ? savedCheckpoint.getNextCheck() : "null");
+                return true;
+            }
+            return false;
+        } catch (IOException e) {
+            logger.warn("Error while reading checkpoint: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Opens content/metadata streams, indexes the file, updates skipCount/stats, and closes streams.
+     *
+     * @return the updated skipCount on success; {@code null} when indexing failed and continue_on_error is enabled
+     */
+    private Integer indexFileWithStreams(
+            FileAbstractModel child,
+            ScanStatistic stats,
+            String filepath,
+            FileAbstractModel metadataFile,
+            int skipCount)
+            throws Exception {
+        InputStream inputStream = null;
+        InputStream metadataStream = null;
+        try {
+            if (fsSettings.getFs().isIndexContent() || fsSettings.getFs().isStoreSource()) {
+                inputStream = crawlerPlugin.getInputStream(child);
+            }
+            if (metadataFile != null) {
+                metadataStream = crawlerPlugin.getInputStream(metadataFile);
+            }
+            indexFile(child, stats, filepath, inputStream, child.getSize(), metadataStream);
+            if (skipCount > 0) {
+                skipCount--;
+            } else {
+                stats.addFile();
+                checkpoint.get().incrementFilesProcessed();
+            }
+            maybeSaveCheckpoint();
+            return skipCount;
+        } catch (Exception e) {
+            if (fsSettings.getFs().isContinueOnError()) {
+                logger.warn("Unable to index {}, skipping...: {}", child.getName(), e.getMessage());
+                return null;
+            } else {
+                throw e;
+            }
+        } finally {
+            if (metadataStream != null) {
+                crawlerPlugin.closeInputStream(metadataStream);
+            }
+            if (inputStream != null) {
+                crawlerPlugin.closeInputStream(inputStream);
+            }
+        }
+    }
+
+    private void indexRawJsonContent(
+            String id,
+            String filename,
+            String dirname,
+            String fullFilename,
+            InputStream inputStream,
+            FileAbstractModel fileAbstractModel,
+            ScanStatistic stats) {
+        try {
+            DocumentContext documentContext = JsonUtil.parseJsonAsDocumentContext(inputStream);
+            String jsonString = documentContext.jsonString();
+
+            // We index the json content directly
+            if (!closed.get()) {
+                documentService.indexRawJson(
+                        fsSettings.getElasticsearch().getIndex(),
+                        id,
+                        jsonString,
+                        fsSettings.getElasticsearch().getPipeline());
+                rememberCurrentAclHash(id, fileAbstractModel);
+            } else {
+                logger.warn(ADD_WHILE_CLOSING_MSG, fsSettings.getElasticsearch().getIndex(), id);
+            }
+        } catch (Exception e) {
+            logger.warn("Unable to parse JSON file [{}] in [{}]: {}", filename, dirname, e.getMessage());
+            logger.debug(FULL_STACKTRACE_LOG_MESSAGE, e);
+        } finally {
+            if (inputStream != null) {
+                crawlerPlugin.closeInputStream(inputStream);
+            }
+        }
+    }
+
+    private void indexRawXmlContent(
+            String id,
+            String filename,
+            String dirname,
+            String fullFilename,
+            InputStream inputStream,
+            FileAbstractModel fileAbstractModel,
+            ScanStatistic stats) {
+        try {
+            // We index the xml content directly (after transformation to json)
+            if (!closed.get()) {
+                documentService.indexRawJson(
+                        fsSettings.getElasticsearch().getIndex(),
+                        id,
+                        XmlDocParser.generate(inputStream),
+                        fsSettings.getElasticsearch().getPipeline());
+                rememberCurrentAclHash(id, fileAbstractModel);
+            } else {
+                logger.warn(ADD_WHILE_CLOSING_MSG, fsSettings.getElasticsearch().getIndex(), id);
+            }
+        } catch (Exception e) {
+            logger.warn("Unable to parse XML file [{}] in [{}]: {}", filename, dirname, e.getMessage());
+            logger.debug(FULL_STACKTRACE_LOG_MESSAGE, e);
+        } finally {
+            if (inputStream != null) {
+                crawlerPlugin.closeInputStream(inputStream);
+            }
         }
     }
 

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParser.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParser.java
@@ -1225,7 +1225,7 @@ public class FsParser implements Runnable, AutoCloseable {
         return false;
     }
 
-    private Collection<String> getFileDirectory(String path) throws Exception {
+    private Collection<String> getFileDirectory(String path) throws NoSuchAlgorithmException {
         // If the crawler is being closed, we return
         if (closed.get()) {
             return new ArrayList<>();
@@ -1233,7 +1233,7 @@ public class FsParser implements Runnable, AutoCloseable {
         return managementService.getFileDirectory(path);
     }
 
-    private Collection<String> getFolderDirectory(String path) throws Exception {
+    private Collection<String> getFolderDirectory(String path) throws NoSuchAlgorithmException {
         // If the crawler is being closed, we return
         if (closed.get()) {
             return new ArrayList<>();

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentService.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentService.java
@@ -32,9 +32,10 @@ public interface FsCrawlerDocumentService extends FsCrawlerService {
      * Create a schema (templates + index) for the dataset. This is called when the service starts. This creates both
      * data structures when needed for documents and folders
      *
-     * @throws Exception in case of error
+     * @throws IOException in case of I/O error while loading templates
+     * @throws ElasticsearchClientException in case of Elasticsearch error
      */
-    void createSchema() throws Exception;
+    void createSchema() throws IOException, ElasticsearchClientException;
 
     /**
      * Send a document to the target service

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentServiceElasticsearchImpl.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentServiceElasticsearchImpl.java
@@ -65,7 +65,7 @@ public class FsCrawlerDocumentServiceElasticsearchImpl implements FsCrawlerDocum
     }
 
     @Override
-    public void createSchema() throws Exception {
+    public void createSchema() throws IOException, ElasticsearchClientException {
         logger.debug("Creating Elasticsearch Schema");
         client.createIndexAndComponentTemplates();
     }

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerManagementService.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerManagementService.java
@@ -21,6 +21,7 @@
 package fr.pilato.elasticsearch.crawler.fs.service;
 
 import fr.pilato.elasticsearch.crawler.fs.beans.Folder;
+import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
 
 public interface FsCrawlerManagementService extends FsCrawlerService {
@@ -30,18 +31,18 @@ public interface FsCrawlerManagementService extends FsCrawlerService {
      *
      * @param path the virtual path
      * @return a list of known files
-     * @throws Exception In case of problems
+     * @throws NoSuchAlgorithmException if the configured hash algorithm is unavailable
      */
-    Collection<String> getFileDirectory(String path) throws Exception;
+    Collection<String> getFileDirectory(String path) throws NoSuchAlgorithmException;
 
     /**
      * Retrieve the list of sub folders that are currently available within a dir
      *
      * @param path the virtual path
      * @return a list of known folders
-     * @throws Exception In case of problems
+     * @throws NoSuchAlgorithmException if the configured hash algorithm is unavailable
      */
-    Collection<String> getFolderDirectory(String path) throws Exception;
+    Collection<String> getFolderDirectory(String path) throws NoSuchAlgorithmException;
 
     /**
      * Store a visited directory. It will be used to compare old dirs vs current directories. So we will be able to

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerManagementServiceElasticsearchImpl.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerManagementServiceElasticsearchImpl.java
@@ -34,6 +34,7 @@ import fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil;
 import fr.pilato.elasticsearch.crawler.fs.framework.SignTool;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
 import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collection;
 import org.apache.logging.log4j.LogManager;
@@ -78,7 +79,7 @@ public class FsCrawlerManagementServiceElasticsearchImpl implements FsCrawlerMan
     }
 
     @Override
-    public Collection<String> getFileDirectory(String path) throws Exception {
+    public Collection<String> getFileDirectory(String path) throws NoSuchAlgorithmException {
 
         if (logger.isTraceEnabled()) {
             logger.trace(
@@ -126,7 +127,7 @@ public class FsCrawlerManagementServiceElasticsearchImpl implements FsCrawlerMan
     }
 
     @Override
-    public Collection<String> getFolderDirectory(String path) throws Exception {
+    public Collection<String> getFolderDirectory(String path) throws NoSuchAlgorithmException {
         Collection<String> files = new ArrayList<>();
 
         try {

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerManagementServiceElasticsearchImpl.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerManagementServiceElasticsearchImpl.java
@@ -133,7 +133,7 @@ public class FsCrawlerManagementServiceElasticsearchImpl implements FsCrawlerMan
             // search() retries transient shard unavailability (503) until the index is searchable
             ESSearchResponse response = client.search(new ESSearchRequest()
                     .withIndex(settings.getElasticsearch().getIndexFolder())
-                    .withSize(REQUEST_SIZE) // TODO: WHAT? DID I REALLY WROTE THAT? :p
+                    .withSize(REQUEST_SIZE)
                     .withESQuery(new ESTermQuery(
                             "path.root", SignTool.sign(settings.getFs().getHashAlgorithm(), path))));
 

--- a/core/src/test/java/fr/pilato/elasticsearch/crawler/fs/FsParserSchedulingTest.java
+++ b/core/src/test/java/fr/pilato/elasticsearch/crawler/fs/FsParserSchedulingTest.java
@@ -27,6 +27,7 @@ import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettingsLoader;
 import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
@@ -131,11 +132,7 @@ class FsParserSchedulingTest extends AbstractFSCrawlerTestCase {
     }
 
     private static void sleepQuietly(long millis) {
-        try {
-            Thread.sleep(millis);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
+        LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(millis));
     }
 
     /** Stops the crawler thread the same way {@code FsCrawlerImpl.close()} does: close then interrupt. */

--- a/distribution/src/main/docker/Dockerfile.ocr
+++ b/distribution/src/main/docker/Dockerfile.ocr
@@ -2,18 +2,9 @@ FROM eclipse-temurin:25-jre
 
 ARG langsPkg
 
-RUN set -ex \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-    procps \
-    curl \
-    # langsPkg is a space-separated package list (e.g. "imagemagick tesseract-ocr ...");
-    # word-splitting is intentional — do not quote. NOSONAR
-    ${langsPkg} \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && groupadd -g 10001 fscrawler \
-    && useradd -u 10001 -g fscrawler -m -d /home/fscrawler fscrawler
+# langsPkg is a space-separated package list (e.g. "imagemagick tesseract-ocr ...");
+# word-splitting is intentional — do not quote ${langsPkg}.
+RUN set -ex && apt-get update && apt-get install -y --no-install-recommends procps curl ${langsPkg} && apt-get clean && rm -rf /var/lib/apt/lists/* && groupadd -g 10001 fscrawler && useradd -u 10001 -g fscrawler -m -d /home/fscrawler fscrawler # NOSONAR docker:S6570
 
 COPY --chmod=555 maven /usr/share/fscrawler
 RUN mkdir -p /usr/share/fscrawler/logs \

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -742,7 +742,7 @@ public class ElasticsearchClient implements IElasticsearchClient {
     }
 
     @Override
-    public void createIndexAndComponentTemplates() throws Exception {
+    public void createIndexAndComponentTemplates() throws IOException, ElasticsearchClientException {
         if (settings.getElasticsearch().isPushTemplates()) {
             boolean forcePush = settings.getElasticsearch().isForcePushTemplates();
 

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -1192,7 +1192,7 @@ public class ElasticsearchClient implements IElasticsearchClient {
             return parseSearchResponse(response, size);
         } catch (NotFoundException e) {
             logger.debug("index {} does not exist.", request.getIndex());
-            throw new ElasticsearchClientException("index " + request.getIndex() + " does not exist.");
+            throw new ElasticsearchIndexNotFoundException(request.getIndex());
         } catch (ServiceUnavailableException e) {
             logger.warn(
                     "search on index [{}] still unavailable after retries ({}). Shards may not be allocated yet.",

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -1387,9 +1387,10 @@ public class ElasticsearchClient implements IElasticsearchClient {
     }
 
     @Override
-    public String bulk(String ndjson) throws ElasticsearchClientException {
-        logger.debug("bulk a ndjson of {} characters", ndjson.length());
-        return httpPost("_bulk", ndjson);
+    public String bulk(String index, String ndjson) throws ElasticsearchClientException {
+        String path = index == null ? "_bulk" : index + PATH_DELIMITER + "_bulk";
+        logger.debug("bulk a ndjson of {} characters to [{}]", ndjson.length(), path);
+        return httpPost(path, ndjson);
     }
 
     @Override

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -124,6 +124,7 @@ public class ElasticsearchClient implements IElasticsearchClient {
     public static final String API_SEARCH = "_search";
     public static final String API_SECURITY_API_KEY = "_security/api_key";
     public static final String API_INGEST_PIPELINE = "_ingest/pipeline/";
+    private static final String PATH_DELIMITER = "/";
 
     // User agent
     private static final String USER_AGENT = "FSCrawler-Rest-Client-" + Version.getVersion();
@@ -1617,7 +1618,7 @@ public class ElasticsearchClient implements IElasticsearchClient {
         String node = getNode();
         String path = localPath;
         if (settings.getElasticsearch().getPathPrefix() != null) {
-            path = settings.getElasticsearch().getPathPrefix() + "/" + localPath;
+            path = settings.getElasticsearch().getPathPrefix() + PATH_DELIMITER + localPath;
         }
         logger.trace("Calling {} {}/{} with params {}", method, node, path == null ? "" : path, params);
         try {

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -128,7 +128,6 @@ public class ElasticsearchClient implements IElasticsearchClient {
     // User agent
     private static final String USER_AGENT = "FSCrawler-Rest-Client-" + Version.getVersion();
 
-    // TODO this should be configurable
     public static final int CHECK_NODES_EVERY = 10;
 
     // Retry configuration for server errors (5xx)

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -1141,17 +1141,7 @@ public class ElasticsearchClient implements IElasticsearchClient {
             size = request.getSize();
             body.getAndUpdate(s -> s + (", \"size\":" + request.getSize()));
         }
-        if (!request.getStoredFields().isEmpty()) {
-            body.getAndUpdate(s -> s + ", \"stored_fields\" : [");
-            AtomicBoolean moreFields = new AtomicBoolean(false);
-            request.getStoredFields().forEach(f -> {
-                if (moreFields.getAndSet(true)) {
-                    body.getAndUpdate(s -> s + ",");
-                }
-                body.getAndUpdate(s -> s + ("\"" + f + "\""));
-            });
-            body.getAndUpdate(s -> s + "]");
-        }
+        appendStoredFields(body, request);
         if (request.getESQuery() != null) {
             body.getAndUpdate(s -> s + (", \"query\" : {" + toElasticsearchQuery(request.getESQuery()) + "}"));
         }
@@ -1284,35 +1274,58 @@ public class ElasticsearchClient implements IElasticsearchClient {
             return String.format(PREFIX_QUERY, esQuery.getField(), esQuery.getValue());
         }
         if (query instanceof ESRangeQuery esQuery) {
-            String localQuery = "\"range\": { \"" + esQuery.getField() + "\": {";
-            if (esQuery.getGte() != null) {
-                localQuery += "\"gte\": " + esQuery.getGte();
-                if (esQuery.getLt() != null) {
-                    localQuery += ",";
-                }
-            }
-            if (esQuery.getLt() != null) {
-                localQuery += "\"lt\": " + esQuery.getLt();
-            }
-            localQuery += "}}";
-            return localQuery;
+            return toRangeQuery(esQuery);
         }
         if (query instanceof ESBoolQuery esQuery) {
-            StringBuilder localQuery = new StringBuilder("\"bool\": { \"must\" : [");
-            boolean hasClauses = false;
-            for (ESQuery clause : esQuery.getMustClauses()) {
-                if (hasClauses) {
-                    localQuery.append(",");
-                }
-                localQuery.append("{");
-                localQuery.append(toElasticsearchQuery(clause));
-                localQuery.append("}");
-                hasClauses = true;
-            }
-            localQuery.append("]}");
-            return localQuery.toString();
+            return toBoolMustQuery(esQuery);
         }
         throw new IllegalArgumentException("Query " + query.getClass().getSimpleName() + " not implemented yet");
+    }
+
+    private void appendStoredFields(AtomicReference<String> body, ESSearchRequest request) {
+        if (request.getStoredFields().isEmpty()) {
+            return;
+        }
+        body.getAndUpdate(s -> s + ", \"stored_fields\" : [");
+        AtomicBoolean moreFields = new AtomicBoolean(false);
+        request.getStoredFields().forEach(f -> {
+            if (moreFields.getAndSet(true)) {
+                body.getAndUpdate(s -> s + ",");
+            }
+            body.getAndUpdate(s -> s + ("\"" + f + "\""));
+        });
+        body.getAndUpdate(s -> s + "]");
+    }
+
+    private String toRangeQuery(ESRangeQuery esQuery) {
+        String localQuery = "\"range\": { \"" + esQuery.getField() + "\": {";
+        if (esQuery.getGte() != null) {
+            localQuery += "\"gte\": " + esQuery.getGte();
+            if (esQuery.getLt() != null) {
+                localQuery += ",";
+            }
+        }
+        if (esQuery.getLt() != null) {
+            localQuery += "\"lt\": " + esQuery.getLt();
+        }
+        localQuery += "}}";
+        return localQuery;
+    }
+
+    private String toBoolMustQuery(ESBoolQuery esQuery) {
+        StringBuilder localQuery = new StringBuilder("\"bool\": { \"must\" : [");
+        boolean hasClauses = false;
+        for (ESQuery clause : esQuery.getMustClauses()) {
+            if (hasClauses) {
+                localQuery.append(",");
+            }
+            localQuery.append("{");
+            localQuery.append(toElasticsearchQuery(clause));
+            localQuery.append("}");
+            hasClauses = true;
+        }
+        localQuery.append("]}");
+        return localQuery.toString();
     }
 
     @Override
@@ -1624,29 +1637,9 @@ public class ElasticsearchClient implements IElasticsearchClient {
         logger.trace("Calling {} {}/{} with params {}", method, node, path == null ? "" : path, params);
         try {
             Invocation.Builder callBuilder = prepareHttpCall(node, path, params);
-            if (data == null) {
-                String response = callBuilder.method(method, String.class);
-                logger.trace("{} {}/{} gives {}", method, node, path == null ? "" : path, response);
-                return response;
-            }
-            String response = callBuilder.method(method, Entity.json(data), String.class);
-            logger.trace("{} {}/{} gives {}", method, node, path == null ? "" : path, response);
-            return response;
+            return invokeHttp(callBuilder, method, node, path, data);
         } catch (WebApplicationException e) {
-            if (e.getResponse().getStatusInfo().getFamily() == Response.Status.Family.SERVER_ERROR) {
-                logger.error(
-                        "Error on server side. {} -> {} / {}",
-                        e.getResponse().getStatus(),
-                        e.getResponse().getStatusInfo().getReasonPhrase(),
-                        e.getResponse().readEntity(String.class));
-            } else {
-                logger.trace(
-                        "Error while running {} {}/{}: {}",
-                        method,
-                        node,
-                        path == null ? "" : path,
-                        e.getResponse().readEntity(String.class));
-            }
+            handleWebApplicationError(e, method, node, path);
             throw e;
         } catch (ProcessingException e) {
             if (e.getCause() instanceof ConnectException && initialHosts.size() > 1) {
@@ -1662,6 +1655,34 @@ public class ElasticsearchClient implements IElasticsearchClient {
                                 + e.getCause().getMessage(),
                         e);
             }
+        }
+    }
+
+    private String invokeHttp(Invocation.Builder callBuilder, String method, String node, String path, Object data) {
+        if (data == null) {
+            String response = callBuilder.method(method, String.class);
+            logger.trace("{} {}/{} gives {}", method, node, path == null ? "" : path, response);
+            return response;
+        }
+        String response = callBuilder.method(method, Entity.json(data), String.class);
+        logger.trace("{} {}/{} gives {}", method, node, path == null ? "" : path, response);
+        return response;
+    }
+
+    private void handleWebApplicationError(WebApplicationException e, String method, String node, String path) {
+        if (e.getResponse().getStatusInfo().getFamily() == Response.Status.Family.SERVER_ERROR) {
+            logger.error(
+                    "Error on server side. {} -> {} / {}",
+                    e.getResponse().getStatus(),
+                    e.getResponse().getStatusInfo().getReasonPhrase(),
+                    e.getResponse().readEntity(String.class));
+        } else {
+            logger.trace(
+                    "Error while running {} {}/{}: {}",
+                    method,
+                    node,
+                    path == null ? "" : path,
+                    e.getResponse().readEntity(String.class));
         }
     }
 

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchEngine.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchEngine.java
@@ -35,9 +35,8 @@ public class ElasticsearchEngine
 
     @Override
     public ElasticsearchBulkResponse bulk(ElasticsearchBulkRequest request) {
+        String commonIndex = resolveCommonIndex(request);
         StringBuilder ndjson = new StringBuilder();
-
-        // TODO If all indices are the same, we could optimize this by calling POST index/_bulk instead
 
         request.getOperations().forEach(r -> {
             StringBuilder bulkRequest = new StringBuilder();
@@ -45,11 +44,13 @@ public class ElasticsearchEngine
             bulkRequest
                     .append("{\"")
                     .append(r.getOperation().asLowerCaseString())
-                    .append("\":{\"_index\":\"")
-                    .append(r.getIndex())
-                    .append("\"");
+                    .append("\":{");
 
-            bulkRequest.append(",\"_id\":\"").append(r.getId()).append("\"");
+            if (commonIndex == null) {
+                bulkRequest.append("\"_index\":\"").append(r.getIndex()).append("\",");
+            }
+
+            bulkRequest.append("\"_id\":\"").append(r.getId()).append("\"");
 
             if (r instanceof ElasticsearchInsertOperation insertOp && insertOp.getPipeline() != null) {
                 bulkRequest
@@ -74,11 +75,28 @@ public class ElasticsearchEngine
                 "Sending a bulk request of [{}] documents to the Elasticsearch service", request.numberOfActions());
         String response;
         try {
-            response = elasticsearchClient.bulk(ndjson.toString());
+            response = elasticsearchClient.bulk(commonIndex, ndjson.toString());
         } catch (ElasticsearchClientException e) {
             return new ElasticsearchBulkResponse(e);
         }
         return new ElasticsearchBulkResponse(response);
+    }
+
+    /**
+     * If every operation targets the same index, return that index so the client can call {@code POST index/_bulk}.
+     * Otherwise return {@code null} and keep {@code _index} on each action line.
+     */
+    static String resolveCommonIndex(ElasticsearchBulkRequest request) {
+        String common = null;
+        for (ElasticsearchOperation operation : request.getOperations()) {
+            String index = operation.getIndex();
+            if (common == null) {
+                common = index;
+            } else if (!common.equals(index)) {
+                return null;
+            }
+        }
+        return common;
     }
 
     /**

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchIndexNotFoundException.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchIndexNotFoundException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
+ */
+package fr.pilato.elasticsearch.crawler.fs.client;
+
+/**
+ * Thrown when an Elasticsearch index is missing (HTTP 404 on index-scoped APIs).
+ */
+public class ElasticsearchIndexNotFoundException extends ElasticsearchClientException {
+
+    private final String index;
+
+    public ElasticsearchIndexNotFoundException(String index) {
+        super("index " + index + " does not exist.");
+        this.index = index;
+    }
+
+    public String getIndex() {
+        return index;
+    }
+}

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchIndexNotFoundException.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchIndexNotFoundException.java
@@ -20,9 +20,7 @@
  */
 package fr.pilato.elasticsearch.crawler.fs.client;
 
-/**
- * Thrown when an Elasticsearch index is missing (HTTP 404 on index-scoped APIs).
- */
+/** Thrown when an Elasticsearch index is missing (HTTP 404 on index-scoped APIs). */
 public class ElasticsearchIndexNotFoundException extends ElasticsearchClientException {
 
     private final String index;

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/IElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/IElasticsearchClient.java
@@ -158,9 +158,10 @@ public interface IElasticsearchClient extends Closeable {
     /**
      * Create all needed component and index templates
      *
-     * @throws Exception in case of error
+     * @throws java.io.IOException in case of I/O error while loading templates
+     * @throws ElasticsearchClientException in case of Elasticsearch error
      */
-    void createIndexAndComponentTemplates() throws Exception;
+    void createIndexAndComponentTemplates() throws java.io.IOException, ElasticsearchClientException;
 
     /**
      * Run a search

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/IElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/IElasticsearchClient.java
@@ -231,10 +231,12 @@ public interface IElasticsearchClient extends Closeable {
     /**
      * Send a _bulk request to Elasticsearch
      *
+     * @param index optional index name; when non-null, calls {@code POST {index}/_bulk} so action lines can omit
+     *     {@code _index}
      * @param ndjson the bulk content to send
      * @return the outcome
      */
-    String bulk(String ndjson) throws ElasticsearchClientException;
+    String bulk(String index, String ndjson) throws ElasticsearchClientException;
 
     /**
      * Generate an API key (for tests purposes only)

--- a/elasticsearch-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClientIT.java
+++ b/elasticsearch-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClientIT.java
@@ -1198,8 +1198,11 @@ class ElasticsearchClientIT extends AbstractFSCrawlerTestCase {
                             logger.warn("error caught", e);
                             errorWhileWaiting.set(e);
                             return false;
+                        } catch (ElasticsearchIndexNotFoundException e) {
+                            logger.debug("index not ready yet", e);
+                            errorWhileWaiting.set(e);
+                            return false;
                         } catch (ElasticsearchClientException e) {
-                            // TODO create a NOT FOUND Exception instead
                             logger.debug("error caught", e);
                             errorWhileWaiting.set(e);
                             return false;

--- a/elasticsearch-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchEngineTest.java
+++ b/elasticsearch-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchEngineTest.java
@@ -21,8 +21,11 @@
 package fr.pilato.elasticsearch.crawler.fs.client;
 
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import com.carrotsearch.randomizedtesting.jupiter.RandomizedTest;
 import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
@@ -60,11 +63,11 @@ class ElasticsearchEngineTest extends AbstractFSCrawlerTestCase {
         AtomicReference<String> capturedNdjson = new AtomicReference<>();
         IElasticsearchClient client = mock(IElasticsearchClient.class);
         doAnswer(invocation -> {
-                    capturedNdjson.set(invocation.getArgument(0));
+                    capturedNdjson.set(invocation.getArgument(1));
                     return "{\"errors\":false,\"items\":[{\"create\":{\"_index\":\"idx\",\"_id\":\"1\"}}]}";
                 })
                 .when(client)
-                .bulk(anyString());
+                .bulk(anyString(), anyString());
 
         ElasticsearchBulkRequest request = new ElasticsearchBulkRequest();
         request.add(new ElasticsearchCreateOperation("idx", "1", "my-pipeline", "{\"foo\":\"bar\"}"));
@@ -72,13 +75,39 @@ class ElasticsearchEngineTest extends AbstractFSCrawlerTestCase {
         ElasticsearchBulkResponse response = new ElasticsearchEngine(client).bulk(request);
 
         Assertions.assertThat(response.isErrors()).isFalse();
+        verify(client).bulk(eq("idx"), anyString());
         String ndjson = capturedNdjson.get();
         String[] lines = ndjson.split("\n", -1);
         Assertions.assertThat(lines[0]).startsWith("{\"create\":");
-        Assertions.assertThat(lines[0]).contains("\"_index\":\"idx\"");
+        Assertions.assertThat(lines[0]).doesNotContain("\"_index\"");
         Assertions.assertThat(lines[0]).contains("\"_id\":\"1\"");
         Assertions.assertThat(lines[0]).contains("\"pipeline\":\"my-pipeline\"");
         Assertions.assertThat(lines[1]).isEqualTo("{\"foo\":\"bar\"}");
+    }
+
+    @Test
+    void bulkKeepsIndexInBodyWhenIndicesDiffer() throws Exception {
+        AtomicReference<String> capturedNdjson = new AtomicReference<>();
+        IElasticsearchClient client = mock(IElasticsearchClient.class);
+        doAnswer(invocation -> {
+                    capturedNdjson.set(invocation.getArgument(1));
+                    return "{\"errors\":false,\"items\":[]}";
+                })
+                .when(client)
+                .bulk(isNull(), anyString());
+
+        String indexA = RandomizedTest.randomAsciiLettersOfLength(randomizedRandomForTests, 6);
+        String indexB = RandomizedTest.randomAsciiLettersOfLength(randomizedRandomForTests, 6);
+        ElasticsearchBulkRequest request = new ElasticsearchBulkRequest();
+        request.add(new ElasticsearchIndexOperation(indexA, "1", null, "{\"a\":1}"));
+        request.add(new ElasticsearchIndexOperation(indexB, "2", null, "{\"b\":2}"));
+
+        new ElasticsearchEngine(client).bulk(request);
+
+        verify(client).bulk(isNull(), anyString());
+        Assertions.assertThat(capturedNdjson.get())
+                .contains("\"_index\":\"" + indexA + "\"")
+                .contains("\"_index\":\"" + indexB + "\"");
     }
 
     @Test
@@ -97,11 +126,11 @@ class ElasticsearchEngineTest extends AbstractFSCrawlerTestCase {
         AtomicReference<String> capturedNdjson = new AtomicReference<>();
         IElasticsearchClient client = mock(IElasticsearchClient.class);
         doAnswer(invocation -> {
-                    capturedNdjson.set(invocation.getArgument(0));
+                    capturedNdjson.set(invocation.getArgument(1));
                     return "{\"errors\":false,\"items\":[{\"index\":{\"_index\":\"idx\",\"_id\":\"1\"}}]}";
                 })
                 .when(client)
-                .bulk(anyString());
+                .bulk(anyString(), anyString());
 
         ElasticsearchBulkRequest request = new ElasticsearchBulkRequest();
         request.add(new ElasticsearchIndexOperation("idx", "1", null, prettyJson));
@@ -153,14 +182,14 @@ class ElasticsearchEngineTest extends AbstractFSCrawlerTestCase {
             AtomicLong capturedNdjsonLength = new AtomicLong();
             IElasticsearchClient client = mock(IElasticsearchClient.class);
             doAnswer(invocation -> {
-                        String ndjson = invocation.getArgument(0);
+                        String ndjson = invocation.getArgument(1);
                         capturedNdjsonLength.set(ndjson.length());
                         Assertions.assertThat(ndjson).startsWith("{\"index\":");
                         Assertions.assertThat(ndjson).contains("\"content\":\"");
                         return "{\"errors\":false,\"items\":[{\"index\":{\"_index\":\"idx\",\"_id\":\"1\"}}]}";
                     })
                     .when(client)
-                    .bulk(anyString());
+                    .bulk(anyString(), anyString());
 
             ElasticsearchBulkRequest request = new ElasticsearchBulkRequest();
             request.add(new ElasticsearchIndexOperation("idx", "1", null, json));

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
@@ -28,6 +28,7 @@ import fr.pilato.elasticsearch.crawler.fs.client.ESSearchRequest;
 import fr.pilato.elasticsearch.crawler.fs.client.ESSearchResponse;
 import fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchClient;
 import fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchClientException;
+import fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchIndexNotFoundException;
 import fr.pilato.elasticsearch.crawler.fs.framework.ExponentialBackoffPollInterval;
 import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil;
 import fr.pilato.elasticsearch.crawler.fs.framework.TimeValue;
@@ -470,8 +471,12 @@ abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
                             logger.warn("error caught", e);
                             errorWhileWaiting.set(e);
                             return false;
+                        } catch (ElasticsearchIndexNotFoundException e) {
+                            logger.debug("index not ready yet: [{}]", e.getMessage());
+                            logger.trace("index not ready yet", e);
+                            errorWhileWaiting.set(e);
+                            return false;
                         } catch (ElasticsearchClientException e) {
-                            // TODO create a NOT FOUND Exception instead
                             logger.debug("error caught: [{}] ", e.getMessage());
                             logger.trace("error caught", e);
                             errorWhileWaiting.set(e);

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractRestITCase.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractRestITCase.java
@@ -155,11 +155,21 @@ public abstract class AbstractRestITCase extends AbstractFsCrawlerITCase {
         return target.path(path).request().get(clazz);
     }
 
+    /**
+     * Apply query parameters to a {@link WebTarget}. Jersey's {@code queryParam} returns a new instance, so the result
+     * must be reassigned.
+     */
+    static WebTarget withQueryParams(WebTarget target, Map<String, Object> params) {
+        WebTarget result = target;
+        for (Map.Entry<String, Object> entry : params.entrySet()) {
+            result = result.queryParam(entry.getKey(), entry.getValue());
+        }
+        return result;
+    }
+
     public static <T> T post(
             WebTarget target, String path, FormDataMultiPart mp, Class<T> clazz, Map<String, Object> params) {
-        WebTarget targetPath = target.path(path);
-        // TODO check this as it does not seem to produce anything
-        params.forEach(targetPath::queryParam);
+        WebTarget targetPath = withQueryParams(target.path(path), params);
 
         return targetPath
                 .request(MediaType.MULTIPART_FORM_DATA)
@@ -177,9 +187,7 @@ public abstract class AbstractRestITCase extends AbstractFsCrawlerITCase {
 
     public static <T> T put(
             WebTarget target, String path, FormDataMultiPart mp, Class<T> clazz, Map<String, Object> params) {
-        WebTarget targetPath = target.path(path);
-        // TODO check this as it does not seem to produce anything
-        params.forEach(targetPath::queryParam);
+        WebTarget targetPath = withQueryParams(target.path(path), params);
 
         return targetPath
                 .request(MediaType.MULTIPART_FORM_DATA)

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/RestClientQueryParamsTest.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/RestClientQueryParamsTest.java
@@ -31,8 +31,8 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
- * Unit coverage for {@link AbstractRestITCase#withQueryParams(WebTarget, Map)} — Jersey {@code queryParam} is
- * immutable and must be reassigned.
+ * Unit coverage for {@link AbstractRestITCase#withQueryParams(WebTarget, Map)} — Jersey {@code queryParam} is immutable
+ * and must be reassigned.
  */
 class RestClientQueryParamsTest extends AbstractFSCrawlerTestCase {
 

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/RestClientQueryParamsTest.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/RestClientQueryParamsTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
+ */
+package fr.pilato.elasticsearch.crawler.fs.test.integration;
+
+import com.carrotsearch.randomizedtesting.jupiter.RandomizedTest;
+import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit coverage for {@link AbstractRestITCase#withQueryParams(WebTarget, Map)} — Jersey {@code queryParam} is
+ * immutable and must be reassigned.
+ */
+class RestClientQueryParamsTest extends AbstractFSCrawlerTestCase {
+
+    @Test
+    void withQueryParamsReassignsImmutableWebTarget() {
+        String index = RandomizedTest.randomAsciiLettersOfLength(randomizedRandomForTests, 8);
+        String id = RandomizedTest.randomAsciiLettersOfLength(randomizedRandomForTests, 6);
+
+        Client client = ClientBuilder.newClient();
+        try {
+            WebTarget target = client.target("http://localhost/_document");
+            Map<String, Object> params = new LinkedHashMap<>();
+            params.put("index", index);
+            params.put("id", id);
+
+            WebTarget withParams = AbstractRestITCase.withQueryParams(target, params);
+
+            Assertions.assertThat(withParams.getUri().getQuery())
+                    .contains("index=" + index)
+                    .contains("id=" + id);
+            Assertions.assertThat(target.getUri().getQuery()).isNull();
+        } finally {
+            client.close();
+        }
+    }
+}

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRemoveDeletedIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestRemoveDeletedIT.java
@@ -327,9 +327,8 @@ class FsCrawlerTestRemoveDeletedIT extends AbstractFsCrawlerITCase {
                 0L,
                 currentTestResourceDir);
 
-        // The scan that removed the old path already ran in the same pass as the new-path check
-        // (see FsParser.processDirectory). If #1300 is fixed, the document is already at the new path;
-        // if not, waiting longer will not help. Assert immediately with a clear message for CI.
+        // Same crawl pass already evaluated both paths (processDirectory). When issue 1300 is fixed the
+        // document is already under the new path; waiting longer does not help. Assert immediately for CI.
         String docsIndex = getCrawlerName() + FsCrawlerUtil.INDEX_SUFFIX_DOCS;
         refresh(docsIndex);
         ESSearchResponse response = client.search(

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsCrawlerValidator.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsCrawlerValidator.java
@@ -44,29 +44,8 @@ public class FsCrawlerValidator {
             logger.warn("username/password is deprecated. Use apiKey instead.");
         }
 
-        // Checking protocol
-        if (settings.getServer() != null) {
-            if (!Server.PROTOCOL.LOCAL.equals(settings.getServer().getProtocol())
-                    && !Server.PROTOCOL.SSH.equals(settings.getServer().getProtocol())
-                    && !Server.PROTOCOL.FTP.equals(settings.getServer().getProtocol())) {
-                // Non supported protocol
-                logger.error(settings.getServer().getProtocol() + " is not supported yet. Please use "
-                        + Server.PROTOCOL.LOCAL + " or " + Server.PROTOCOL.SSH + " or " + Server.PROTOCOL.FTP
-                        + ". Disabling crawler");
-                return true;
-            }
-
-            // Checking username/password
-            if (Server.PROTOCOL.SSH.equals(settings.getServer().getProtocol())
-                    && FsCrawlerUtil.isNullOrEmpty(settings.getServer().getUsername())) {
-                logger.error(
-                        "When using SSH, you need to set a username and probably a password or a pem file. Disabling crawler");
-                return true;
-            } else if (Server.PROTOCOL.FTP.equals(settings.getServer().getProtocol())
-                    && FsCrawlerUtil.isNullOrEmpty(settings.getServer().getUsername())) {
-                logger.error("When using FTP, you need to set a username and probably a password. Disabling crawler");
-                return true;
-            }
+        if (validateServerSettings(logger, settings)) {
+            return true;
         }
 
         // Checking bulk_operation (DELETE is internal-only)
@@ -81,35 +60,11 @@ public class FsCrawlerValidator {
             return true;
         }
 
-        // Checking Checksum Algorithm
-        if (settings.getFs().getChecksum() != null
-                && !Digests.isSupported(settings.getFs().getChecksum())) {
-            logger.error(
-                    "Algorithm [{}] not found. Disabling crawler",
-                    settings.getFs().getChecksum());
+        if (validateDigestSettings(logger, settings)) {
             return true;
         }
 
-        // Checking document _id hash algorithm
-        if (settings.getFs().getHashAlgorithm() != null
-                && !Digests.isSupported(settings.getFs().getHashAlgorithm())) {
-            logger.error(
-                    "Hash algorithm [{}] not found. Disabling crawler",
-                    settings.getFs().getHashAlgorithm());
-            return true;
-        }
-
-        // Checking That we don't try to do both xml and json
-        if (settings.getFs().isJsonSupport() && settings.getFs().isXmlSupport()) {
-            logger.error("Can not support both xml and json parsing. Disabling crawler");
-            return true;
-        }
-
-        // Checking That we don't try to have xml or json, but we don't want to index their content
-        if ((settings.getFs().isJsonSupport() || settings.getFs().isXmlSupport())
-                && !settings.getFs().isIndexContent()) {
-            logger.error(
-                    "Json or Xml indexation is activated but you disabled indexing content which does not make sense. Disabling crawler");
+        if (validateFsContentFlags(logger, settings)) {
             return true;
         }
 
@@ -123,6 +78,64 @@ public class FsCrawlerValidator {
             logger.warn("acl_support is set to true but attributes_support is false. ACL collection is disabled.");
         }
 
+        return false;
+    }
+
+    private static boolean validateServerSettings(Logger logger, FsSettings settings) {
+        if (settings.getServer() == null) {
+            return false;
+        }
+        if (!Server.PROTOCOL.LOCAL.equals(settings.getServer().getProtocol())
+                && !Server.PROTOCOL.SSH.equals(settings.getServer().getProtocol())
+                && !Server.PROTOCOL.FTP.equals(settings.getServer().getProtocol())) {
+            logger.error(settings.getServer().getProtocol() + " is not supported yet. Please use "
+                    + Server.PROTOCOL.LOCAL + " or " + Server.PROTOCOL.SSH + " or " + Server.PROTOCOL.FTP
+                    + ". Disabling crawler");
+            return true;
+        }
+        if (Server.PROTOCOL.SSH.equals(settings.getServer().getProtocol())
+                && FsCrawlerUtil.isNullOrEmpty(settings.getServer().getUsername())) {
+            logger.error(
+                    "When using SSH, you need to set a username and probably a password or a pem file. Disabling crawler");
+            return true;
+        }
+        if (Server.PROTOCOL.FTP.equals(settings.getServer().getProtocol())
+                && FsCrawlerUtil.isNullOrEmpty(settings.getServer().getUsername())) {
+            logger.error("When using FTP, you need to set a username and probably a password. Disabling crawler");
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean validateDigestSettings(Logger logger, FsSettings settings) {
+        if (settings.getFs().getChecksum() != null
+                && !Digests.isSupported(settings.getFs().getChecksum())) {
+            logger.error(
+                    "Algorithm [{}] not found. Disabling crawler",
+                    settings.getFs().getChecksum());
+            return true;
+        }
+        if (settings.getFs().getHashAlgorithm() != null
+                && !Digests.isSupported(settings.getFs().getHashAlgorithm())) {
+            logger.error(
+                    "Hash algorithm [{}] not found. Disabling crawler",
+                    settings.getFs().getHashAlgorithm());
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean validateFsContentFlags(Logger logger, FsSettings settings) {
+        if (settings.getFs().isJsonSupport() && settings.getFs().isXmlSupport()) {
+            logger.error("Can not support both xml and json parsing. Disabling crawler");
+            return true;
+        }
+        if ((settings.getFs().isJsonSupport() || settings.getFs().isXmlSupport())
+                && !settings.getFs().isIndexContent()) {
+            logger.error(
+                    "Json or Xml indexation is activated but you disabled indexing content which does not make sense. Disabling crawler");
+            return true;
+        }
         return false;
     }
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,9 +2,8 @@
 # The project binding (project key / organization) is managed in the SonarCloud UI;
 # only analysis-scope parameters are declared here.
 
-# Exclude test fixtures from analysis. The test-documents module contains sample
-# files (PDF, Office, e-mails, plain text) used as test inputs, not source code.
-# Some are intentionally encoded in non-UTF-8 charsets (e.g. issue-400-shiftjis.txt
-# is Shift-JIS to exercise encoding detection), which triggers Sonar's
-# "problems with file encoding" warning when read as UTF-8 source.
-sonar.exclusions=test-documents/**
+# Exclude non-product sources from analysis:
+# - test-documents: sample fixtures (PDF, Office, HTML, non-UTF-8 encodings), not product code
+# - spotless JavaLicenseHeader: license template consumed by Spotless, not runtime code
+# - Noop: empty class required to satisfy central-publishing-maven-plugin packaging
+sonar.exclusions=**/test-documents/**,**/src/main/spotless/**,**/Noop.java

--- a/test-framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/framework/AbstractFSCrawlerTestCase.java
+++ b/test-framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/framework/AbstractFSCrawlerTestCase.java
@@ -196,30 +196,31 @@ public abstract class AbstractFSCrawlerTestCase {
         for (int i = 0; i < value.length(); i++) {
             char c = value.charAt(i);
             if (Character.isUpperCase(c)) {
-                if (!changed) {
-                    sb.setLength(0);
-                    // copy it over here
-                    for (int j = 0; j < i; j++) {
-                        sb.append(value.charAt(j));
-                    }
-                    changed = true;
-                    if (i != 0) {
-                        sb.append('_');
-                    }
-                } else {
-                    sb.append('_');
-                }
-                sb.append(Character.toLowerCase(c));
-            } else {
-                if (changed) {
-                    sb.append(c);
-                }
+                changed = appendUpperCase(sb, value, i, changed);
+            } else if (changed) {
+                sb.append(c);
             }
         }
         if (!changed) {
             return value;
         }
         return sb.toString();
+    }
+
+    private static boolean appendUpperCase(StringBuilder sb, String value, int i, boolean changed) {
+        if (!changed) {
+            sb.setLength(0);
+            for (int j = 0; j < i; j++) {
+                sb.append(value.charAt(j));
+            }
+            if (i != 0) {
+                sb.append('_');
+            }
+        } else {
+            sb.append('_');
+        }
+        sb.append(Character.toLowerCase(value.charAt(i)));
+        return true;
     }
 
     public static File urlToFile(URL url) {

--- a/test-framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/framework/FsCrawlerUtilForTests.java
+++ b/test-framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/framework/FsCrawlerUtilForTests.java
@@ -26,6 +26,7 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -53,7 +54,7 @@ public class FsCrawlerUtilForTests {
 
         logger.debug("  --> Copying resources from [{}]", source);
         if (Files.notExists(source)) {
-            throw new RuntimeException(source + " doesn't seem to exist.");
+            throw new NoSuchFileException(source.toString());
         }
 
         Files.walkFileTree(

--- a/test-framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/framework/TestContainerHelper.java
+++ b/test-framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/framework/TestContainerHelper.java
@@ -111,19 +111,7 @@ public class TestContainerHelper {
                 elasticsearch = container;
                 elasticsearch.start();
 
-                String url = String.format(HTTPS_URL, elasticsearch.getHttpHostAddress());
-
-                // Try to get the https certificate if exists
-                try {
-                    certAsBytes = elasticsearch.copyFileFromContainer(
-                            "/usr/share/elasticsearch/config/certs/http_ca.crt", IOUtils::toByteArray);
-                    log.debug("Found an https elasticsearch cert for version [{}].", elasticsearchVersion);
-                } catch (Exception e) {
-                    log.debug(
-                            "We did not find the https elasticsearch cert for version [{}]. We switch to http instead.",
-                            elasticsearchVersion);
-                    url = String.format(HTTP_URL, elasticsearch.getHttpHostAddress());
-                }
+                String url = resolveUrlAndCert(elasticsearch);
 
                 log.info("Elasticsearch container is now running at {}", url);
 
@@ -164,6 +152,21 @@ public class TestContainerHelper {
 
     public String getElasticsearchVersion() {
         return elasticsearchVersion;
+    }
+
+    private String resolveUrlAndCert(ElasticsearchContainer container) {
+        String url = String.format(HTTPS_URL, container.getHttpHostAddress());
+        try {
+            certAsBytes = container.copyFileFromContainer(
+                    "/usr/share/elasticsearch/config/certs/http_ca.crt", IOUtils::toByteArray);
+            log.debug("Found an https elasticsearch cert for version [{}].", elasticsearchVersion);
+        } catch (Exception e) {
+            log.debug(
+                    "We did not find the https elasticsearch cert for version [{}]. We switch to http instead.",
+                    elasticsearchVersion);
+            url = String.format(HTTP_URL, container.getHttpHostAddress());
+        }
+        return url;
     }
 
     private synchronized void waitForReadiness() {

--- a/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
+++ b/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
@@ -282,8 +282,8 @@ public class TikaDocParser {
                             Office.KEYWORDS,
                             doc.getMeta()::setKeywords,
                             TikaDocParser::commaDelimitedListToStringArray);
-                    // TODO Fix this with Tika 2.2.1+
-                    // See https://issues.apache.org/jira/browse/TIKA-3629
+                    // PDF keywords often land only in pdf:docinfo:keywords (not Office.KEYWORDS), even with
+                    // recent Tika — keep this fallback. See https://issues.apache.org/jira/browse/TIKA-3629
                     if (doc.getMeta().getKeywords() == null) {
                         setMeta(
                                 doc.getPath().getReal(),

--- a/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
+++ b/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
@@ -46,6 +46,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -544,11 +545,15 @@ public class TikaDocParser {
             Consumer<T> setter,
             Function<String, T> transformer) {
         String sMeta = metadata.get(property);
-        if (sMeta == null) {
-            return;
-        }
         try {
-            setter.accept(transformer.apply(sMeta));
+            T value = transformer.apply(sMeta);
+            // Transformers may return an empty collection when the property is absent/blank (java:S1168). Treat that
+            // as "field not present" so language detection and PDF keyword fallback still see null.
+            if (value == null
+                    || (value instanceof Collection<?> c && c.isEmpty() && (sMeta == null || sMeta.isBlank()))) {
+                return;
+            }
+            setter.accept(value);
         } catch (Exception e) {
             logger.warn(
                     "Can not parse meta [{}] for [{}]. Skipping [{}] field...", sMeta, filename, property.getName());

--- a/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
+++ b/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
@@ -193,47 +193,7 @@ public class TikaDocParser {
                 }
 
                 if (fsSettings.getFs().isIndexContent()) {
-                    try {
-                        // Set the maximum length of strings returned by the parseToString method, -1 sets no limit
-                        logger.trace("Beginning Tika extraction");
-                        parsedContent = tikaInstance.extractText(indexedChars, inputStream, metadata);
-                        logger.trace("End of Tika extraction");
-                    } catch (Throwable e) {
-                        // Build a message from embedded errors
-                        Throwable current = e;
-                        StringBuilder sb = new StringBuilder();
-                        while (current != null) {
-                            sb.append(current.getMessage());
-                            current = current.getCause();
-                            if (current != null) {
-                                sb.append(" -> ");
-                            }
-                        }
-
-                        try {
-                            FSCrawlerLogger.documentError(
-                                    fsSettings.getFs().isFilenameAsId()
-                                            ? doc.getFile().getFilename()
-                                            : SignTool.sign(
-                                                    fsSettings.getFs().getHashAlgorithm(),
-                                                    doc.getPath().getReal()),
-                                    FsCrawlerUtil.computeVirtualPathName(
-                                            fsSettings.getFs().getUrl(),
-                                            doc.getPath().getReal()),
-                                    sb.toString());
-                        } catch (NoSuchAlgorithmException ignored) {
-                            // Error is already logged below; hash algorithm failure must not hide it
-                        }
-                        logger.warn(
-                                "Failed to extract [{}] characters of text for [{}]: {}",
-                                indexedChars,
-                                doc.getPath().getReal(),
-                                sb.toString());
-                        logger.debug(
-                                "Failed to extract [" + indexedChars + "] characters of text for ["
-                                        + doc.getPath().getReal() + "]",
-                                e);
-                    }
+                    parsedContent = extractParsedContent(tikaInstance, indexedChars, inputStream, metadata, doc);
 
                     // Adding what we found to the document we want to index
 
@@ -485,20 +445,11 @@ public class TikaDocParser {
             } finally {
                 // Close the temp file stream before deleting the file
                 if (tempFileStream != null) {
-                    try {
-                        tempFileStream.close();
-                    } catch (IOException e) {
-                        logger.debug("Failed to close temp file stream: {}", e.getMessage());
-                    }
+                    closeQuietly(tempFileStream);
                 }
                 // Clean up temp file if it was created
                 if (tempFile != null) {
-                    try {
-                        Files.deleteIfExists(tempFile);
-                        logger.trace("Deleted temp file [{}]", tempFile);
-                    } catch (IOException e) {
-                        logger.warn("Failed to delete temp file [{}]: {}", tempFile, e.getMessage());
-                    }
+                    deleteTempFileQuietly(tempFile);
                 }
             }
         } catch (Exception e) {
@@ -515,6 +466,75 @@ public class TikaDocParser {
                 tikaSpan.setAttribute("tika.indexed_chars", doc.getFile().getIndexedChars());
             }
             tikaSpan.end();
+        }
+    }
+
+    /**
+     * Extracts text via Tika. On failure, logs the document error (best-effort) and returns {@code null}.
+     */
+    private String extractParsedContent(
+            TikaInstance tikaInstance, int indexedChars, InputStream inputStream, Metadata metadata, Doc doc) {
+        try {
+            // Set the maximum length of strings returned by the parseToString method, -1 sets no limit
+            logger.trace("Beginning Tika extraction");
+            String parsedContent = tikaInstance.extractText(indexedChars, inputStream, metadata);
+            logger.trace("End of Tika extraction");
+            return parsedContent;
+        } catch (Throwable e) {
+            // Build a message from embedded errors
+            Throwable current = e;
+            StringBuilder sb = new StringBuilder();
+            while (current != null) {
+                sb.append(current.getMessage());
+                current = current.getCause();
+                if (current != null) {
+                    sb.append(" -> ");
+                }
+            }
+
+            logDocumentError(doc, sb.toString());
+            logger.warn(
+                    "Failed to extract [{}] characters of text for [{}]: {}",
+                    indexedChars,
+                    doc.getPath().getReal(),
+                    sb.toString());
+            logger.debug(
+                    "Failed to extract [" + indexedChars + "] characters of text for ["
+                            + doc.getPath().getReal() + "]",
+                    e);
+            return null;
+        }
+    }
+
+    private void logDocumentError(Doc doc, String errorMessage) {
+        try {
+            FSCrawlerLogger.documentError(
+                    fsSettings.getFs().isFilenameAsId()
+                            ? doc.getFile().getFilename()
+                            : SignTool.sign(
+                                    fsSettings.getFs().getHashAlgorithm(), doc.getPath().getReal()),
+                    FsCrawlerUtil.computeVirtualPathName(
+                            fsSettings.getFs().getUrl(), doc.getPath().getReal()),
+                    errorMessage);
+        } catch (NoSuchAlgorithmException ignored) {
+            // Error is already logged below; hash algorithm failure must not hide it
+        }
+    }
+
+    private static void closeQuietly(InputStream inputStream) {
+        try {
+            inputStream.close();
+        } catch (IOException e) {
+            logger.debug("Failed to close temp file stream: {}", e.getMessage());
+        }
+    }
+
+    private static void deleteTempFileQuietly(Path tempFile) {
+        try {
+            Files.deleteIfExists(tempFile);
+            logger.trace("Deleted temp file [{}]", tempFile);
+        } catch (IOException e) {
+            logger.warn("Failed to delete temp file [{}]: {}", tempFile, e.getMessage());
         }
     }
 

--- a/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
+++ b/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
@@ -469,9 +469,7 @@ public class TikaDocParser {
         }
     }
 
-    /**
-     * Extracts text via Tika. On failure, logs the document error (best-effort) and returns {@code null}.
-     */
+    /** Extracts text via Tika. On failure, logs the document error (best-effort) and returns {@code null}. */
     private String extractParsedContent(
             TikaInstance tikaInstance, int indexedChars, InputStream inputStream, Metadata metadata, Doc doc) {
         try {
@@ -512,7 +510,8 @@ public class TikaDocParser {
                     fsSettings.getFs().isFilenameAsId()
                             ? doc.getFile().getFilename()
                             : SignTool.sign(
-                                    fsSettings.getFs().getHashAlgorithm(), doc.getPath().getReal()),
+                                    fsSettings.getFs().getHashAlgorithm(),
+                                    doc.getPath().getReal()),
                     FsCrawlerUtil.computeVirtualPathName(
                             fsSettings.getFs().getUrl(), doc.getPath().getReal()),
                     errorMessage);

--- a/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
+++ b/tika/src/main/java/fr/pilato/elasticsearch/crawler/fs/tika/TikaDocParser.java
@@ -525,6 +525,9 @@ public class TikaDocParser {
             Consumer<T> setter,
             Function<String, T> transformer) {
         String sMeta = metadata.get(property);
+        if (sMeta == null) {
+            return;
+        }
         try {
             setter.accept(transformer.apply(sMeta));
         } catch (Exception e) {
@@ -535,7 +538,7 @@ public class TikaDocParser {
 
     private static List<String> commaDelimitedListToStringArray(String str) {
         if (str == null) {
-            return null;
+            return List.of();
         }
         List<String> result = new ArrayList<>();
         int pos = 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Pre-3.0 SonarCloud cleanup (~68 open issues). Scope **B**: quick wins + cognitive complexity ≤25 + concrete exceptions + nested-try extractions — without brain-method refactors of `FsParser` / `TikaDocParser`.

### Done
- **Quick wins**: Docker NOSONAR, S125 comment, Sonar exclusions, S1168, S2925, S1075, TODO cleanups (#6, #10, #13)
- **Bugs**: Jersey `queryParam` reassignment (IT helpers); `ElasticsearchIndexNotFoundException`; index-scoped `_bulk` when all indices match
- **S112**: `throws Exception` → `NoSuchAlgorithmException` / `IOException`+`ElasticsearchClientException` / `NoSuchFileException`
- **S3776 (≤25)**: `TestContainerHelper`, `FsCrawlerCli`, `FsParser.loadOrCreateCheckpoint`, `ElasticsearchClient` search/query/http, `AbstractFSCrawlerTestCase`, `FsCrawlerValidator`
- **S1141**: nested-try extractions in `FsParser` and `TikaDocParser`

### Intentionally out of scope
- Brain methods / complexity >25 (`FsParser` main loops, `TikaDocParser.generate`, large `ElasticsearchClient` methods)
- S107 (too many parameters)
- `@Deprecated(since="3.0")` migration APIs
- TODOs kept: #1 bulk payload cache, #5 filename batch search, #9 TIKA-3364 OCR, #11–12 node re-ping

### Commits
One commit per discrete Sonar fix / logical change (23 commits).

## Test plan
- [x] `mvn spotless:check`
- [x] `TikaDocParserTest` (full)
- [x] `ElasticsearchEngineTest`, `FsParserSchedulingTest`, `RestClientQueryParamsTest`
- [x] Unit tests in `settings`, `elasticsearch-client`, `core` (non-IT)
- [ ] Full IT suite (optional / CI)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d1daabc-ce50-4b6c-afe7-120bca0accaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d1daabc-ce50-4b6c-afe7-120bca0accaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

