### PR TITLE
docs(tutorial): add start-local and Docker quick start

### DIFF
--- a/docs/source/user/tutorial.md
+++ b/docs/source/user/tutorial.md
@@ -5,20 +5,148 @@ This tutorial use case is:
 Search for the resumes (PDF or Word file which resides in One drive or local) and search for anything in the content
 using Kibana. For example location worked or the previous company, etc.
 
-## Prerequisites
+The fastest way to follow this tutorial is to run Elasticsearch and Kibana with Elastic's
+[start-local](https://www.elastic.co/docs/deploy-manage/deploy/self-managed/local-development-installation-quickstart)
+script, and FSCrawler with Docker. If you prefer a manual install, see
+[Alternative: manual installation](#alternative-manual-installation).
+
+## Recommended: Docker and start-local
+
+### Prerequisites
+
+* [Docker](https://docs.docker.com/get-docker/) must be installed and running
+* On Windows, use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) as required by `start-local`
+
+### Start Elasticsearch and Kibana
+
+Run Elastic's `start-local` script:
+
+```sh
+curl -fsSL https://elastic.co/start-local | sh
+```
+
+This creates an `elastic-start-local` directory, starts Elasticsearch and Kibana in Docker, and writes credentials
+to `elastic-start-local/.env`.
+
+After a few seconds, check that the services are up:
+
+* Elasticsearch: <http://localhost:9200>
+* Kibana: <http://localhost:5601>
+
+Load the generated API key (you will need it for FSCrawler):
+
+```sh
+cd elastic-start-local
+source .env
+echo "$ES_LOCAL_API_KEY"
+```
+
+```{note}
+`start-local` is meant for local development only. It exposes HTTP (not HTTPS) on `localhost`.
+```
+
+### Start FSCrawler with Docker
+
+* Pull the FSCrawler image. See {ref}`docker` for details (including the smaller `noocr` variant):
+
+```sh
+docker pull dadoonet/fscrawler
+```
+
+* Create a job named `resumes`:
+
+```sh
+docker run -it --rm \
+  -v ~/.fscrawler:/root/.fscrawler \
+  dadoonet/fscrawler --setup resumes
+```
+
+* Edit `~/.fscrawler/resumes/_settings.yaml` so the crawler reads documents from `/tmp/es` **inside** the
+  container (this is the default `fs.url` value). A minimal job file looks like:
+
+```yaml
+---
+name: "resumes"
+fs:
+  url: "/tmp/es"
+```
+
+  Leave `elasticsearch.index` unset. FSCrawler will index into `resumes_docs` and create a `resumes` alias.
+
+* Put your resume files in a local folder (for example `~/resumes`), then start FSCrawler.
+  From a Docker container, Elasticsearch on the host is reached via `host.docker.internal`
+  (not `127.0.0.1`):
+
+```sh
+# From the elastic-start-local directory, or after: source elastic-start-local/.env
+docker run -it --rm \
+  --add-host=host.docker.internal:host-gateway \
+  -v ~/.fscrawler:/root/.fscrawler \
+  -v ~/resumes:/tmp/es:ro \
+  -e FSCRAWLER_ELASTICSEARCH_URLS=http://host.docker.internal:9200 \
+  -e FSCRAWLER_ELASTICSEARCH_API_KEY="${ES_LOCAL_API_KEY}" \
+  dadoonet/fscrawler resumes
+```
+
+```{note}
+`--add-host=host.docker.internal:host-gateway` is required on Linux so the container can reach services
+published on the host. On Docker Desktop (macOS / Windows), `host.docker.internal` is usually available
+already; keeping the flag is still fine.
+```
+
+You can also put the Elasticsearch settings in `_settings.yaml` instead of environment variables:
+
+```yaml
+---
+name: "resumes"
+fs:
+  url: "/tmp/es"
+elasticsearch:
+  urls:
+    - "http://host.docker.internal:9200"
+  api_key: "YOUR_ES_LOCAL_API_KEY"
+```
+
+Use `http://` (not `https://`) with `start-local`. Copy the API key value from `ES_LOCAL_API_KEY` in
+`elastic-start-local/.env`.
+
+FSCrawler should index all the documents inside your directory. Then continue with
+[Create Index pattern](#create-index-pattern).
+
+````{note}
+
+ If you want to start again reindexing from scratch instead of monitoring the changes, stop FSCrawler, restart it
+ with the `--restart` option:
+
+ ```bash
+ docker run -it --rm \
+   --add-host=host.docker.internal:host-gateway \
+   -v ~/.fscrawler:/root/.fscrawler \
+   -v ~/resumes:/tmp/es:ro \
+   -e FSCRAWLER_ELASTICSEARCH_URLS=http://host.docker.internal:9200 \
+   -e FSCRAWLER_ELASTICSEARCH_API_KEY="${ES_LOCAL_API_KEY}" \
+   dadoonet/fscrawler resumes --restart
+ ```
+````
+
+## Alternative: manual installation
+
+Use this path if you prefer to download Elasticsearch, Kibana, and FSCrawler yourself instead of using Docker.
+
+### Prerequisites
 
 * Java {{ java_version }}+ must be installed
 * `JAVA_HOME` must be defined
 
-## Install Elastic stack
+### Install Elastic stack
 
 * Download [Elasticsearch](https://www.elastic.co/downloads/elasticsearch)
 * Download [Kibana](https://www.elastic.co/downloads/kibana)
 * Start Elasticsearch server
 * Start Kibana server
-* Check that Kibana is running by opening <https://localhost:5601>
+* Check that Kibana is running by opening <http://localhost:5601>
 
-## Start FSCrawler
+### Start FSCrawler
 
 * Download FSCrawler. See {ref}`installation`.
 * Open a terminal and navigate to the `fscrawler` folder.
@@ -64,6 +192,9 @@ cd C:\Users\myuser\.fscrawler\resumes
     url: "c:\\path\\to\\resumes"
   ```
 
+  If your Elasticsearch cluster requires an API key (recommended), add it under `elasticsearch` as well.
+  See {ref}`elasticsearch-settings`.
+
 * Start again FSCrawler:
 
 ```sh
@@ -91,8 +222,8 @@ FSCrawler should index all the documents inside your directory.
 ## Create Index pattern
 
 * Open [Kibana](http://localhost:5601)
-* Create a [Data View](http://localhost:5601/app/management/kibana/dataViews) named `resumes` 
-for the `resumes` index. Don't forget to remove the star `*` that is automatically added by default
+* Create a [Data View](http://localhost:5601/app/management/kibana/dataViews) named `resumes`
+for the `resumes` alias (documents are stored in `resumes_docs` by default). Don't forget to remove the star `*` that is automatically added by default
 by Kibana.
 
 ![](images/kibana-step1.jpg)
@@ -116,8 +247,8 @@ by Kibana.
  version of Kibana.
 ```
 
-* Open [Kibana](https://localhost:5601)
-* Go to the [Discover](https://localhost:5601/app/discover#/) page
+* Open [Kibana](http://localhost:5601)
+* Go to the [Discover](http://localhost:5601/app/discover#/) page
 * Depending on the date you selected in the [Create Index pattern](#create-index-pattern) step, you should see something similar to the
   following image. If you don't see it, you probably have to adjust the time picker to make sure you are looking
   at the right period of time.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the user tutorial so the recommended path is Elastic `start-local` (Elasticsearch + Kibana) plus FSCrawler via Docker, placed at the top of the page. The previous manual download/install flow is kept as an alternative section.

## Changes

- Add a Docker + `start-local` quick start (prereqs, `curl | sh`, API key from `.env`)
- Document FSCrawler Docker `--setup`, volume mounts, `host.docker.internal`, and `FSCRAWLER_ELASTICSEARCH_*` env vars
- Call out `http://` (not `https://`) and leaving `elasticsearch.index` unset for the `resumes` alias
- Reframe the existing Java/ZIP steps under “Alternative: manual installation”
- Align Kibana links to `http://localhost:5601` and clarify the data view targets the `resumes` alias

## Test plan

- [ ] Review rendered tutorial structure (Docker path first, manual second, shared Kibana steps)
- [ ] Optionally smoke-test: `start-local` → Docker FSCrawler `resumes` job → Kibana Discover

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ab23844-4ca3-4d05-8d78-4f0a9437f970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ab23844-4ca3-4d05-8d78-4f0a9437f970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

