### PR TITLE
Exclude binary IT samples from SonarCloud analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,6 +4,7 @@
 
 # Exclude non-product sources from analysis:
 # - test-documents: sample fixtures (PDF, Office, HTML, non-UTF-8 encodings), not product code
+# - integration-tests resources-binary: binary samples (.pdf, .docx, .png, …), not UTF-8 text
 # - spotless JavaLicenseHeader: license template consumed by Spotless, not runtime code
 # - Noop: empty class required to satisfy central-publishing-maven-plugin packaging
-sonar.exclusions=**/test-documents/**,**/src/main/spotless/**,**/Noop.java
+sonar.exclusions=**/test-documents/**,**/integration-tests/src/test/resources-binary/**,**/src/main/spotless/**,**/Noop.java

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,6 +5,7 @@
 # Exclude non-product sources from analysis:
 # - test-documents: sample fixtures (PDF, Office, HTML, non-UTF-8 encodings), not product code
 # - integration-tests resources-binary: binary samples (.pdf, .docx, .png, …), not UTF-8 text
+# - **/*.png / **/*.jpg: documentation and other image assets (non-UTF-8 binaries)
 # - spotless JavaLicenseHeader: license template consumed by Spotless, not runtime code
 # - Noop: empty class required to satisfy central-publishing-maven-plugin packaging
-sonar.exclusions=**/test-documents/**,**/integration-tests/src/test/resources-binary/**,**/src/main/spotless/**,**/Noop.java
+sonar.exclusions=**/test-documents/**,**/integration-tests/src/test/resources-binary/**,**/*.png,**/*.jpg,**/src/main/spotless/**,**/Noop.java


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Extends `sonar.exclusions` in `sonar-project.properties` with:
  - `**/integration-tests/src/test/resources-binary/**` (binary IT samples)
  - `**/*.png` and `**/*.jpg` (generic image assets: docs screenshots, diagrams)
- Keeps the existing `**/test-documents/**` exclusion (already covers `test-documents/src/main/resources/documents/**`)
- Avoids SonarCloud warnings on non-UTF-8 binary fixtures and image files

## Test plan

- [ ] Confirm SonarCloud Automatic Analysis no longer flags files under `integration-tests/src/test/resources-binary/`
- [ ] Confirm SonarCloud no longer warns on `*.png` / `*.jpg` (e.g. docs images)
- [ ] Confirm product sources and unit/IT Java sources remain in the analysis scope

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f90ca-17e8-7555-8265-f4a30783f5ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f90ca-17e8-7555-8265-f4a30783f5ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

