### PR TITLE
fix(es-client): retry bulk on 429/5xx and fail runs on exhausted errors

### DIFF
--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParser.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParser.java
@@ -325,8 +325,9 @@ public class FsParser implements Runnable, AutoCloseable {
 
             try (Scope ignored = crawlSpan.makeCurrent()) {
                 logger.info("Run #{}: job [{}]: starting...", run, fsSettings.getName());
-                // Drop sticky bulk failures from a previous run (ensureBulkSucceeded does not clear them)
-                documentService.clearFatalBulkFailure();
+                // Drop sticky bulk failures from a previous run (ensureBulkSucceeded does not clear them).
+                // REST-only unit tests may pass a null documentService.
+                clearFatalBulkFailureIfPresent();
                 filesSinceLastCheckpoint = 0;
 
                 String url = fsSettings.getFs().getUrl();
@@ -450,8 +451,8 @@ public class FsParser implements Runnable, AutoCloseable {
                     saveCheckpoint();
                 }
             } finally {
-                // Always clear so a mid-run bulk failure + early exit cannot poison the next successful run
-                documentService.clearFatalBulkFailure();
+                // Do not clear fatalBulkFailure here: REST shares this client and may still need to observe a
+                // timer-driven bulk failure. The next crawl run clears at start instead.
                 crawlSpan.end();
                 persistAclHashCacheIfNeeded();
                 if (crawlerPlugin != null) {
@@ -606,6 +607,12 @@ public class FsParser implements Runnable, AutoCloseable {
      * error handler only persists when we have actually loaded/created this checkpoint (avoids overwriting a valid
      * checkpoint file with the default empty instance on early failures).
      */
+    private void clearFatalBulkFailureIfPresent() {
+        if (documentService != null) {
+            documentService.clearFatalBulkFailure();
+        }
+    }
+
     private void setCurrentCheckpoint(FsCrawlerCheckpoint cp) {
         cp.setLoadedThisRun(true);
         checkpoint.set(cp);

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParser.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParser.java
@@ -325,6 +325,8 @@ public class FsParser implements Runnable, AutoCloseable {
 
             try (Scope ignored = crawlSpan.makeCurrent()) {
                 logger.info("Run #{}: job [{}]: starting...", run, fsSettings.getName());
+                // Drop sticky bulk failures from a previous run (ensureBulkSucceeded does not clear them)
+                documentService.clearFatalBulkFailure();
                 filesSinceLastCheckpoint = 0;
 
                 String url = fsSettings.getFs().getUrl();
@@ -448,6 +450,8 @@ public class FsParser implements Runnable, AutoCloseable {
                     saveCheckpoint();
                 }
             } finally {
+                // Always clear so a mid-run bulk failure + early exit cannot poison the next successful run
+                documentService.clearFatalBulkFailure();
                 crawlSpan.end();
                 persistAclHashCacheIfNeeded();
                 if (crawlerPlugin != null) {

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParser.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParser.java
@@ -383,6 +383,9 @@ public class FsParser implements Runnable, AutoCloseable {
                     // Process directories using work queue instead of recursion
                     processDirectoriesWithCheckpoint(effectiveScanDate, stats);
 
+                    // Flush async bulks and fail the run if HTTP retries were exhausted (marks checkpoint ERROR)
+                    documentService.flushAndEnsureBulkSucceeded();
+
                     stats.setEndTime(Instant.now());
                     stats.setNbDocScan((int) checkpoint.get().getFilesProcessed());
                     stats.setNbDocDeleted((int) checkpoint.get().getFilesDeleted());

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentService.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentService.java
@@ -106,4 +106,7 @@ public interface FsCrawlerDocumentService extends FsCrawlerService {
      * @throws ElasticsearchClientException when a fatal bulk failure was recorded
      */
     void flushAndEnsureBulkSucceeded() throws ElasticsearchClientException;
+
+    /** Clears any sticky fatal bulk failure from a previous run so a new crawl does not fail on a stale error. */
+    void clearFatalBulkFailure();
 }

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentService.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentService.java
@@ -98,4 +98,12 @@ public interface FsCrawlerDocumentService extends FsCrawlerService {
      * @return the document or null
      */
     ESSearchHit get(String index, String id) throws IOException, ElasticsearchClientException;
+
+    /**
+     * Flush pending bulk operations and fail if a bulk request failed after retries (429/5xx). Used at the end of a
+     * crawl run so the checkpoint can be marked {@code ERROR} instead of silently losing documents.
+     *
+     * @throws ElasticsearchClientException when a fatal bulk failure was recorded
+     */
+    void flushAndEnsureBulkSucceeded() throws ElasticsearchClientException;
 }

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentService.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentService.java
@@ -107,6 +107,21 @@ public interface FsCrawlerDocumentService extends FsCrawlerService {
      */
     void flushAndEnsureBulkSucceeded() throws ElasticsearchClientException;
 
+    /**
+     * Current bulk-failure generation. Capture before index for REST, then pass to
+     * {@link #flushAndEnsureBulkSucceededSince(long)}.
+     */
+    long getBulkFailureGeneration();
+
+    /**
+     * Flush and fail if any bulk failure was recorded since {@code generation} (REST path). Survives a concurrent crawl
+     * {@link #clearFatalBulkFailure()}.
+     *
+     * @param generation value from {@link #getBulkFailureGeneration()} before indexing
+     * @throws ElasticsearchClientException when a fatal bulk failure occurred since {@code generation}
+     */
+    void flushAndEnsureBulkSucceededSince(long generation) throws ElasticsearchClientException;
+
     /** Clears any sticky fatal bulk failure from a previous run so a new crawl does not fail on a stale error. */
     void clearFatalBulkFailure();
 }

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentServiceElasticsearchImpl.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentServiceElasticsearchImpl.java
@@ -118,6 +118,17 @@ public class FsCrawlerDocumentServiceElasticsearchImpl implements FsCrawlerDocum
     }
 
     @Override
+    public long getBulkFailureGeneration() {
+        return client.getBulkFailureGeneration();
+    }
+
+    @Override
+    public void flushAndEnsureBulkSucceededSince(long generation) throws ElasticsearchClientException {
+        client.flush();
+        client.ensureBulkSucceededSince(generation);
+    }
+
+    @Override
     public void clearFatalBulkFailure() {
         client.clearFatalBulkFailure();
     }

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentServiceElasticsearchImpl.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentServiceElasticsearchImpl.java
@@ -116,4 +116,9 @@ public class FsCrawlerDocumentServiceElasticsearchImpl implements FsCrawlerDocum
         client.flush();
         client.ensureBulkSucceeded();
     }
+
+    @Override
+    public void clearFatalBulkFailure() {
+        client.clearFatalBulkFailure();
+    }
 }

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentServiceElasticsearchImpl.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentServiceElasticsearchImpl.java
@@ -110,4 +110,10 @@ public class FsCrawlerDocumentServiceElasticsearchImpl implements FsCrawlerDocum
         logger.debug("Getting {}/{}", index, id);
         return client.get(index, id);
     }
+
+    @Override
+    public void flushAndEnsureBulkSucceeded() throws ElasticsearchClientException {
+        client.flush();
+        client.ensureBulkSucceeded();
+    }
 }

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentServiceElasticsearchImpl.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerDocumentServiceElasticsearchImpl.java
@@ -113,8 +113,7 @@ public class FsCrawlerDocumentServiceElasticsearchImpl implements FsCrawlerDocum
 
     @Override
     public void flushAndEnsureBulkSucceeded() throws ElasticsearchClientException {
-        client.flush();
-        client.ensureBulkSucceeded();
+        client.flushAndEnsureBulkSucceeded();
     }
 
     @Override
@@ -124,8 +123,7 @@ public class FsCrawlerDocumentServiceElasticsearchImpl implements FsCrawlerDocum
 
     @Override
     public void flushAndEnsureBulkSucceededSince(long generation) throws ElasticsearchClientException {
-        client.flush();
-        client.ensureBulkSucceededSince(generation);
+        client.flushAndEnsureBulkSucceededSince(generation);
     }
 
     @Override

--- a/docs/source/admin/fs/elasticsearch.md
+++ b/docs/source/admin/fs/elasticsearch.md
@@ -274,6 +274,10 @@ elasticsearch:
   flush_interval: "2s"
 ```
 
+Whole `_bulk` HTTP calls are retried on `429` (Too Many Requests) and `5xx` responses, using the
+same backoff policy as search requests. If retries are exhausted, the failure is logged and the
+crawl run is marked as `ERROR` in the checkpoint (documents are not silently dropped).
+
 ```{versionadded} 3.0
 ```
 

--- a/docs/source/admin/fs/rest.md
+++ b/docs/source/admin/fs/rest.md
@@ -123,6 +123,10 @@ It will give you a response similar to:
 }
 ```
 
+The REST layer flushes the bulk processor before returning, so `ok: true` means Elasticsearch
+accepted the document (after any `429`/`5xx` retries). If indexing still fails, the response has
+`ok: false` and a `message` describing the error.
+
 The `url` represents the elasticsearch address of the indexed
 document. If you call:
 

--- a/docs/source/release/3.0.md
+++ b/docs/source/release/3.0.md
@@ -65,6 +65,9 @@
 - Image raw metadata extraction was not working. Thanks to dadoonet.
 - Fix issue when using crawling over SSH when the directory ends with a space. Thanks to dadoonet.
 - On windows, files and directories to be removed were not properly detected. Thanks to newschapmj1.
+- Bulk `_bulk` HTTP calls now retry on `429`/`5xx` and no longer treat a failed bulk as success.
+  Exhausted retries mark the crawl checkpoint as `ERROR` and REST uploads return `ok: false`.
+  Thanks to dadoonet.
 
 ## Deprecated
 

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchBulkResponse.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchBulkResponse.java
@@ -32,6 +32,8 @@ public class ElasticsearchBulkResponse extends FsCrawlerBulkResponse<Elasticsear
 
     public ElasticsearchBulkResponse(ElasticsearchClientException exception) {
         this.exception = exception;
+        // Whole-request failures (HTTP 429/5xx after retries, connection errors, …) must not look like success.
+        this.errors = true;
     }
 
     public ElasticsearchBulkResponse(String response) {
@@ -58,6 +60,16 @@ public class ElasticsearchBulkResponse extends FsCrawlerBulkResponse<Elasticsear
             items.add(itemResponse);
         });
         errors = items.stream().anyMatch(BulkItemResponse::isFailed);
+    }
+
+    /** The transport-level failure when the whole {@code _bulk} call failed; {@code null} for item-level failures. */
+    public ElasticsearchClientException getException() {
+        return exception;
+    }
+
+    @Override
+    public boolean hasFailures() {
+        return exception != null || super.hasFailures();
     }
 
     @Override

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -68,6 +68,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.stream.StreamSupport;
@@ -160,6 +161,11 @@ public class ElasticsearchClient implements IElasticsearchClient {
      * {@link #ensureBulkSucceeded()} (without clearing) and cleared by {@link #clearFatalBulkFailure()}.
      */
     private final AtomicReference<Exception> fatalBulkFailure = new AtomicReference<>();
+    /**
+     * Monotonic counter bumped on every recorded bulk failure. Survives {@link #clearFatalBulkFailure()} so REST can
+     * detect a failure that the crawl cleared from the sticky flag.
+     */
+    private final AtomicLong bulkFailureGeneration = new AtomicLong();
 
     private final List<String> hosts;
     private final List<String> initialHosts;
@@ -348,7 +354,7 @@ public class ElasticsearchClient implements IElasticsearchClient {
                         "Bulk request failed after retries ({} actions): {}",
                         request.numberOfActions(),
                         response.getException().getMessage());
-                fatalBulkFailure.compareAndSet(null, response.getException());
+                recordFatalBulkFailure(response.getException());
             }
         }
 
@@ -364,8 +370,13 @@ public class ElasticsearchClient implements IElasticsearchClient {
             Exception asException = failure instanceof Exception e
                     ? e
                     : new ElasticsearchClientException("Bulk request failed", failure);
-            fatalBulkFailure.compareAndSet(null, asException);
+            recordFatalBulkFailure(asException);
         }
+    }
+
+    private void recordFatalBulkFailure(Exception failure) {
+        fatalBulkFailure.compareAndSet(null, failure);
+        bulkFailureGeneration.incrementAndGet();
     }
 
     private static SSLContext sslContextFromHttpCaCrt(File file) throws ElasticsearchClientException {
@@ -1466,7 +1477,24 @@ public class ElasticsearchClient implements IElasticsearchClient {
     }
 
     @Override
+    public long getBulkFailureGeneration() {
+        return bulkFailureGeneration.get();
+    }
+
+    @Override
+    public void ensureBulkSucceededSince(long generation) throws ElasticsearchClientException {
+        if (bulkFailureGeneration.get() != generation) {
+            Exception failure = fatalBulkFailure.get();
+            throw new ElasticsearchClientException(
+                    "Bulk indexing failed after retries",
+                    failure != null ? failure : new ElasticsearchClientException("Bulk indexing failed after retries"));
+        }
+        ensureBulkSucceeded();
+    }
+
+    @Override
     public void clearFatalBulkFailure() {
+        // Clears the sticky flag only — generation is intentionally kept so concurrent REST can still detect the event.
         fatalBulkFailure.set(null);
     }
 

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -156,8 +156,8 @@ public class ElasticsearchClient implements IElasticsearchClient {
     private FsCrawlerBulkProcessor<ElasticsearchOperation, ElasticsearchBulkRequest, ElasticsearchBulkResponse>
             bulkProcessor = null;
     /**
-     * Set when a whole {@code _bulk} HTTP call fails after retries (429/5xx). Cleared by
-     * {@link #ensureBulkSucceeded()}.
+     * Set when a whole {@code _bulk} HTTP call fails after retries (429/5xx). Observed by
+     * {@link #ensureBulkSucceeded()} (without clearing) and cleared by {@link #clearFatalBulkFailure()}.
      */
     private final AtomicReference<Exception> fatalBulkFailure = new AtomicReference<>();
 
@@ -1452,16 +1452,22 @@ public class ElasticsearchClient implements IElasticsearchClient {
     }
 
     /**
-     * Throws if a previous bulk request failed after HTTP retries were exhausted. Clears the recorded failure so the
-     * next successful run can proceed. Call after {@link #flush()} at the end of a crawl run (or REST upload).
+     * Throws if a previous bulk request failed after HTTP retries were exhausted. Does not clear the failure so a
+     * concurrent REST {@code ensureBulkSucceeded()} cannot hide it from the crawl (and vice versa).
      *
      * @throws ElasticsearchClientException when a fatal bulk failure was recorded
      */
+    @Override
     public void ensureBulkSucceeded() throws ElasticsearchClientException {
-        Exception failure = fatalBulkFailure.getAndSet(null);
+        Exception failure = fatalBulkFailure.get();
         if (failure != null) {
             throw new ElasticsearchClientException("Bulk indexing failed after retries", failure);
         }
+    }
+
+    @Override
+    public void clearFatalBulkFailure() {
+        fatalBulkFailure.set(null);
     }
 
     @Override

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -155,6 +155,12 @@ public class ElasticsearchClient implements IElasticsearchClient {
     private Client client = null;
     private FsCrawlerBulkProcessor<ElasticsearchOperation, ElasticsearchBulkRequest, ElasticsearchBulkResponse>
             bulkProcessor = null;
+    /**
+     * Set when a whole {@code _bulk} HTTP call fails after retries (429/5xx). Cleared by
+     * {@link #ensureBulkSucceeded()}.
+     */
+    private final AtomicReference<Exception> fatalBulkFailure = new AtomicReference<>();
+
     private final List<String> hosts;
     private final List<String> initialHosts;
 
@@ -315,13 +321,51 @@ public class ElasticsearchClient implements IElasticsearchClient {
      */
     protected void initBulkProcessor() {
         bulkProcessor = new FsCrawlerBulkProcessor.Builder<>(
-                        new ElasticsearchEngine(this),
-                        new FsCrawlerRetryBulkProcessorListener<>("es_rejected_execution_exception"),
-                        ElasticsearchBulkRequest::new)
+                        new ElasticsearchEngine(this), new FailOnHttpBulkErrorListener(), ElasticsearchBulkRequest::new)
                 .setBulkActions(settings.getElasticsearch().getBulkSize())
                 .setFlushInterval(settings.getElasticsearch().getFlushInterval())
                 .setByteSize(settings.getElasticsearch().getByteSize())
                 .build();
+    }
+
+    /**
+     * Retries item-level {@code es_rejected_execution_exception} and records whole-request HTTP failures (after
+     * retries) so {@link #ensureBulkSucceeded()} can fail the crawl/run.
+     */
+    private final class FailOnHttpBulkErrorListener
+            extends FsCrawlerRetryBulkProcessorListener<
+                    ElasticsearchOperation, ElasticsearchBulkRequest, ElasticsearchBulkResponse> {
+
+        private FailOnHttpBulkErrorListener() {
+            super("es_rejected_execution_exception");
+        }
+
+        @Override
+        public void afterBulk(long executionId, ElasticsearchBulkRequest request, ElasticsearchBulkResponse response) {
+            super.afterBulk(executionId, request, response);
+            if (response.getException() != null) {
+                logger.error(
+                        "Bulk request failed after retries ({} actions): {}",
+                        request.numberOfActions(),
+                        response.getException().getMessage());
+                fatalBulkFailure.compareAndSet(null, response.getException());
+            }
+        }
+
+        @Override
+        public void afterBulk(long executionId, ElasticsearchBulkRequest request, Throwable failure) {
+            super.afterBulk(executionId, request, failure);
+            logger.error(
+                    "Bulk request failed ({} actions): {}",
+                    request.numberOfActions(),
+                    failure.getMessage() != null
+                            ? failure.getMessage()
+                            : failure.getClass().getName());
+            Exception asException = failure instanceof Exception e
+                    ? e
+                    : new ElasticsearchClientException("Bulk request failed", failure);
+            fatalBulkFailure.compareAndSet(null, asException);
+        }
     }
 
     private static SSLContext sslContextFromHttpCaCrt(File file) throws ElasticsearchClientException {
@@ -1403,7 +1447,21 @@ public class ElasticsearchClient implements IElasticsearchClient {
     public String bulk(String index, String ndjson) throws ElasticsearchClientException {
         String path = index == null ? "_bulk" : index + PATH_DELIMITER + "_bulk";
         logger.debug("bulk a ndjson of {} characters to [{}]", ndjson.length(), path);
-        return httpPost(path, ndjson);
+        // Same retry policy as _search: 5xx short backoff, 429 longer. Safe because FSCrawler always sets _id.
+        return httpPostWithRetry(path, ndjson);
+    }
+
+    /**
+     * Throws if a previous bulk request failed after HTTP retries were exhausted. Clears the recorded failure so the
+     * next successful run can proceed. Call after {@link #flush()} at the end of a crawl run (or REST upload).
+     *
+     * @throws ElasticsearchClientException when a fatal bulk failure was recorded
+     */
+    public void ensureBulkSucceeded() throws ElasticsearchClientException {
+        Exception failure = fatalBulkFailure.getAndSet(null);
+        if (failure != null) {
+            throw new ElasticsearchClientException("Bulk indexing failed after retries", failure);
+        }
     }
 
     @Override

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -1417,7 +1417,33 @@ public class ElasticsearchClient implements IElasticsearchClient {
 
     @Override
     public void flush() {
-        bulkProcessor.flush();
+        if (bulkProcessor != null) {
+            bulkProcessor.flush();
+        }
+    }
+
+    @Override
+    public void flushAndEnsureBulkSucceeded() throws ElasticsearchClientException {
+        flushAndEnsureBulkSucceededSince(bulkFailureGeneration.get());
+    }
+
+    @Override
+    public void flushAndEnsureBulkSucceededSince(long generation) throws ElasticsearchClientException {
+        if (bulkProcessor == null) {
+            ensureBulkSucceededSince(generation);
+            return;
+        }
+        AtomicReference<ElasticsearchClientException> error = new AtomicReference<>();
+        bulkProcessor.flushWhileQuiesced(() -> {
+            try {
+                ensureBulkSucceededSince(generation);
+            } catch (ElasticsearchClientException e) {
+                error.set(e);
+            }
+        });
+        if (error.get() != null) {
+            throw error.get();
+        }
     }
 
     @Override

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchEngine.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchEngine.java
@@ -78,6 +78,9 @@ public class ElasticsearchEngine
             response = elasticsearchClient.bulk(commonIndex, ndjson.toString());
         } catch (ElasticsearchClientException e) {
             return new ElasticsearchBulkResponse(e);
+        } catch (RuntimeException e) {
+            // httpPostWithRetry may throw WebApplicationException (e.g. 503) when retries are exhausted
+            return new ElasticsearchBulkResponse(new ElasticsearchClientException("Bulk request failed", e));
         }
         return new ElasticsearchBulkResponse(response);
     }

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/IElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/IElasticsearchClient.java
@@ -201,12 +201,16 @@ public interface IElasticsearchClient extends Closeable {
     void flush();
 
     /**
-     * Throws if a previous bulk request failed after HTTP retries were exhausted. Clears the recorded failure.
-     * Typically called after {@link #flush()} at the end of a crawl run or REST upload.
+     * Throws if a previous bulk request failed after HTTP retries were exhausted. Does <b>not</b> clear the recorded
+     * failure (so concurrent callers — e.g. crawl + REST — all observe it). Clear explicitly with
+     * {@link #clearFatalBulkFailure()} at the start/end of a crawl run.
      *
      * @throws ElasticsearchClientException when a fatal bulk failure was recorded
      */
     void ensureBulkSucceeded() throws ElasticsearchClientException;
+
+    /** Clears any recorded fatal bulk failure so a new crawl run (or test) can start clean. */
+    void clearFatalBulkFailure();
 
     /**
      * Perform a LowLevel Request

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/IElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/IElasticsearchClient.java
@@ -194,10 +194,19 @@ public interface IElasticsearchClient extends Closeable {
     void deletePipeline(String pipeline) throws ElasticsearchClientException;
 
     /**
-     * Flush any pending Bulk operation. Used for tests only. Note that flushing means immediate execution of the bulk,
-     * but it does not wait for the bulk to be fully executed.
+     * Flush any pending Bulk operation. Note that flushing means immediate execution of the bulk request (with HTTP
+     * retries), but does not by itself fail the caller when the bulk failed — use {@link #ensureBulkSucceeded()} after
+     * flush for that.
      */
     void flush();
+
+    /**
+     * Throws if a previous bulk request failed after HTTP retries were exhausted. Clears the recorded failure.
+     * Typically called after {@link #flush()} at the end of a crawl run or REST upload.
+     *
+     * @throws ElasticsearchClientException when a fatal bulk failure was recorded
+     */
+    void ensureBulkSucceeded() throws ElasticsearchClientException;
 
     /**
      * Perform a LowLevel Request

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/IElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/IElasticsearchClient.java
@@ -203,13 +203,30 @@ public interface IElasticsearchClient extends Closeable {
     /**
      * Throws if a previous bulk request failed after HTTP retries were exhausted. Does <b>not</b> clear the recorded
      * failure (so concurrent callers — e.g. crawl + REST — all observe it). Clear explicitly with
-     * {@link #clearFatalBulkFailure()} at the start/end of a crawl run.
+     * {@link #clearFatalBulkFailure()} at the start of a crawl run.
      *
      * @throws ElasticsearchClientException when a fatal bulk failure was recorded
      */
     void ensureBulkSucceeded() throws ElasticsearchClientException;
 
-    /** Clears any recorded fatal bulk failure so a new crawl run (or test) can start clean. */
+    /**
+     * Monotonic counter bumped whenever a fatal bulk failure is recorded. Survives {@link #clearFatalBulkFailure()}.
+     */
+    long getBulkFailureGeneration();
+
+    /**
+     * Like {@link #ensureBulkSucceeded()}, but also fails if a bulk failure was recorded since {@code generation} (even
+     * if the sticky flag was cleared meanwhile). Used by REST around index+flush.
+     *
+     * @param generation value from {@link #getBulkFailureGeneration()} captured before indexing
+     * @throws ElasticsearchClientException when a fatal bulk failure occurred since {@code generation}
+     */
+    void ensureBulkSucceededSince(long generation) throws ElasticsearchClientException;
+
+    /**
+     * Clears the sticky fatal bulk failure flag so a new crawl run can start clean. Does not reset the failure
+     * generation counter.
+     */
     void clearFatalBulkFailure();
 
     /**

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/IElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/IElasticsearchClient.java
@@ -195,10 +195,27 @@ public interface IElasticsearchClient extends Closeable {
 
     /**
      * Flush any pending Bulk operation. Note that flushing means immediate execution of the bulk request (with HTTP
-     * retries), but does not by itself fail the caller when the bulk failed — use {@link #ensureBulkSucceeded()} after
-     * flush for that.
+     * retries), but does not by itself fail the caller when the bulk failed — use
+     * {@link #flushAndEnsureBulkSucceeded()} (or {@link #ensureBulkSucceeded()} after flush) for that.
      */
     void flush();
+
+    /**
+     * Atomically flush pending bulks and fail if a fatal bulk failure was recorded during that window. Prefer this over
+     * separate {@link #flush()}+{@link #ensureBulkSucceeded()} calls (timer/REST can sneak a bulk in between).
+     *
+     * @throws ElasticsearchClientException when a fatal bulk failure was recorded
+     */
+    void flushAndEnsureBulkSucceeded() throws ElasticsearchClientException;
+
+    /**
+     * Like {@link #flushAndEnsureBulkSucceeded()}, but also fails if a bulk failure was recorded since
+     * {@code generation}.
+     *
+     * @param generation value from {@link #getBulkFailureGeneration()} captured before indexing
+     * @throws ElasticsearchClientException when a fatal bulk failure occurred since {@code generation}
+     */
+    void flushAndEnsureBulkSucceededSince(long generation) throws ElasticsearchClientException;
 
     /**
      * Throws if a previous bulk request failed after HTTP retries were exhausted. Does <b>not</b> clear the recorded

--- a/elasticsearch-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchBulkResponseTest.java
+++ b/elasticsearch-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchBulkResponseTest.java
@@ -90,4 +90,16 @@ class ElasticsearchBulkResponseTest extends AbstractFSCrawlerTestCase {
         Assertions.assertThat(bulkResponse.getItems().get(0).getFailureMessage())
                 .contains("failed to parse field");
     }
+
+    @Test
+    void httpFailureIsTreatedAsFailure() {
+        ElasticsearchClientException exception = new ElasticsearchClientException("bulk failed with HTTP 503");
+
+        ElasticsearchBulkResponse bulkResponse = new ElasticsearchBulkResponse(exception);
+
+        Assertions.assertThat(bulkResponse.isErrors()).isTrue();
+        Assertions.assertThat(bulkResponse.hasFailures()).isTrue();
+        Assertions.assertThat(bulkResponse.getException()).isSameAs(exception);
+        Assertions.assertThat(bulkResponse.buildFailureMessage()).isSameAs(exception);
+    }
 }

--- a/elasticsearch-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClientIT.java
+++ b/elasticsearch-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClientIT.java
@@ -1179,6 +1179,7 @@ class ElasticsearchClientIT extends AbstractFSCrawlerTestCase {
                 expected == null ? "some" : expected,
                 request.getIndex());
         AtomicReference<Exception> errorWhileWaiting = new AtomicReference<>();
+        AtomicReference<Long> lastHitCount = new AtomicReference<>();
 
         try {
             Awaitility.await()
@@ -1208,6 +1209,7 @@ class ElasticsearchClientIT extends AbstractFSCrawlerTestCase {
                             return false;
                         }
                         totalHits = response[0].getTotalHits();
+                        lastHitCount.set(totalHits);
 
                         logger.debug("got so far [{}] hits on expected [{}]", totalHits, expected);
 
@@ -1217,6 +1219,16 @@ class ElasticsearchClientIT extends AbstractFSCrawlerTestCase {
                         return totalHits == expected;
                     });
         } catch (ConditionTimeoutException e) {
+            Long lastHits = lastHitCount.get();
+            logger.warn(
+                    "Timed out waiting for {} documents in {} after {}. Last observed hit count: {}{}",
+                    expected == null ? "some" : expected,
+                    request.getIndex(),
+                    FsCrawlerUtil.durationToString(maxWaitForSearch),
+                    lastHits == null ? "unknown (search never succeeded)" : lastHits,
+                    errorWhileWaiting.get() != null
+                            ? "; last error: " + errorWhileWaiting.get().getMessage()
+                            : "");
             // If we caught an exception during waiting, throw it instead of the timeout
             if (errorWhileWaiting.get() != null) {
                 throw errorWhileWaiting.get();

--- a/elasticsearch-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClientRetryTest.java
+++ b/elasticsearch-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClientRetryTest.java
@@ -623,9 +623,16 @@ class ElasticsearchClientRetryTest extends AbstractFSCrawlerTestCase {
                     .isThrownBy(client::ensureBulkSucceeded)
                     .withMessageContaining("Bulk indexing failed");
 
-            // Explicit clear (start/end of crawl run) allows the next run to proceed
+            // Explicit clear (start of crawl run) allows sticky ensure to proceed, but generation still records the
+            // event
+            long generationBeforeClear = client.getBulkFailureGeneration();
             client.clearFatalBulkFailure();
             client.ensureBulkSucceeded();
+            Assertions.assertThatExceptionOfType(ElasticsearchClientException.class)
+                    .isThrownBy(() -> client.ensureBulkSucceededSince(generationBeforeClear - 1))
+                    .withMessageContaining("Bulk indexing failed");
+            // Same generation as after the failure: no new failure since that point
+            client.ensureBulkSucceededSince(generationBeforeClear);
         }
 
         WireMock.verify(WireMock.moreThan(1), WireMock.postRequestedFor(WireMock.urlPathEqualTo("/test-index/_bulk")));

--- a/elasticsearch-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClientRetryTest.java
+++ b/elasticsearch-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClientRetryTest.java
@@ -491,6 +491,138 @@ class ElasticsearchClientRetryTest extends AbstractFSCrawlerTestCase {
         logger.info("Test passed: search retries exhausted and exception propagated");
     }
 
+    /** Test that {@code _bulk} retries on 503 and eventually succeeds. */
+    @Test
+    void testBulkRetryOnServerError() throws IOException, ElasticsearchClientException {
+        wireMockServer.resetAll();
+
+        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/"))
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"version\": {\"number\": \"" + elasticsearchVersion + "\"}}")));
+
+        String bulkOk = """
+                {"errors":false,"items":[{"index":{"_index":"test-index","_id":"doc1","status":201}}]}
+                """;
+
+        WireMock.stubFor(WireMock.post(WireMock.urlPathEqualTo("/test-index/_bulk"))
+                .inScenario("Bulk Retry")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(WireMock.aResponse().withStatus(503).withBody("""
+                                {"error":{"type":"no_shard_available_action_exception","status":503}}
+                                """))
+                .willSetStateTo("First Failure"));
+
+        WireMock.stubFor(WireMock.post(WireMock.urlPathEqualTo("/test-index/_bulk"))
+                .inScenario("Bulk Retry")
+                .whenScenarioStateIs("First Failure")
+                .willReturn(WireMock.aResponse().withStatus(503).withBody("""
+                                {"error":{"type":"no_shard_available_action_exception","status":503}}
+                                """))
+                .willSetStateTo("Recovered"));
+
+        WireMock.stubFor(WireMock.post(WireMock.urlPathEqualTo("/test-index/_bulk"))
+                .inScenario("Bulk Retry")
+                .whenScenarioStateIs("Recovered")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(bulkOk)));
+
+        try (ElasticsearchClient client = createClient()) {
+            client.start();
+            wireMockServer.resetRequests();
+
+            String response = client.bulk("test-index", "{}\n{}\n");
+            Assertions.assertThat(response).contains("\"errors\":false");
+        }
+
+        WireMock.verify(3, WireMock.postRequestedFor(WireMock.urlPathEqualTo("/test-index/_bulk")));
+        logger.info("Test passed: bulk retry on server error works correctly");
+    }
+
+    /** Test that {@code _bulk} retries on 429 and eventually succeeds. */
+    @Test
+    @Slow
+    void testBulkRetryOn429TooManyRequests() throws IOException, ElasticsearchClientException {
+        wireMockServer.resetAll();
+
+        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/"))
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"version\": {\"number\": \"" + elasticsearchVersion + "\"}}")));
+
+        String bulkOk = """
+                {"errors":false,"items":[{"index":{"_index":"test-index","_id":"doc1","status":201}}]}
+                """;
+
+        WireMock.stubFor(WireMock.post(WireMock.urlPathEqualTo("/test-index/_bulk"))
+                .inScenario("Bulk 429")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(WireMock.aResponse().withStatus(429).withBody("""
+                                {"error":{"type":"rate_limit_exception","reason":"rejected"}}
+                                """))
+                .willSetStateTo("First 429"));
+
+        WireMock.stubFor(WireMock.post(WireMock.urlPathEqualTo("/test-index/_bulk"))
+                .inScenario("Bulk 429")
+                .whenScenarioStateIs("First 429")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(bulkOk)));
+
+        try (ElasticsearchClient client = createClient()) {
+            client.start();
+            wireMockServer.resetRequests();
+
+            String response = client.bulk("test-index", "{}\n{}\n");
+            Assertions.assertThat(response).contains("\"errors\":false");
+        }
+
+        WireMock.verify(2, WireMock.postRequestedFor(WireMock.urlPathEqualTo("/test-index/_bulk")));
+        logger.info("Test passed: bulk retry on 429 works correctly");
+    }
+
+    /**
+     * When bulk HTTP retries are exhausted, the failure is recorded and
+     * {@link ElasticsearchClient#ensureBulkSucceeded()} fails the caller so the crawl/run can be marked as ERROR.
+     */
+    @Test
+    @Slow
+    void testBulkRetriesExhaustedAreRecordedAsFatal() throws Exception {
+        wireMockServer.resetAll();
+
+        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/"))
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"version\": {\"number\": \"" + elasticsearchVersion + "\"}}")));
+
+        WireMock.stubFor(WireMock.post(WireMock.urlPathEqualTo("/test-index/_bulk"))
+                .willReturn(WireMock.aResponse().withStatus(503).withBody("""
+                                {"error":{"type":"no_shard_available_action_exception","status":503}}
+                                """)));
+
+        try (ElasticsearchClient client = createClient()) {
+            client.start();
+            wireMockServer.resetRequests();
+
+            // index + flush triggers engine.bulk -> client.bulk with retries; exhausted failures are recorded
+            client.indexRawJson("test-index", "doc1", "{\"foo\":\"bar\"}", null);
+            client.flush();
+
+            Assertions.assertThatExceptionOfType(ElasticsearchClientException.class)
+                    .isThrownBy(client::ensureBulkSucceeded)
+                    .withMessageContaining("Bulk indexing failed");
+        }
+
+        WireMock.verify(WireMock.moreThan(1), WireMock.postRequestedFor(WireMock.urlPathEqualTo("/test-index/_bulk")));
+        logger.info("Test passed: exhausted bulk retries are recorded as fatal");
+    }
+
     /**
      * Test that connection errors are propagated immediately without silent retry. This ensures the original error
      * message is preserved.

--- a/elasticsearch-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClientRetryTest.java
+++ b/elasticsearch-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClientRetryTest.java
@@ -617,10 +617,51 @@ class ElasticsearchClientRetryTest extends AbstractFSCrawlerTestCase {
             Assertions.assertThatExceptionOfType(ElasticsearchClientException.class)
                     .isThrownBy(client::ensureBulkSucceeded)
                     .withMessageContaining("Bulk indexing failed");
+
+            // Must not clear on ensure: concurrent REST ensureBulkSucceeded must not hide the failure from the crawl
+            Assertions.assertThatExceptionOfType(ElasticsearchClientException.class)
+                    .isThrownBy(client::ensureBulkSucceeded)
+                    .withMessageContaining("Bulk indexing failed");
+
+            // Explicit clear (start/end of crawl run) allows the next run to proceed
+            client.clearFatalBulkFailure();
+            client.ensureBulkSucceeded();
         }
 
         WireMock.verify(WireMock.moreThan(1), WireMock.postRequestedFor(WireMock.urlPathEqualTo("/test-index/_bulk")));
         logger.info("Test passed: exhausted bulk retries are recorded as fatal");
+    }
+
+    /**
+     * Empty end-of-run flush must not POST {@code _bulk} or record a fatal failure (Bugbot: empty flush after
+     * interval/size-triggered flushes).
+     */
+    @Test
+    @Slow
+    void testEmptyFlushDoesNotRecordFatalBulkFailure() throws Exception {
+        wireMockServer.resetAll();
+
+        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/"))
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"version\": {\"number\": \"" + elasticsearchVersion + "\"}}")));
+
+        WireMock.stubFor(WireMock.post(WireMock.urlPathMatching(".*/_bulk"))
+                .willReturn(WireMock.aResponse().withStatus(400).withBody("""
+                                {"error":{"type":"parse_exception","reason":"request body is required"}}
+                                """)));
+
+        try (ElasticsearchClient client = createClient()) {
+            client.start();
+            wireMockServer.resetRequests();
+
+            client.flush();
+            client.ensureBulkSucceeded();
+        }
+
+        WireMock.verify(0, WireMock.postRequestedFor(WireMock.urlPathMatching(".*/_bulk")));
+        logger.info("Test passed: empty flush does not hit _bulk or record fatal failure");
     }
 
     /**

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerBulkProcessor.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerBulkProcessor.java
@@ -201,8 +201,9 @@ public class FsCrawlerBulkProcessor<
                     inFlightMonitor.wait();
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
-                    logger.warn("Interrupted while waiting for in-flight bulk execution(s)");
-                    return;
+                    // Do not return while a bulk is still in flight: callers would run ensureBulkSucceeded()
+                    // too early and miss a fatal HTTP failure recorded by the completing bulk.
+                    throw new IllegalStateException("Interrupted while waiting for in-flight bulk execution(s)", e);
                 }
             }
         }

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerBulkProcessor.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerBulkProcessor.java
@@ -52,6 +52,10 @@ public class FsCrawlerBulkProcessor<
     private final ScheduledExecutorService executor;
     private volatile boolean closed = false;
     private final AtomicLong executionIdGen = new AtomicLong();
+    /** Guards {@link #inFlightExecutions} so {@link #flush()} can wait for timer-triggered bulks to finish. */
+    private final Object inFlightMonitor = new Object();
+
+    private int inFlightExecutions = 0;
 
     private FsCrawlerBulkProcessor(
             Engine<O, Q, S> engine,
@@ -139,6 +143,10 @@ public class FsCrawlerBulkProcessor<
         this.bulkRequest = supplyRequestWithLimits(requestSupplier, bulkActions, byteSize);
         final long executionId = executionIdGen.incrementAndGet();
 
+        synchronized (inFlightMonitor) {
+            inFlightExecutions++;
+        }
+
         Span bulkSpan = FsCrawlerTracing.startSpan("fscrawler.es.bulk");
         bulkSpan.setAttribute("es.bulk.actions", br.numberOfActions());
 
@@ -159,6 +167,10 @@ public class FsCrawlerBulkProcessor<
             }
         } finally {
             bulkSpan.end();
+            synchronized (inFlightMonitor) {
+                inFlightExecutions--;
+                inFlightMonitor.notifyAll();
+            }
         }
     }
 
@@ -173,8 +185,27 @@ public class FsCrawlerBulkProcessor<
         return listener;
     }
 
+    /**
+     * Flush pending actions if any, then wait for any in-flight bulk (including one started by the flush interval
+     * timer) to finish. No-op HTTP when the queue is empty so callers do not POST an empty {@code _bulk} body.
+     */
     public void flush() {
-        execute();
+        executeWhenNeeded();
+        awaitInFlightExecutions();
+    }
+
+    private void awaitInFlightExecutions() {
+        synchronized (inFlightMonitor) {
+            while (inFlightExecutions > 0) {
+                try {
+                    inFlightMonitor.wait();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    logger.warn("Interrupted while waiting for in-flight bulk execution(s)");
+                    return;
+                }
+            }
+        }
     }
 
     public static class Builder<

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerBulkProcessor.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerBulkProcessor.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -58,12 +59,12 @@ public class FsCrawlerBulkProcessor<
 
     private int inFlightExecutions = 0;
     /**
-     * When true, only the thread inside {@link #flushWhileQuiesced(Runnable)} may start a new bulk execute. The
-     * flush-interval timer and size-triggered flushes from {@link #add} are suppressed so flush+ensure is atomic.
+     * When true, only the thread holding {@link #quiesceLock} may start a new bulk execute. The flush-interval timer
+     * and size-triggered flushes from {@link #add} are suppressed so flush+ensure is atomic.
      */
     private final AtomicBoolean quiesced = new AtomicBoolean();
-
-    private final ThreadLocal<Boolean> flushOwner = ThreadLocal.withInitial(() -> Boolean.FALSE);
+    /** Exclusive lock so crawl-end and REST cannot interleave two {@link #flushWhileQuiesced} calls. */
+    private final ReentrantLock quiesceLock = new ReentrantLock();
 
     private FsCrawlerBulkProcessor(
             Engine<O, Q, S> engine,
@@ -153,7 +154,7 @@ public class FsCrawlerBulkProcessor<
     }
 
     private boolean isQuiescedForOtherThreads() {
-        return quiesced.get() && !Boolean.TRUE.equals(flushOwner.get());
+        return quiesced.get() && !quiesceLock.isHeldByCurrentThread();
     }
 
     private void execute() {
@@ -213,28 +214,28 @@ public class FsCrawlerBulkProcessor<
     }
 
     /**
-     * Suppress concurrent timer/size-triggered executes, drain pending (+ retry re-queues), then run {@code action}
-     * before releasing quiesce. Closes the race where a bulk starts after {@link #flush()} and fails after ensure.
+     * Exclusively suppress concurrent timer/size-triggered executes, drain until idle (including retry re-queues), then
+     * run {@code action} before releasing quiesce. Closes the race where a bulk starts after {@link #flush()} and fails
+     * after ensure.
      *
      * @param action runs after the processor is idle (no pending actions, no in-flight execute)
      */
     public void flushWhileQuiesced(Runnable action) {
-        flushOwner.set(Boolean.TRUE);
+        quiesceLock.lock();
         try {
             quiesced.set(true);
             try {
-                // First pass: pending work + wait for in-flight (including timer bulks started before quiesce).
-                executeWhenNeeded();
-                awaitInFlightExecutions();
-                // Second pass: operations re-queued by retry listeners during afterBulk.
-                executeWhenNeeded();
-                awaitInFlightExecutions();
+                // Drain until empty: afterBulk retry listeners may re-queue under the bulk-size threshold.
+                do {
+                    executeWhenNeeded();
+                    awaitInFlightExecutions();
+                } while (bulkRequest.numberOfActions() > 0);
                 action.run();
             } finally {
                 quiesced.set(false);
             }
         } finally {
-            flushOwner.set(Boolean.FALSE);
+            quiesceLock.unlock();
         }
     }
 

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerBulkProcessor.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerBulkProcessor.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
@@ -56,6 +57,13 @@ public class FsCrawlerBulkProcessor<
     private final Object inFlightMonitor = new Object();
 
     private int inFlightExecutions = 0;
+    /**
+     * When true, only the thread inside {@link #flushWhileQuiesced(Runnable)} may start a new bulk execute. The
+     * flush-interval timer and size-triggered flushes from {@link #add} are suppressed so flush+ensure is atomic.
+     */
+    private final AtomicBoolean quiesced = new AtomicBoolean();
+
+    private final ThreadLocal<Boolean> flushOwner = ThreadLocal.withInitial(() -> Boolean.FALSE);
 
     private FsCrawlerBulkProcessor(
             Engine<O, Q, S> engine,
@@ -126,6 +134,9 @@ public class FsCrawlerBulkProcessor<
 
     private void executeIfNeeded() {
         ensureOpen();
+        if (isQuiescedForOtherThreads()) {
+            return;
+        }
         if (bulkRequest.isOverTheLimit()) {
             execute();
         }
@@ -133,9 +144,16 @@ public class FsCrawlerBulkProcessor<
 
     private void executeWhenNeeded() {
         ensureOpen();
+        if (isQuiescedForOtherThreads()) {
+            return;
+        }
         if (bulkRequest.numberOfActions() > 0) {
             execute();
         }
+    }
+
+    private boolean isQuiescedForOtherThreads() {
+        return quiesced.get() && !Boolean.TRUE.equals(flushOwner.get());
     }
 
     private void execute() {
@@ -192,6 +210,32 @@ public class FsCrawlerBulkProcessor<
     public void flush() {
         executeWhenNeeded();
         awaitInFlightExecutions();
+    }
+
+    /**
+     * Suppress concurrent timer/size-triggered executes, drain pending (+ retry re-queues), then run {@code action}
+     * before releasing quiesce. Closes the race where a bulk starts after {@link #flush()} and fails after ensure.
+     *
+     * @param action runs after the processor is idle (no pending actions, no in-flight execute)
+     */
+    public void flushWhileQuiesced(Runnable action) {
+        flushOwner.set(Boolean.TRUE);
+        try {
+            quiesced.set(true);
+            try {
+                // First pass: pending work + wait for in-flight (including timer bulks started before quiesce).
+                executeWhenNeeded();
+                awaitInFlightExecutions();
+                // Second pass: operations re-queued by retry listeners during afterBulk.
+                executeWhenNeeded();
+                awaitInFlightExecutions();
+                action.run();
+            } finally {
+                quiesced.set(false);
+            }
+        } finally {
+            flushOwner.set(Boolean.FALSE);
+        }
     }
 
     private void awaitInFlightExecutions() {

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerBulkProcessorTest.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerBulkProcessorTest.java
@@ -119,6 +119,25 @@ class FsCrawlerBulkProcessorTest extends AbstractFSCrawlerTestCase {
         Assertions.assertThat(listener.nbSuccessfulExecutions).isEqualTo(3);
     }
 
+    /**
+     * Explicit {@link FsCrawlerBulkProcessor#flush()} must be a no-op when the queue is empty. Otherwise end-of-run
+     * flushes send an empty {@code _bulk} body and can mark a successful crawl as failed.
+     */
+    @Test
+    void bulkProcessorFlushWithNoPendingActionsIsNoOp() throws IOException {
+        TestBulkListener listener = new TestBulkListener();
+        FsCrawlerBulkProcessor<TestOperation, TestBulkRequest, TestBulkResponse> bulkProcessor =
+                new FsCrawlerBulkProcessor.Builder<>(new TestEngine(), listener, TestBulkRequest::new)
+                        .setBulkActions(RandomizedTest.randomIntInRange(randomizedRandomForTests, 10, 100))
+                        .setByteSize(new ByteSizeValue(1, ByteSizeUnit.MB))
+                        .build();
+
+        bulkProcessor.flush();
+        Assertions.assertThat(listener.nbSuccessfulExecutions).isZero();
+        bulkProcessor.close();
+        Assertions.assertThat(listener.nbSuccessfulExecutions).isZero();
+    }
+
     @Test
     void bulkProcessorFlushInterval() throws IOException {
         int maxActions = RandomizedTest.randomIntInRange(randomizedRandomForTests, 1, 1000);

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerBulkProcessorTest.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerBulkProcessorTest.java
@@ -29,6 +29,7 @@ import fr.pilato.elasticsearch.crawler.fs.framework.TimeValue;
 import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.assertj.core.api.Assertions;
@@ -117,6 +118,31 @@ class FsCrawlerBulkProcessorTest extends AbstractFSCrawlerTestCase {
         generatePayload(bulkProcessor, 2 * maxActions + 1, 1);
         bulkProcessor.close();
         Assertions.assertThat(listener.nbSuccessfulExecutions).isEqualTo(3);
+    }
+
+    /**
+     * {@link FsCrawlerBulkProcessor#flushWhileQuiesced} must drain pending actions and run the callback only once the
+     * processor is idle — so flush+ensure cannot race with the flush-interval timer.
+     */
+    @Test
+    void bulkProcessorFlushWhileQuiescedRunsWhenIdle() throws IOException {
+        TestBulkListener listener = new TestBulkListener();
+        FsCrawlerBulkProcessor<TestOperation, TestBulkRequest, TestBulkResponse> bulkProcessor =
+                new FsCrawlerBulkProcessor.Builder<>(new TestEngine(), listener, TestBulkRequest::new)
+                        .setBulkActions(RandomizedTest.randomIntInRange(randomizedRandomForTests, 10, 100))
+                        .setByteSize(new ByteSizeValue(1, ByteSizeUnit.MB))
+                        .build();
+
+        int pending = RandomizedTest.randomIntInRange(randomizedRandomForTests, 1, 5);
+        generatePayload(bulkProcessor, 1, pending);
+        Assertions.assertThat(listener.nbSuccessfulExecutions).isZero();
+
+        AtomicInteger actionsAtCallback = new AtomicInteger(-1);
+        bulkProcessor.flushWhileQuiesced(() -> actionsAtCallback.set(listener.nbSuccessfulExecutions));
+
+        Assertions.assertThat(actionsAtCallback.get()).isEqualTo(1);
+        Assertions.assertThat(listener.nbSuccessfulExecutions).isEqualTo(1);
+        bulkProcessor.close();
     }
 
     /**

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerBulkProcessorTest.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerBulkProcessorTest.java
@@ -29,6 +29,7 @@ import fr.pilato.elasticsearch.crawler.fs.framework.TimeValue;
 import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -142,6 +143,37 @@ class FsCrawlerBulkProcessorTest extends AbstractFSCrawlerTestCase {
 
         Assertions.assertThat(actionsAtCallback.get()).isEqualTo(1);
         Assertions.assertThat(listener.nbSuccessfulExecutions).isEqualTo(1);
+        bulkProcessor.close();
+    }
+
+    /**
+     * Retries re-queued in {@code afterBulk} under the bulk-size threshold must be drained before the quiesced callback
+     * runs — otherwise ensure would report success with documents still pending.
+     */
+    @Test
+    void bulkProcessorFlushWhileQuiescedDrainsRetryRequeues() throws IOException {
+        AtomicBoolean requeued = new AtomicBoolean();
+        TestBulkListener listener = new TestBulkListener() {
+            @Override
+            public void afterBulk(long executionId, TestBulkRequest request, TestBulkResponse response) {
+                super.afterBulk(executionId, request, response);
+                if (requeued.compareAndSet(false, true)) {
+                    bulkProcessor.add(new TestOperation(PAYLOAD));
+                }
+            }
+        };
+        FsCrawlerBulkProcessor<TestOperation, TestBulkRequest, TestBulkResponse> bulkProcessor =
+                new FsCrawlerBulkProcessor.Builder<>(new TestEngine(), listener, TestBulkRequest::new)
+                        .setBulkActions(RandomizedTest.randomIntInRange(randomizedRandomForTests, 10, 100))
+                        .setByteSize(new ByteSizeValue(1, ByteSizeUnit.MB))
+                        .build();
+
+        generatePayload(bulkProcessor, 1, 1);
+        AtomicInteger executionsAtCallback = new AtomicInteger(-1);
+        bulkProcessor.flushWhileQuiesced(() -> executionsAtCallback.set(listener.nbSuccessfulExecutions));
+
+        Assertions.assertThat(executionsAtCallback.get()).isEqualTo(2);
+        Assertions.assertThat(listener.nbSuccessfulExecutions).isEqualTo(2);
         bulkProcessor.close();
     }
 

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
@@ -452,6 +452,7 @@ abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
                 expected == null ? "some" : expected,
                 request.getIndex());
         AtomicReference<Exception> errorWhileWaiting = new AtomicReference<>();
+        AtomicReference<Long> lastHitCount = new AtomicReference<>();
 
         try {
             Awaitility.await()
@@ -483,6 +484,7 @@ abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
                             return false;
                         }
                         totalHits = response[0].getTotalHits();
+                        lastHitCount.set(totalHits);
 
                         logger.debug("got so far [{}] hits on expected [{}]", totalHits, expected);
 
@@ -492,6 +494,16 @@ abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
                         return totalHits == expected;
                     });
         } catch (ConditionTimeoutException e) {
+            Long lastHits = lastHitCount.get();
+            logger.warn(
+                    "Timed out waiting for {} documents in {} after {}. Last observed hit count: {}{}",
+                    expected == null ? "some" : expected,
+                    request.getIndex(),
+                    FsCrawlerUtil.durationToString(duration),
+                    lastHits == null ? "unknown (search never succeeded)" : lastHits,
+                    errorWhileWaiting.get() != null
+                            ? "; last error: " + errorWhileWaiting.get().getMessage()
+                            : "");
             // If we caught an exception during waiting, throw it instead of the timeout
             if (errorWhileWaiting.get() != null) {
                 throw errorWhileWaiting.get();

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerImplAllDocumentsIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerImplAllDocumentsIT.java
@@ -100,7 +100,7 @@ class FsCrawlerImplAllDocumentsIT extends AbstractFsCrawlerITCase {
         crawler = new FsCrawlerImpl(classMetadataDir, fsSettings, FsCrawlerImpl.LOOP_INFINITE, false);
         crawler.start();
 
-        // We wait until we have all docs up to 10 minutes
+        // We wait until we have all docs up to MAX_WAIT_FOR_SEARCH_LONG_TESTS
         countTestHelper(
                 new ESSearchRequest().withIndex(JOB_NAME + FsCrawlerUtil.INDEX_SUFFIX_DOCS),
                 numFiles,

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerRestFilenameAsIdIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerRestFilenameAsIdIT.java
@@ -74,6 +74,9 @@ class FsCrawlerRestFilenameAsIdIT extends AbstractRestITCase {
         }
         Files.walk(from).filter(Files::isRegularFile).forEach(path -> {
             UploadResponse response = uploadFile(target, path);
+            Assertions.assertThat(response.isOk())
+                    .as("upload of [%s] should succeed: %s", path.getFileName(), response.getMessage())
+                    .isTrue();
             Assertions.assertThat(response.getFilename())
                     .isEqualTo(path.getFileName().toString());
         });

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerRestFilenameAsIdIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerRestFilenameAsIdIT.java
@@ -81,12 +81,12 @@ class FsCrawlerRestFilenameAsIdIT extends AbstractRestITCase {
                     .isEqualTo(path.getFileName().toString());
         });
 
-        // We wait until we have all docs
+        // We wait until we have all docs (same workload as FsCrawlerImplAllDocumentsIT)
         ESSearchResponse response = countTestHelper(
                 new ESSearchRequest().withIndex(getCrawlerName() + FsCrawlerUtil.INDEX_SUFFIX_DOCS),
                 Files.list(from).count(),
                 null,
-                MAX_WAIT_FOR_SEARCH);
+                MAX_WAIT_FOR_SEARCH_LONG_TESTS);
         for (ESSearchHit hit : response.getHits()) {
             Assertions.assertThat(hit.getId()).isEqualTo((String) JsonPath.read(hit.getSource(), "$.file.filename"));
         }

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerRestIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerRestIT.java
@@ -133,12 +133,12 @@ class FsCrawlerRestIT extends AbstractRestITCase {
                     .isEqualTo(path.getFileName().toString());
         });
 
-        // We wait until we have all docs
+        // We wait until we have all docs (same workload as FsCrawlerImplAllDocumentsIT)
         ESSearchResponse response = countTestHelper(
                 new ESSearchRequest().withIndex(getCrawlerName() + FsCrawlerUtil.INDEX_SUFFIX_DOCS),
                 Files.list(from).count(),
                 null,
-                MAX_WAIT_FOR_SEARCH);
+                MAX_WAIT_FOR_SEARCH_LONG_TESTS);
         for (ESSearchHit hit : response.getHits()) {
             Assertions.assertThat((String) JsonPath.read(hit.getSource(), "$.file.extension"))
                     .isNotEmpty();

--- a/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/DocumentApi.java
+++ b/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/DocumentApi.java
@@ -23,6 +23,7 @@ package fr.pilato.elasticsearch.crawler.fs.rest;
 import com.jayway.jsonpath.DocumentContext;
 import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
 import fr.pilato.elasticsearch.crawler.fs.beans.DocUtils;
+import fr.pilato.elasticsearch.crawler.fs.client.ElasticsearchClientException;
 import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil;
 import fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil;
 import fr.pilato.elasticsearch.crawler.fs.framework.SignTool;
@@ -265,7 +266,22 @@ public class DocumentApi implements RestApi {
         } else {
             logger.debug(
                     "Sending document [{}] to elasticsearch.", doc.getFile().getFilename());
-            documentService.index(index, id, doc, settings.getElasticsearch().getPipeline());
+            try {
+                documentService.index(
+                        index, id, doc, settings.getElasticsearch().getPipeline());
+                // Make the REST response reflect ES acknowledgment: flush and fail if bulk retries were exhausted
+                documentService.flushAndEnsureBulkSucceeded();
+            } catch (ElasticsearchClientException e) {
+                logger.error(
+                        "Failed to index document [{}] via REST after bulk retries: {}",
+                        doc.getFile().getFilename(),
+                        e.getMessage());
+                UploadResponse response = new UploadResponse(
+                        false, "Can not index document [" + doc.getFile().getFilename() + "]: " + e.getMessage());
+                response.setFilename(doc.getFile().getFilename());
+                response.setUrl(url);
+                return response;
+            }
         }
 
         UploadResponse response = new UploadResponse(true);

--- a/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/DocumentApi.java
+++ b/rest/src/main/java/fr/pilato/elasticsearch/crawler/fs/rest/DocumentApi.java
@@ -267,10 +267,12 @@ public class DocumentApi implements RestApi {
             logger.debug(
                     "Sending document [{}] to elasticsearch.", doc.getFile().getFilename());
             try {
+                // Capture generation before index so a timer-driven bulk failure (and a concurrent crawl clear of the
+                // sticky flag) still makes this upload return ok:false.
+                long bulkFailureGeneration = documentService.getBulkFailureGeneration();
                 documentService.index(
                         index, id, doc, settings.getElasticsearch().getPipeline());
-                // Make the REST response reflect ES acknowledgment: flush and fail if bulk retries were exhausted
-                documentService.flushAndEnsureBulkSucceeded();
+                documentService.flushAndEnsureBulkSucceededSince(bulkFailureGeneration);
             } catch (ElasticsearchClientException e) {
                 logger.error(
                         "Failed to index document [{}] via REST after bulk retries: {}",

--- a/test-framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/framework/AbstractFSCrawlerTestCase.java
+++ b/test-framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/test/framework/AbstractFSCrawlerTestCase.java
@@ -71,13 +71,13 @@ public abstract class AbstractFSCrawlerTestCase {
     protected static final String INDEX_PREFIX = getSystemProperty("tests.index.prefix", "");
 
     /** For tests only: maximum time to wait for a search when we want to be sure that something is in the index. */
-    public static final Duration MAX_WAIT_FOR_SEARCH = Duration.ofMinutes(5);
+    public static final Duration MAX_WAIT_FOR_SEARCH = Duration.ofMinutes(2);
 
     /**
      * For tests only: maximum time to wait for a search when we want to be sure that something is in the index, but we
      * are running long tests (like with Tika OCR for instance).
      */
-    public static final Duration MAX_WAIT_FOR_SEARCH_LONG_TESTS = Duration.ofMinutes(10);
+    public static final Duration MAX_WAIT_FOR_SEARCH_LONG_TESTS = Duration.ofMinutes(5);
 
     @TempDir
     protected Path rootTmpDir;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens Elasticsearch bulk indexing against Cloud overload and improves IT diagnostics when document counts do not converge.

### Changes

- **`ElasticsearchBulkResponse(exception)`**: treat transport/HTTP failures as `hasFailures() == true`.
- **Bulk HTTP retry**: `_bulk` uses `httpPostWithRetry` for 429/5xx.
- **Fatal bulk errors**: crawl checkpoint / REST report failure after flush when bulk is exhausted.
- **Atomic flush+ensure**: `flushWhileQuiesced` suppresses timer/size-triggered bulks until ensure runs (closes the flush→ensure race with concurrent REST).
- **`countTestHelper` timeout**: WARN with last hit count before failing.
- **IT search waits**: `MAX_WAIT_FOR_SEARCH` 2 min / `LONG_TESTS` 5 min; REST upload-all uses long wait.

### Bugbot follow-ups addressed

1. REST must not clear shared sticky failure  
2. Empty end-of-run flush  
3. Stale failure across runs (clear at crawl start only)  
4. Crawl clear vs REST (`bulkFailureGeneration`)  
5. NPE when `documentService` is null  
6. Interrupt during in-flight wait fails closed  
7. **Flush and ensure not atomic** — quiesced drain + ensure before releasing quiesce  

### Test plan

- [x] Unit / WireMock + `FsParserSchedulingTest`
- [ ] CI: Windows + Linux ITs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f32d209-30b3-4b3c-b087-42daab67c679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f32d209-30b3-4b3c-b087-42daab67c679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

