### PR TITLE
feat(kibana): add infrastructure for default dashboard provisioning (#2477)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,10 +7,13 @@ on:
   pull_request:
 
 env:
-  ELASTIC_SERVERLESS_APIKEY: ${{ secrets.ELASTIC_SERVERLESS_APIKEY }}
-  ELASTIC_SERVERLESS_URL: ${{ secrets.ELASTIC_SERVERLESS_URL }}
+  # Credentials stay in secrets; public endpoint URLs live in repository variables.
   ELASTIC_CLOUD_APIKEY: ${{ secrets.ELASTIC_CLOUD_APIKEY }}
-  ELASTIC_CLOUD_URL: ${{ secrets.ELASTIC_CLOUD_URL }}
+  ELASTIC_CLOUD_URL: ${{ vars.ELASTIC_CLOUD_URL }}
+  ELASTIC_CLOUD_KIBANA_URL: ${{ vars.ELASTIC_CLOUD_KIBANA_URL }}
+  ELASTIC_SERVERLESS_APIKEY: ${{ secrets.ELASTIC_SERVERLESS_APIKEY }}
+  ELASTIC_SERVERLESS_URL: ${{ vars.ELASTIC_SERVERLESS_URL }}
+  ELASTIC_SERVERLESS_KIBANA_URL: ${{ vars.ELASTIC_SERVERLESS_KIBANA_URL }}
 
 jobs:
   # Detect non-documentation changes to skip expensive integration tests on docs-only PRs
@@ -119,7 +122,7 @@ jobs:
       - name: Run the integration tests
         run: mvn --batch-mode verify -Ddocker.skip -Dossindex.skip -DskipUnitTests -Pes-8x -Dtests.leaveTemporary=false
 
-  # We run integration tests with Elastic Cloud Elasticsearch service (if secrets are set)
+  # We run integration tests with Elastic Cloud Elasticsearch service (if secrets/vars are set)
   it-cloud:
     runs-on: ubuntu-latest
     if: needs.changes.outputs.code == 'true'
@@ -129,36 +132,30 @@ jobs:
       - get-pr-number
     steps:
       - uses: actions/checkout@v7
-        if: ${{ env.ELASTIC_CLOUD_APIKEY && env.ELASTIC_CLOUD_URL }}
+        if: ${{ env.ELASTIC_CLOUD_APIKEY && env.ELASTIC_CLOUD_URL && env.ELASTIC_CLOUD_KIBANA_URL }}
       - name: Fetch base branch for Spotless ratchet
-        if: ${{ env.ELASTIC_CLOUD_APIKEY && env.ELASTIC_CLOUD_URL }}
+        if: ${{ env.ELASTIC_CLOUD_APIKEY && env.ELASTIC_CLOUD_URL && env.ELASTIC_CLOUD_KIBANA_URL }}
         run: git fetch origin main --depth=1
       - name: Warm up Elastic Cloud cluster
-        if: ${{ env.ELASTIC_CLOUD_APIKEY && env.ELASTIC_CLOUD_URL }}
+        if: ${{ env.ELASTIC_CLOUD_APIKEY && env.ELASTIC_CLOUD_URL && env.ELASTIC_CLOUD_KIBANA_URL }}
         env:
-          TESTS_CLUSTER_URL: ${{ secrets.ELASTIC_CLOUD_URL }}
+          TESTS_CLUSTER_URL: ${{ vars.ELASTIC_CLOUD_URL }}
           TESTS_CLUSTER_APIKEY: ${{ secrets.ELASTIC_CLOUD_APIKEY }}
         run: bash .github/scripts/warm-up-elasticsearch.sh
       - name: Set up JDK 21
         uses: actions/setup-java@v5
-        if: ${{ env.ELASTIC_CLOUD_APIKEY && env.ELASTIC_CLOUD_URL }}
+        if: ${{ env.ELASTIC_CLOUD_APIKEY && env.ELASTIC_CLOUD_URL && env.ELASTIC_CLOUD_KIBANA_URL }}
         with:
           java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
-      - name: Cache Docker images
-        uses: AndreKurait/docker-cache@0.7.0
-        if: ${{ env.ELASTIC_CLOUD_APIKEY && env.ELASTIC_CLOUD_URL }}
-        with:
-          key: fscrawler-docker-cache-${{ runner.os }}-${{ hashFiles('pom.xml') }}
-        continue-on-error: true
       - name: Run the integration tests
-        if: ${{ env.ELASTIC_CLOUD_APIKEY && env.ELASTIC_CLOUD_URL }}
+        if: ${{ env.ELASTIC_CLOUD_APIKEY && env.ELASTIC_CLOUD_URL && env.ELASTIC_CLOUD_KIBANA_URL }}
         run: |
           echo "Running integration tests with Elastic Cloud Elasticsearch service with prefix ${{ needs.get-pr-number.outputs.pr_number }}"
-          mvn --batch-mode verify -Ddocker.skip -Dossindex.skip -DskipUnitTests -Dtests.leaveTemporary=false -Dtests.timeoutSuite=1200 -Dtests.timeout=900 -Dtests.cluster.apiKey=${{ secrets.ELASTIC_CLOUD_APIKEY }} -Dtests.cluster.url=${{ secrets.ELASTIC_CLOUD_URL }} -Dtests.index.prefix=${{ needs.get-pr-number.outputs.pr_number }}
+          mvn --batch-mode verify -Ddocker.skip -Dossindex.skip -DskipUnitTests -Dtests.leaveTemporary=false -Dtests.timeoutSuite=1200 -Dtests.timeout=900 -Dtests.cluster.apiKey=${{ secrets.ELASTIC_CLOUD_APIKEY }} -Dtests.cluster.url=${{ vars.ELASTIC_CLOUD_URL }} -Dtests.kibana.url=${{ vars.ELASTIC_CLOUD_KIBANA_URL }} -Dtests.index.prefix=${{ needs.get-pr-number.outputs.pr_number }}
 
-  # We run integration tests with Elastic Cloud Serverless (if secrets are set)
+  # We run integration tests with Elastic Cloud Serverless (if secrets/vars are set)
   it-serverless:
     runs-on: ubuntu-latest
     if: needs.changes.outputs.code == 'true'
@@ -168,34 +165,28 @@ jobs:
       - get-pr-number
     steps:
       - uses: actions/checkout@v7
-        if: ${{ env.ELASTIC_SERVERLESS_APIKEY && env.ELASTIC_SERVERLESS_URL }}
+        if: ${{ env.ELASTIC_SERVERLESS_APIKEY && env.ELASTIC_SERVERLESS_URL && env.ELASTIC_SERVERLESS_KIBANA_URL }}
       - name: Fetch base branch for Spotless ratchet
-        if: ${{ env.ELASTIC_SERVERLESS_APIKEY && env.ELASTIC_SERVERLESS_URL }}
+        if: ${{ env.ELASTIC_SERVERLESS_APIKEY && env.ELASTIC_SERVERLESS_URL && env.ELASTIC_SERVERLESS_KIBANA_URL }}
         run: git fetch origin main --depth=1
       - name: Warm up Elastic Cloud Serverless cluster
-        if: ${{ env.ELASTIC_SERVERLESS_APIKEY && env.ELASTIC_SERVERLESS_URL }}
+        if: ${{ env.ELASTIC_SERVERLESS_APIKEY && env.ELASTIC_SERVERLESS_URL && env.ELASTIC_SERVERLESS_KIBANA_URL }}
         env:
-          TESTS_CLUSTER_URL: ${{ secrets.ELASTIC_SERVERLESS_URL }}
+          TESTS_CLUSTER_URL: ${{ vars.ELASTIC_SERVERLESS_URL }}
           TESTS_CLUSTER_APIKEY: ${{ secrets.ELASTIC_SERVERLESS_APIKEY }}
         run: bash .github/scripts/warm-up-elasticsearch.sh
       - name: Set up JDK 21
         uses: actions/setup-java@v5
-        if: ${{ env.ELASTIC_SERVERLESS_APIKEY && env.ELASTIC_SERVERLESS_URL }}
+        if: ${{ env.ELASTIC_SERVERLESS_APIKEY && env.ELASTIC_SERVERLESS_URL && env.ELASTIC_SERVERLESS_KIBANA_URL }}
         with:
           java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
-      - name: Cache Docker images
-        uses: AndreKurait/docker-cache@0.7.0
-        if: ${{ env.ELASTIC_SERVERLESS_APIKEY && env.ELASTIC_SERVERLESS_URL }}
-        with:
-          key: fscrawler-docker-cache-${{ runner.os }}-${{ hashFiles('pom.xml') }}
-        continue-on-error: true
       - name: Run the integration tests
-        if: ${{ env.ELASTIC_SERVERLESS_APIKEY && env.ELASTIC_SERVERLESS_URL }}
+        if: ${{ env.ELASTIC_SERVERLESS_APIKEY && env.ELASTIC_SERVERLESS_URL && env.ELASTIC_SERVERLESS_KIBANA_URL }}
         run: |
           echo "Running integration tests with Elastic Cloud Elasticsearch Serverless service with prefix ${{ needs.get-pr-number.outputs.pr_number }}"
-          mvn --batch-mode verify -Ddocker.skip -Dossindex.skip -DskipUnitTests -Dtests.leaveTemporary=false -Dtests.timeoutSuite=1200 -Dtests.timeout=900 -Dtests.cluster.apiKey=${{ secrets.ELASTIC_SERVERLESS_APIKEY }} -Dtests.cluster.url=${{ secrets.ELASTIC_SERVERLESS_URL }} -Dtests.index.prefix=${{ needs.get-pr-number.outputs.pr_number }}
+          mvn --batch-mode verify -Ddocker.skip -Dossindex.skip -DskipUnitTests -Dtests.leaveTemporary=false -Dtests.timeoutSuite=1200 -Dtests.timeout=900 -Dtests.cluster.apiKey=${{ secrets.ELASTIC_SERVERLESS_APIKEY }} -Dtests.cluster.url=${{ vars.ELASTIC_SERVERLESS_URL }} -Dtests.kibana.url=${{ vars.ELASTIC_SERVERLESS_KIBANA_URL }} -Dtests.index.prefix=${{ needs.get-pr-number.outputs.pr_number }}
 
   # We run integration tests from a Windows machine to Elastic Cloud
   it-windows:
@@ -216,18 +207,18 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: Warm up Elastic Cloud cluster
-        if: ${{ env.ELASTIC_CLOUD_APIKEY && env.ELASTIC_CLOUD_URL }}
+        if: ${{ env.ELASTIC_CLOUD_APIKEY && env.ELASTIC_CLOUD_URL && env.ELASTIC_CLOUD_KIBANA_URL }}
         shell: bash
         env:
-          TESTS_CLUSTER_URL: ${{ secrets.ELASTIC_CLOUD_URL }}
+          TESTS_CLUSTER_URL: ${{ vars.ELASTIC_CLOUD_URL }}
           TESTS_CLUSTER_APIKEY: ${{ secrets.ELASTIC_CLOUD_APIKEY }}
         run: bash .github/scripts/warm-up-elasticsearch.sh
       - name: Run the integration tests
-        if: ${{ env.ELASTIC_CLOUD_APIKEY && env.ELASTIC_CLOUD_URL }}
+        if: ${{ env.ELASTIC_CLOUD_APIKEY && env.ELASTIC_CLOUD_URL && env.ELASTIC_CLOUD_KIBANA_URL }}
         shell: bash
         run: |
           echo "Running integration tests from Windows with Elastic Cloud Elasticsearch service with prefix win_${{ needs.get-pr-number.outputs.pr_number }}"
-          mvn --batch-mode verify -Ddocker.skip -Dossindex.skip -DskipUnitTests -Dtests.leaveTemporary=false -Dtests.timeoutSuite=1200 -Dtests.timeout=900 -Dtests.cluster.apiKey=${{ secrets.ELASTIC_CLOUD_APIKEY }} -Dtests.cluster.url=${{ secrets.ELASTIC_CLOUD_URL }} -Dtests.index.prefix=win_${{ needs.get-pr-number.outputs.pr_number }}
+          mvn --batch-mode verify -Ddocker.skip -Dossindex.skip -DskipUnitTests -Dtests.leaveTemporary=false -Dtests.timeoutSuite=1200 -Dtests.timeout=900 -Dtests.cluster.apiKey=${{ secrets.ELASTIC_CLOUD_APIKEY }} -Dtests.cluster.url=${{ vars.ELASTIC_CLOUD_URL }} -Dtests.kibana.url=${{ vars.ELASTIC_CLOUD_KIBANA_URL }} -Dtests.index.prefix=win_${{ needs.get-pr-number.outputs.pr_number }}
 
   # We run this job in parallel after the build
   build-docker:

--- a/contrib/docker-compose-example-elasticsearch/.env
+++ b/contrib/docker-compose-example-elasticsearch/.env
@@ -18,6 +18,10 @@ ES_LOCAL_PORT=9200
 ES_LOCAL_DISK_SPACE_REQUIRED=1gb
 ES_LOCAL_JAVA_OPTS="-XX:UseSVE=0 -Xms128m -Xmx2g"
 
+# Kibana
+KIBANA_LOCAL_CONTAINER_NAME=kibana-fscrawler
+KIBANA_LOCAL_PORT=5601
+
 # Increase or decrease based on the available host memory (in bytes)
 # When using basic, that should be enough as we don't run ML jobs
 # MEM_LIMIT=1073741824

--- a/contrib/docker-compose-example-elasticsearch/docker-compose.yml
+++ b/contrib/docker-compose-example-elasticsearch/docker-compose.yml
@@ -32,6 +32,30 @@ services:
       timeout: 10s
       retries: 30
 
+  kibana:
+    image: docker.elastic.co/kibana/kibana:${ES_LOCAL_VERSION}
+    container_name: ${KIBANA_LOCAL_CONTAINER_NAME}
+    volumes:
+      - dev-kibana:/usr/share/kibana/data
+    ports:
+      - 127.0.0.1:${KIBANA_LOCAL_PORT}:5601
+    environment:
+      - ELASTICSEARCH_HOSTS=http://${ES_LOCAL_CONTAINER_NAME}:9200
+      - ELASTICSEARCH_USERNAME=elastic
+      - ELASTICSEARCH_PASSWORD=${ES_LOCAL_PASSWORD}
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -s -I http://localhost:5601 | grep -q 'HTTP/1.1 302 Found'",
+        ]
+      interval: 10s
+      timeout: 10s
+      retries: 30
+
   # FSCrawler
   fscrawler:
     image: dadoonet/fscrawler:${FSCRAWLER_VERSION}
@@ -42,6 +66,7 @@ services:
       - FSCRAWLER_ELASTICSEARCH_URLS=http://${ES_LOCAL_CONTAINER_NAME}:9200
       - FSCRAWLER_ELASTICSEARCH_USERNAME=elastic
       - FSCRAWLER_ELASTICSEARCH_PASSWORD=${ES_LOCAL_PASSWORD}
+      - FSCRAWLER_KIBANA_URL=http://${KIBANA_LOCAL_CONTAINER_NAME}:5601
       - FSCRAWLER_REST_URL=http://fscrawler:${FSCRAWLER_PORT}
     volumes:
       # Mount your documents here into docs folder
@@ -53,9 +78,12 @@ services:
     depends_on:
       elasticsearch:
         condition: service_healthy
+      kibana:
+        condition: service_healthy
     ports:
       - ${FSCRAWLER_PORT}:8080
     command: --rest
 
 volumes:
   dev-elasticsearch:
+  dev-kibana:

--- a/contrib/src/main/resources/docker-compose-example-elasticsearch/.env
+++ b/contrib/src/main/resources/docker-compose-example-elasticsearch/.env
@@ -18,6 +18,10 @@ ES_LOCAL_PORT=9200
 ES_LOCAL_DISK_SPACE_REQUIRED=1gb
 ES_LOCAL_JAVA_OPTS="-XX:UseSVE=0 -Xms128m -Xmx2g"
 
+# Kibana
+KIBANA_LOCAL_CONTAINER_NAME=kibana-fscrawler
+KIBANA_LOCAL_PORT=5601
+
 # Increase or decrease based on the available host memory (in bytes)
 # When using basic, that should be enough as we don't run ML jobs
 # MEM_LIMIT=1073741824

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -41,6 +41,12 @@
             <artifactId>fscrawler-elasticsearch-client</artifactId>
         </dependency>
 
+        <!-- Kibana dashboard provisioning -->
+        <dependency>
+            <groupId>fr.pilato.elasticsearch.crawler</groupId>
+            <artifactId>fscrawler-kibana-client</artifactId>
+        </dependency>
+
         <!-- OpenTelemetry API — noop at runtime unless elastic-otel-javaagent is attached -->
         <dependency>
             <groupId>io.opentelemetry</groupId>
@@ -70,6 +76,11 @@
         <dependency>
             <groupId>fr.pilato.elasticsearch.crawler</groupId>
             <artifactId>fscrawler-test-documents</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsCrawlerImpl.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsCrawlerImpl.java
@@ -23,8 +23,12 @@ package fr.pilato.elasticsearch.crawler.fs;
 import fr.pilato.elasticsearch.crawler.fs.beans.FsCrawlerCheckpointFileHandler;
 import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerIllegalConfigurationException;
 import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil;
+import fr.pilato.elasticsearch.crawler.fs.kibana.IKibanaClient;
+import fr.pilato.elasticsearch.crawler.fs.kibana.KibanaClientException;
 import fr.pilato.elasticsearch.crawler.fs.service.FsCrawlerDocumentService;
 import fr.pilato.elasticsearch.crawler.fs.service.FsCrawlerDocumentServiceElasticsearchImpl;
+import fr.pilato.elasticsearch.crawler.fs.service.FsCrawlerKibanaService;
+import fr.pilato.elasticsearch.crawler.fs.service.FsCrawlerKibanaServiceImpl;
 import fr.pilato.elasticsearch.crawler.fs.service.FsCrawlerManagementService;
 import fr.pilato.elasticsearch.crawler.fs.service.FsCrawlerManagementServiceElasticsearchImpl;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsCrawlerValidator;
@@ -54,6 +58,7 @@ public class FsCrawlerImpl implements AutoCloseable {
 
     private final FsCrawlerDocumentService documentService;
     private final FsCrawlerManagementService managementService;
+    private final FsCrawlerKibanaService kibanaService;
     private final FsCrawlerPluginsManager pluginsManager;
     private final FsParser fsParser;
     private final Thread fsCrawlerThread;
@@ -67,6 +72,7 @@ public class FsCrawlerImpl implements AutoCloseable {
 
         this.managementService = new FsCrawlerManagementServiceElasticsearchImpl(settings);
         this.documentService = new FsCrawlerDocumentServiceElasticsearchImpl(settings);
+        this.kibanaService = IKibanaClient.isEnabled(settings) ? new FsCrawlerKibanaServiceImpl(settings) : null;
 
         // Initialize and start the plugin manager
         this.pluginsManager = new FsCrawlerPluginsManager();
@@ -199,6 +205,7 @@ public class FsCrawlerImpl implements AutoCloseable {
         managementService.start();
         documentService.start();
         documentService.createSchema();
+        setupKibanaDashboardIfNeeded();
 
         if (loop == 0 && !rest) {
             logger.warn("Number of runs is set to 0 and rest layer has not been started. Exiting");
@@ -261,6 +268,9 @@ public class FsCrawlerImpl implements AutoCloseable {
 
         managementService.close();
         documentService.close();
+        if (kibanaService != null) {
+            kibanaService.close();
+        }
         logger.debug("ES Client Manager stopped");
 
         pluginsManager.close();
@@ -271,5 +281,25 @@ public class FsCrawlerImpl implements AutoCloseable {
 
     public FsParser getFsParser() {
         return fsParser;
+    }
+
+    private void setupKibanaDashboardIfNeeded() {
+        if (kibanaService == null) {
+            return;
+        }
+        try {
+            kibanaService.start();
+            kibanaService.setupDashboard();
+        } catch (KibanaClientException e) {
+            logger.warn(
+                    "Failed to create the default Kibana dashboard for job [{}]. Crawler will continue without it.",
+                    settings.getName(),
+                    e);
+        } catch (IOException e) {
+            logger.warn(
+                    "Failed to connect to Kibana for job [{}]. Crawler will continue without dashboard provisioning.",
+                    settings.getName(),
+                    e);
+        }
     }
 }

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerKibanaService.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerKibanaService.java
@@ -18,19 +18,16 @@
  *
  * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
  */
-package fr.pilato.elasticsearch.crawler.fs.settings;
+package fr.pilato.elasticsearch.crawler.fs.service;
 
-import java.util.List;
+import fr.pilato.elasticsearch.crawler.fs.kibana.KibanaClientException;
+import java.io.Closeable;
+import java.io.IOException;
 
-public class Defaults {
-    public static final String DEFAULT_DIR = "/tmp/es";
-    public static final List<String> DEFAULT_EXCLUDED = List.of("*/~*", "*/.ds_store");
-    public static final String ELASTICSEARCH_URL_DEFAULT = "https://127.0.0.1:9200";
-    public static final String DEFAULT_META_FILENAME = ".meta.yml";
-    public static final String REST_URL_DEFAULT = "http://127.0.0.1:8080/fscrawler";
-    public static final String KIBANA_URL_DEFAULT = "http://127.0.0.1:5601";
-    public static final String JOB_NAME_DEFAULT = "fscrawler";
+public interface FsCrawlerKibanaService extends Closeable {
 
-    // To make sur we don't create an instance of this class
-    private Defaults() {}
+    void start() throws IOException, KibanaClientException;
+
+    /** Creates the default FSCrawler data view and dashboard when they do not exist yet. */
+    void setupDashboard() throws KibanaClientException;
 }

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerKibanaServiceImpl.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerKibanaServiceImpl.java
@@ -54,6 +54,11 @@ public class FsCrawlerKibanaServiceImpl implements FsCrawlerKibanaService {
 
     @Override
     public void setupDashboard() throws KibanaClientException {
+        if (!client.isDashboardProvisioningEnabled()) {
+            logger.debug("Kibana dashboard provisioning is disabled, skipping");
+            return;
+        }
+
         String jobName = settings.getName();
         String indexPattern = settings.getElasticsearch().getIndex();
         String dataViewId = KibanaDashboardBuilder.dataViewIdForJob(jobName);
@@ -61,12 +66,25 @@ public class FsCrawlerKibanaServiceImpl implements FsCrawlerKibanaService {
 
         client.createDataViewIfMissing(dataViewId, indexPattern, KibanaDashboardBuilder.DEFAULT_TIME_FIELD);
 
+        String payload = KibanaDashboardBuilder.buildDefaultDashboardPayload(settings);
+        boolean forcePush = settings.getKibana().isForcePushDashboard();
+
         if (client.dashboardExists(dashboardId)) {
-            logger.info("Kibana dashboard [{}] already exists, skipping creation", dashboardId);
+            if (!forcePush) {
+                logger.info(
+                        "Kibana dashboard [{}] already exists. Skipping. "
+                                + "Use kibana.force_push_dashboard: true to override.",
+                        dashboardId);
+                return;
+            }
+            String updatedId = client.updateDashboard(dashboardId, payload);
+            logger.info(
+                    "Updated Kibana dashboard [{}] at {}",
+                    updatedId,
+                    settings.getKibana().getUrl());
             return;
         }
 
-        String payload = KibanaDashboardBuilder.buildDefaultDashboardPayload(settings);
         String createdId = client.createDashboard(payload);
         logger.info(
                 "Created Kibana dashboard [{}] at {}",

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerKibanaServiceImpl.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerKibanaServiceImpl.java
@@ -85,7 +85,7 @@ public class FsCrawlerKibanaServiceImpl implements FsCrawlerKibanaService {
             return;
         }
 
-        String createdId = client.createDashboard(payload);
+        String createdId = client.createDashboard(dashboardId, payload);
         logger.info(
                 "Created Kibana dashboard [{}] at {}",
                 createdId,

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerKibanaServiceImpl.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerKibanaServiceImpl.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
+ */
+package fr.pilato.elasticsearch.crawler.fs.service;
+
+import fr.pilato.elasticsearch.crawler.fs.kibana.IKibanaClient;
+import fr.pilato.elasticsearch.crawler.fs.kibana.KibanaClient;
+import fr.pilato.elasticsearch.crawler.fs.kibana.KibanaClientException;
+import fr.pilato.elasticsearch.crawler.fs.kibana.KibanaDashboardBuilder;
+import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
+import java.io.IOException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class FsCrawlerKibanaServiceImpl implements FsCrawlerKibanaService {
+
+    private static final Logger logger = LogManager.getLogger();
+
+    private final FsSettings settings;
+    private final IKibanaClient client;
+
+    public FsCrawlerKibanaServiceImpl(FsSettings settings) {
+        this.settings = settings;
+        this.client = new KibanaClient(settings);
+    }
+
+    FsCrawlerKibanaServiceImpl(FsSettings settings, IKibanaClient client) {
+        this.settings = settings;
+        this.client = client;
+    }
+
+    @Override
+    public void start() throws IOException, KibanaClientException {
+        client.start();
+        logger.debug("Kibana service started");
+    }
+
+    @Override
+    public void setupDashboard() throws KibanaClientException {
+        String jobName = settings.getName();
+        String indexPattern = settings.getElasticsearch().getIndex();
+        String dataViewId = KibanaDashboardBuilder.dataViewIdForJob(jobName);
+        String dashboardId = KibanaDashboardBuilder.dashboardIdForJob(jobName);
+
+        client.createDataViewIfMissing(dataViewId, indexPattern, KibanaDashboardBuilder.DEFAULT_TIME_FIELD);
+
+        if (client.dashboardExists(dashboardId)) {
+            logger.info("Kibana dashboard [{}] already exists, skipping creation", dashboardId);
+            return;
+        }
+
+        String payload = KibanaDashboardBuilder.buildDefaultDashboardPayload(settings);
+        String createdId = client.createDashboard(payload);
+        logger.info(
+                "Created Kibana dashboard [{}] at {}",
+                createdId,
+                settings.getKibana().getUrl());
+    }
+
+    @Override
+    public void close() throws IOException {
+        client.close();
+        logger.debug("Kibana service stopped");
+    }
+}

--- a/core/src/test/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerKibanaServiceImplTest.java
+++ b/core/src/test/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerKibanaServiceImplTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
+ */
+package fr.pilato.elasticsearch.crawler.fs.service;
+
+import fr.pilato.elasticsearch.crawler.fs.kibana.IKibanaClient;
+import fr.pilato.elasticsearch.crawler.fs.kibana.KibanaDashboardBuilder;
+import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
+import fr.pilato.elasticsearch.crawler.fs.settings.FsSettingsLoader;
+import fr.pilato.elasticsearch.crawler.fs.settings.Kibana;
+import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class FsCrawlerKibanaServiceImplTest extends AbstractFSCrawlerTestCase {
+
+    @Test
+    void setupDashboard_createsDataViewAndDashboardWhenMissing() throws Exception {
+        FsSettings settings = settingsWithKibana("demo");
+        IKibanaClient client = Mockito.mock(IKibanaClient.class);
+        Mockito.when(client.createDataViewIfMissing(
+                        KibanaDashboardBuilder.dataViewIdForJob("demo"),
+                        "demo_docs",
+                        KibanaDashboardBuilder.DEFAULT_TIME_FIELD))
+                .thenReturn(true);
+        Mockito.when(client.dashboardExists(KibanaDashboardBuilder.dashboardIdForJob("demo")))
+                .thenReturn(false);
+        Mockito.when(client.createDashboard(Mockito.anyString())).thenReturn("fscrawler-demo");
+
+        FsCrawlerKibanaServiceImpl service = new FsCrawlerKibanaServiceImpl(settings, client);
+        service.setupDashboard();
+
+        Mockito.verify(client)
+                .createDataViewIfMissing(
+                        KibanaDashboardBuilder.dataViewIdForJob("demo"),
+                        "demo_docs",
+                        KibanaDashboardBuilder.DEFAULT_TIME_FIELD);
+        Mockito.verify(client).createDashboard(Mockito.anyString());
+    }
+
+    @Test
+    void setupDashboard_skipsDashboardCreationWhenAlreadyPresent() throws Exception {
+        FsSettings settings = settingsWithKibana("demo");
+        IKibanaClient client = Mockito.mock(IKibanaClient.class);
+        Mockito.when(client.createDataViewIfMissing(
+                        KibanaDashboardBuilder.dataViewIdForJob("demo"),
+                        "demo_docs",
+                        KibanaDashboardBuilder.DEFAULT_TIME_FIELD))
+                .thenReturn(false);
+        Mockito.when(client.dashboardExists(KibanaDashboardBuilder.dashboardIdForJob("demo")))
+                .thenReturn(true);
+
+        new FsCrawlerKibanaServiceImpl(settings, client).setupDashboard();
+
+        Mockito.verify(client, Mockito.never()).createDashboard(Mockito.anyString());
+    }
+
+    private FsSettings settingsWithKibana(String jobName) {
+        FsSettings settings = FsSettingsLoader.load();
+        settings.setName(jobName);
+        settings.getElasticsearch().setIndex(jobName + "_docs");
+        Kibana kibana = new Kibana();
+        kibana.setUrl("http://127.0.0.1:5601");
+        kibana.setPushDashboard(true);
+        settings.setKibana(kibana);
+        return settings;
+    }
+}

--- a/core/src/test/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerKibanaServiceImplTest.java
+++ b/core/src/test/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerKibanaServiceImplTest.java
@@ -32,9 +32,23 @@ import org.mockito.Mockito;
 class FsCrawlerKibanaServiceImplTest extends AbstractFSCrawlerTestCase {
 
     @Test
+    void setupDashboard_skipsWhenProvisioningDisabled() throws Exception {
+        FsSettings settings = settingsWithKibana("demo");
+        IKibanaClient client = Mockito.mock(IKibanaClient.class);
+        Mockito.when(client.isDashboardProvisioningEnabled()).thenReturn(false);
+
+        new FsCrawlerKibanaServiceImpl(settings, client).setupDashboard();
+
+        Mockito.verify(client, Mockito.never())
+                .createDataViewIfMissing(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+        Mockito.verify(client, Mockito.never()).createDashboard(Mockito.anyString());
+    }
+
+    @Test
     void setupDashboard_createsDataViewAndDashboardWhenMissing() throws Exception {
         FsSettings settings = settingsWithKibana("demo");
         IKibanaClient client = Mockito.mock(IKibanaClient.class);
+        Mockito.when(client.isDashboardProvisioningEnabled()).thenReturn(true);
         Mockito.when(client.createDataViewIfMissing(
                         KibanaDashboardBuilder.dataViewIdForJob("demo"),
                         "demo_docs",
@@ -59,6 +73,7 @@ class FsCrawlerKibanaServiceImplTest extends AbstractFSCrawlerTestCase {
     void setupDashboard_skipsDashboardCreationWhenAlreadyPresent() throws Exception {
         FsSettings settings = settingsWithKibana("demo");
         IKibanaClient client = Mockito.mock(IKibanaClient.class);
+        Mockito.when(client.isDashboardProvisioningEnabled()).thenReturn(true);
         Mockito.when(client.createDataViewIfMissing(
                         KibanaDashboardBuilder.dataViewIdForJob("demo"),
                         "demo_docs",
@@ -69,6 +84,29 @@ class FsCrawlerKibanaServiceImplTest extends AbstractFSCrawlerTestCase {
 
         new FsCrawlerKibanaServiceImpl(settings, client).setupDashboard();
 
+        Mockito.verify(client, Mockito.never()).createDashboard(Mockito.anyString());
+        Mockito.verify(client, Mockito.never()).updateDashboard(Mockito.anyString(), Mockito.anyString());
+    }
+
+    @Test
+    void setupDashboard_updatesDashboardWhenForcePushEnabled() throws Exception {
+        FsSettings settings = settingsWithKibana("demo");
+        settings.getKibana().setForcePushDashboard(true);
+        IKibanaClient client = Mockito.mock(IKibanaClient.class);
+        Mockito.when(client.isDashboardProvisioningEnabled()).thenReturn(true);
+        Mockito.when(client.createDataViewIfMissing(
+                        KibanaDashboardBuilder.dataViewIdForJob("demo"),
+                        "demo_docs",
+                        KibanaDashboardBuilder.DEFAULT_TIME_FIELD))
+                .thenReturn(false);
+        Mockito.when(client.dashboardExists(KibanaDashboardBuilder.dashboardIdForJob("demo")))
+                .thenReturn(true);
+        Mockito.when(client.updateDashboard(Mockito.eq("fscrawler-demo"), Mockito.anyString()))
+                .thenReturn("fscrawler-demo");
+
+        new FsCrawlerKibanaServiceImpl(settings, client).setupDashboard();
+
+        Mockito.verify(client).updateDashboard(Mockito.eq("fscrawler-demo"), Mockito.anyString());
         Mockito.verify(client, Mockito.never()).createDashboard(Mockito.anyString());
     }
 

--- a/core/src/test/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerKibanaServiceImplTest.java
+++ b/core/src/test/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerKibanaServiceImplTest.java
@@ -41,7 +41,7 @@ class FsCrawlerKibanaServiceImplTest extends AbstractFSCrawlerTestCase {
 
         Mockito.verify(client, Mockito.never())
                 .createDataViewIfMissing(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
-        Mockito.verify(client, Mockito.never()).createDashboard(Mockito.anyString());
+        Mockito.verify(client, Mockito.never()).createDashboard(Mockito.anyString(), Mockito.anyString());
     }
 
     @Test
@@ -56,7 +56,8 @@ class FsCrawlerKibanaServiceImplTest extends AbstractFSCrawlerTestCase {
                 .thenReturn(true);
         Mockito.when(client.dashboardExists(KibanaDashboardBuilder.dashboardIdForJob("demo")))
                 .thenReturn(false);
-        Mockito.when(client.createDashboard(Mockito.anyString())).thenReturn("fscrawler-demo");
+        Mockito.when(client.createDashboard(Mockito.eq("fscrawler-demo"), Mockito.anyString()))
+                .thenReturn("fscrawler-demo");
 
         FsCrawlerKibanaServiceImpl service = new FsCrawlerKibanaServiceImpl(settings, client);
         service.setupDashboard();
@@ -66,7 +67,7 @@ class FsCrawlerKibanaServiceImplTest extends AbstractFSCrawlerTestCase {
                         KibanaDashboardBuilder.dataViewIdForJob("demo"),
                         "demo_docs",
                         KibanaDashboardBuilder.DEFAULT_TIME_FIELD);
-        Mockito.verify(client).createDashboard(Mockito.anyString());
+        Mockito.verify(client).createDashboard(Mockito.eq("fscrawler-demo"), Mockito.anyString());
     }
 
     @Test
@@ -84,7 +85,7 @@ class FsCrawlerKibanaServiceImplTest extends AbstractFSCrawlerTestCase {
 
         new FsCrawlerKibanaServiceImpl(settings, client).setupDashboard();
 
-        Mockito.verify(client, Mockito.never()).createDashboard(Mockito.anyString());
+        Mockito.verify(client, Mockito.never()).createDashboard(Mockito.anyString(), Mockito.anyString());
         Mockito.verify(client, Mockito.never()).updateDashboard(Mockito.anyString(), Mockito.anyString());
     }
 
@@ -107,7 +108,7 @@ class FsCrawlerKibanaServiceImplTest extends AbstractFSCrawlerTestCase {
         new FsCrawlerKibanaServiceImpl(settings, client).setupDashboard();
 
         Mockito.verify(client).updateDashboard(Mockito.eq("fscrawler-demo"), Mockito.anyString());
-        Mockito.verify(client, Mockito.never()).createDashboard(Mockito.anyString());
+        Mockito.verify(client, Mockito.never()).createDashboard(Mockito.anyString(), Mockito.anyString());
     }
 
     private FsSettings settingsWithKibana(String jobName) {

--- a/docs/source/admin/fs/index.md
+++ b/docs/source/admin/fs/index.md
@@ -210,6 +210,7 @@ Here is a list of existing top level settings:
 | `tags`                   | {ref}`tags`                   |
 | `passwords`              | {ref}`password-settings`      |
 | `elasticsearch`          | {ref}`elasticsearch-settings` |
+| `kibana`                 | {ref}`kibana-settings`        |
 | `server`                 | {ref}`ssh-settings`           |
 | `rest`                   | {ref}`rest-service`           |
 

--- a/docs/source/admin/fs/kibana.md
+++ b/docs/source/admin/fs/kibana.md
@@ -1,0 +1,113 @@
+(kibana-settings)=
+# Kibana settings
+
+```{contents}
+:backlinks: entry
+```
+
+```{versionadded} 3.0
+```
+
+FSCrawler can create a default Kibana dashboard when a job starts, using the
+[Kibana Dashboards API](https://elastic.github.io/dashboards-api-spec/dashboards)
+(generally available in Kibana 9.5+).
+
+Here is a list of Kibana settings (under `kibana.` prefix):
+
+| Name                          | Environment Variable                   | Default value             | Documentation                                      |
+|-------------------------------|----------------------------------------|---------------------------|----------------------------------------------------|
+| `kibana.url`                  | `FSCRAWLER_KIBANA_URL`                 | `http://127.0.0.1:5601`   | [Kibana URL](#kibana-url)                          |
+| `kibana.push_dashboard`       | `FSCRAWLER_KIBANA_PUSH_DASHBOARD`      | `true`                    | [Push dashboard](#push-dashboard)                  |
+| `kibana.force_push_dashboard` | `FSCRAWLER_KIBANA_FORCE_PUSH_DASHBOARD`| `false`                   | [Push dashboard](#push-dashboard)                  |
+| `kibana.space`                | `FSCRAWLER_KIBANA_SPACE`               | `null` (default space)    | [Kibana space](#kibana-space)                      |
+| `kibana.api_key`              | `FSCRAWLER_KIBANA_API_KEY`             | `null`                    | [API Key](#kibana-api-key)                         |
+
+## Kibana URL
+
+Point FSCrawler at your Kibana endpoint:
+
+```yaml
+name: "test"
+kibana:
+  url: "http://127.0.0.1:5601"
+```
+
+```{note}
+With Elastic's [start-local](https://www.elastic.co/docs/deploy-manage/deploy/self-managed/local-development-installation-quickstart)
+tooling (and similar local demos), Kibana is exposed over HTTP even when Elasticsearch may use
+HTTPS. Use `http://` in that case.
+
+In production, expose Kibana over HTTPS (TLS termination or `server.ssl.enabled`) and set
+`kibana.url` to an `https://` endpoint.
+```
+
+## Push dashboard
+
+When `kibana.push_dashboard` is `true` (the default), FSCrawler creates on startup:
+
+1. A **data view** on the job documents index (time field `file.indexing_date`)
+2. A **dashboard** named `FSCrawler - <job-name>` with a document count metric and a
+   breakdown by file extension
+
+By default, if the dashboard already exists, FSCrawler skips creation (same behaviour as
+{ref}`mappings` with `push_templates`). To overwrite an existing dashboard — for example after
+upgrading FSCrawler with new panels — set `force_push_dashboard` to `true`:
+
+```yaml
+kibana:
+  force_push_dashboard: true
+```
+
+Provisioning is **soft-disabled** (with a warning) when:
+
+* Kibana is older than **9.5** (Dashboards API not generally available)
+* `kibana.url` is missing
+* No credentials are available (`elasticsearch.api_key`, `kibana.api_key`, or
+  deprecated username/password)
+* Kibana is unreachable
+
+In those cases the crawler continues normally without a dashboard.
+
+To disable provisioning explicitly:
+
+```yaml
+kibana:
+  push_dashboard: false
+```
+
+## Kibana space
+
+Optional Kibana space id. When unset, the default space is used:
+
+```yaml
+kibana:
+  url: "http://127.0.0.1:5601"
+  space: "marketing"
+```
+
+## Kibana API Key
+
+By default FSCrawler reuses `elasticsearch.api_key` (or basic auth) for Kibana.
+Set `kibana.api_key` only when Kibana needs a different credential:
+
+```yaml
+kibana:
+  url: "http://127.0.0.1:5601"
+  api_key: "VnVhQ2ZHY0JDZGJrUW0tZTVhT3g6dWkybHAyYXhUTm1zeWFrdzl0dk5udw=="
+```
+
+## Example with start-local
+
+```yaml
+name: "resumes"
+fs:
+  url: "/tmp/es"
+elasticsearch:
+  urls:
+    - "http://localhost:9200"
+  api_key: "<ES_LOCAL_API_KEY>"
+kibana:
+  url: "http://localhost:5601"
+```
+
+After the first crawl, open Kibana → **Dashboards** → **FSCrawler - resumes**.

--- a/docs/source/admin/fs/kibana.md
+++ b/docs/source/admin/fs/kibana.md
@@ -48,11 +48,18 @@ When `kibana.push_dashboard` is `true` (the default), FSCrawler creates on start
 1. A **data view** on the job documents index (time field `file.indexing_date`)
 2. A **dashboard** named `FSCrawler - <job-name>` that includes:
 
-   * an introductory Markdown panel (with the running FSCrawler version)
+   * an introductory Markdown panel (FSCrawler version link, docs link, and the job
+     ``fs.url`` root)
+   * a runtime Markdown panel (OS, Java, heap, processors)
    * metrics for document count, total ``file.filesize``, and unique ``file.extension`` values
    * an **Overview** section (documents by extension, top content types)
+   * a **Directories** section (treemaps on ``path.virtual.tree`` by file count and by size,
+     with Discover drill-down)
    * a **Timeline** section (indexing activity over ``file.indexing_date``)
+   * a **Documents** Discover session (filename, virtual path, extension, content type,
+     filesize, indexing date, title, author)
    * collapsed **File dates** and **Document metadata** sections
+     (language and creator tool — keyword fields only for terms aggregations)
 
 By default, if the dashboard already exists, FSCrawler skips creation (same behaviour as
 {ref}`mappings` with `push_templates`). To overwrite an existing dashboard — for example after

--- a/docs/source/admin/fs/kibana.md
+++ b/docs/source/admin/fs/kibana.md
@@ -46,8 +46,13 @@ In production, expose Kibana over HTTPS (TLS termination or `server.ssl.enabled`
 When `kibana.push_dashboard` is `true` (the default), FSCrawler creates on startup:
 
 1. A **data view** on the job documents index (time field `file.indexing_date`)
-2. A **dashboard** named `FSCrawler - <job-name>` with a document count metric and a
-   breakdown by file extension
+2. A **dashboard** named `FSCrawler - <job-name>` that includes:
+
+   * an introductory Markdown panel (with the running FSCrawler version)
+   * metrics for document count, total ``file.filesize``, and unique ``file.extension`` values
+   * an **Overview** section (documents by extension, top content types)
+   * a **Timeline** section (indexing activity over ``file.indexing_date``)
+   * collapsed **File dates** and **Document metadata** sections
 
 By default, if the dashboard already exists, FSCrawler skips creation (same behaviour as
 {ref}`mappings` with `push_templates`). To overwrite an existing dashboard — for example after

--- a/docs/source/admin/fs/kibana.md
+++ b/docs/source/admin/fs/kibana.md
@@ -50,16 +50,18 @@ When `kibana.push_dashboard` is `true` (the default), FSCrawler creates on start
 
    * an introductory Markdown panel (FSCrawler version link, docs link, and the job
      ``fs.url`` root)
-   * a runtime Markdown panel (OS, Java, heap, processors)
+   * a runtime Markdown panel (OS, Java, heap max, processors)
    * metrics for document count, total ``file.filesize``, and unique ``file.extension`` values
-   * an **Overview** section (documents by extension, top content types)
+   * an **Overview** section (tag cloud of extensions, top content types)
    * a **Directories** section (treemaps on ``path.virtual.tree`` by file count and by size,
      with Discover drill-down)
    * a **Timeline** section (indexing activity over ``file.indexing_date``)
    * a **Documents** Discover session (filename, virtual path, extension, content type,
      filesize, indexing date, title, author)
-   * collapsed **File dates** and **Document metadata** sections
-     (language and creator tool — keyword fields only for terms aggregations)
+   * a collapsed **File dates** section (created / last modified / last accessed; ignores the
+     dashboard time picker so the view is global)
+   * a collapsed **Document metadata** section (language and creator tool — keyword fields only
+     for terms aggregations)
 
 By default, if the dashboard already exists, FSCrawler skips creation (same behaviour as
 {ref}`mappings` with `push_templates`). To overwrite an existing dashboard — for example after

--- a/docs/source/dev/build.md
+++ b/docs/source/dev/build.md
@@ -147,6 +147,17 @@ mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it -Dtests.cluster.url=
  ```
 
  You can use both Elasticsearch service and Serverless projects.
+
+ To also run the Kibana dashboard integration test (`FsCrawlerTestKibanaDashboardIT`), set
+ `tests.kibana.url`. This IT is skipped unless that property is set (CI enables it only on Cloud and
+ Serverless jobs to avoid starting Kibana in the default TestContainers matrix):
+
+ ```shell
+ mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it \
+     -Dtests.cluster.apiKey=APIKEYHERE \
+     -Dtests.cluster.url=https://ALIAS.es.REGION.CLOUD_PROVIDER.elastic.cloud \
+     -Dtests.kibana.url=https://ALIAS.kb.REGION.CLOUD_PROVIDER.elastic.cloud
+ ```
 ````
 
 ### Changing the REST port

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -69,6 +69,7 @@ admin/fs/tags
 admin/fs/ssh
 admin/fs/ftp
 admin/fs/elasticsearch
+admin/fs/kibana
 admin/fs/rest
 admin/status
 ```

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -125,6 +125,10 @@ ES_LOCAL_PORT=9200
 ES_LOCAL_DISK_SPACE_REQUIRED=1gb
 ES_LOCAL_JAVA_OPTS="-XX:UseSVE=0 -Xms128m -Xmx2g"
 
+# Kibana
+KIBANA_LOCAL_CONTAINER_NAME=kibana-fscrawler
+KIBANA_LOCAL_PORT=5601
+
 # Project namespace (defaults to the current folder name if not set)
 COMPOSE_PROJECT_NAME=fscrawler
 
@@ -173,6 +177,30 @@ services:
       timeout: 10s
       retries: 30
 
+  kibana:
+    image: docker.elastic.co/kibana/kibana:${ES_LOCAL_VERSION}
+    container_name: ${KIBANA_LOCAL_CONTAINER_NAME}
+    volumes:
+      - dev-kibana:/usr/share/kibana/data
+    ports:
+      - 127.0.0.1:${KIBANA_LOCAL_PORT}:5601
+    environment:
+      - ELASTICSEARCH_HOSTS=http://${ES_LOCAL_CONTAINER_NAME}:9200
+      - ELASTICSEARCH_USERNAME=elastic
+      - ELASTICSEARCH_PASSWORD=${ES_LOCAL_PASSWORD}
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -s -I http://localhost:5601 | grep -q 'HTTP/1.1 302 Found'",
+        ]
+      interval: 10s
+      timeout: 10s
+      retries: 30
+
   # FSCrawler
   fscrawler:
     image: dadoonet/fscrawler:${FSCRAWLER_VERSION}
@@ -183,11 +211,14 @@ services:
       - FSCRAWLER_ELASTICSEARCH_URLS=http://${ES_LOCAL_CONTAINER_NAME}:9200
       - FSCRAWLER_ELASTICSEARCH_USERNAME=elastic
       - FSCRAWLER_ELASTICSEARCH_PASSWORD=${ES_LOCAL_PASSWORD}
+      - FSCRAWLER_KIBANA_URL=http://${KIBANA_LOCAL_CONTAINER_NAME}:5601
       - FSCRAWLER_REST_URL=http://fscrawler:${FSCRAWLER_PORT}
     volumes:
       - ${PWD}/docs:/tmp/es:ro
     depends_on:
       elasticsearch:
+        condition: service_healthy
+      kibana:
         condition: service_healthy
     ports:
       - ${FSCRAWLER_PORT}:8080
@@ -195,6 +226,7 @@ services:
 
 volumes:
   dev-elasticsearch:
+  dev-kibana:
 ```
 
 Copy your pdf/doc files into the `docs` directory and run the full stack, including FSCrawler with:

--- a/docs/source/release/3.0.md
+++ b/docs/source/release/3.0.md
@@ -84,10 +84,17 @@ XML implementation and to betofilippi for the switch to JSON.
 - Add support for pause/resume functionality with checkpoint persistence. The crawler can now be paused and resumed
   without losing progress. It also automatically recovers from network errors with exponential backoff retry.
   See {ref}`rest-service`. Thanks to dadoonet.
+<<<<<<< HEAD
 - HTTP retry backoff is configurable via `elasticsearch.retry_max_duration`,
   `elasticsearch.retry_initial_delay` and `elasticsearch.retry_max_delay`
   (defaults `5m` / `500ms` / `30s`). The same budget applies to `5xx`, `429`, and a
   cold-start `404` on `GET /`. See {ref}`http-retry-settings`. Thanks to dadoonet.
+=======
+- Document `_id` hashing is configurable via `fs.hash_algorithm` (any Java `MessageDigest` algorithm). See
+  {ref}`document-ids`. Closes [#2425](https://github.com/dadoonet/fscrawler/issues/2425). Thanks to dadoonet.
+- FSCrawler can create a default Kibana dashboard on job startup via the Kibana Dashboards API (Kibana 9.5+).
+  See {ref}`kibana-settings`. Closes [#2477](https://github.com/dadoonet/fscrawler/issues/2477). Thanks to dadoonet.
+>>>>>>> 1f2a11fc (feat(kibana): ✨ enable default dashboards with force push and Cloud/Serverless CI)
 
 ## Fix
 

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/AbstractITCase.java
@@ -634,6 +634,11 @@ abstract class AbstractITCase extends AbstractFSCrawlerTestCase {
         fsSettings.getElasticsearch().setFlushInterval(TimeValue.timeValueSeconds(1));
         // We explicitly set semantic search to false because IT takes too long time
         fsSettings.getElasticsearch().setSemanticSearch(false);
+        // Disable Kibana dashboard provisioning by default; enable it only in dedicated Kibana ITs
+        // when -Dtests.kibana.url=... is provided (Cloud / Serverless CI).
+        if (fsSettings.getKibana() != null) {
+            fsSettings.getKibana().setPushDashboard(false);
+        }
         return fsSettings;
     }
 

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerImplAllDocumentsIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerImplAllDocumentsIT.java
@@ -95,6 +95,10 @@ class FsCrawlerImplAllDocumentsIT extends AbstractFsCrawlerITCase {
         fsSettings.getElasticsearch().setBulkSize(5);
         fsSettings.getElasticsearch().setFlushInterval(TimeValue.timeValueSeconds(1));
         fsSettings.getElasticsearch().setSemanticSearch(false);
+        // Defaults load kibana.push_dashboard=true with localhost:5601; disable for this IT suite.
+        if (fsSettings.getKibana() != null) {
+            fsSettings.getKibana().setPushDashboard(false);
+        }
 
         fsSettings.getFs().setRawMetadata(true);
 

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestKibanaDashboardIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestKibanaDashboardIT.java
@@ -28,6 +28,7 @@ import fr.pilato.elasticsearch.crawler.fs.test.framework.Slow;
 import fr.pilato.elasticsearch.crawler.fs.test.integration.AbstractFsCrawlerITCase;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
@@ -60,6 +61,15 @@ class FsCrawlerTestKibanaDashboardIT extends AbstractFsCrawlerITCase {
     void createsDefaultDashboardOnStartup() throws Exception {
         FsSettings settings = createKibanaSettings();
         dashboardId = KibanaDashboardBuilder.dashboardIdForJob(settings.getName());
+
+        // Probe Kibana version first: Cloud deployments may still be on 9.4 where the Dashboards
+        // API is only experimental / soft-disabled by FSCrawler.
+        try (KibanaClient probe = new KibanaClient(settings)) {
+            probe.start();
+            Assumptions.assumeTrue(
+                    KibanaClient.supportsDashboardsApi(probe.getVersion()),
+                    () -> "Kibana Dashboards API requires 9.5+; cluster reports " + probe.getVersion());
+        }
 
         startCrawler(settings);
 

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestKibanaDashboardIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestKibanaDashboardIT.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
+ */
+package fr.pilato.elasticsearch.crawler.fs.test.integration.elasticsearch;
+
+import fr.pilato.elasticsearch.crawler.fs.kibana.KibanaClient;
+import fr.pilato.elasticsearch.crawler.fs.kibana.KibanaDashboardBuilder;
+import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
+import fr.pilato.elasticsearch.crawler.fs.settings.Kibana;
+import fr.pilato.elasticsearch.crawler.fs.test.framework.Slow;
+import fr.pilato.elasticsearch.crawler.fs.test.integration.AbstractFsCrawlerITCase;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+/**
+ * Kibana dashboard provisioning against a real Kibana instance.
+ *
+ * <p>Skipped unless {@code -Dtests.kibana.url=...} is set. CI enables this only for Cloud and Serverless jobs so local
+ * TestContainers runs stay light on RAM.
+ */
+@Slow
+@EnabledIfSystemProperty(named = "tests.kibana.url", matches = ".+")
+class FsCrawlerTestKibanaDashboardIT extends AbstractFsCrawlerITCase {
+
+    private String dashboardId;
+
+    @AfterEach
+    void cleanupDashboard() throws Exception {
+        if (dashboardId == null) {
+            return;
+        }
+        FsSettings settings = createKibanaSettings();
+        try (KibanaClient kibanaClient = new KibanaClient(settings)) {
+            kibanaClient.start();
+            kibanaClient.deleteDashboard(dashboardId);
+        }
+        dashboardId = null;
+    }
+
+    @Test
+    void createsDefaultDashboardOnStartup() throws Exception {
+        FsSettings settings = createKibanaSettings();
+        dashboardId = KibanaDashboardBuilder.dashboardIdForJob(settings.getName());
+
+        startCrawler(settings);
+
+        try (KibanaClient kibanaClient = new KibanaClient(settings)) {
+            kibanaClient.start();
+            Assertions.assertThat(kibanaClient.isDashboardProvisioningEnabled()).isTrue();
+            Assertions.assertThat(kibanaClient.dashboardExists(dashboardId)).isTrue();
+        }
+    }
+
+    private FsSettings createKibanaSettings() {
+        FsSettings settings = createTestSettings();
+        Kibana kibana = settings.getKibana() != null ? settings.getKibana() : new Kibana();
+        kibana.setUrl(System.getProperty("tests.kibana.url"));
+        kibana.setPushDashboard(true);
+        if (testApiKey != null) {
+            kibana.setApiKey(testApiKey);
+        }
+        settings.setKibana(kibana);
+        return settings;
+    }
+}

--- a/kibana-client/pom.xml
+++ b/kibana-client/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>fr.pilato.elasticsearch.crawler</groupId>
+        <artifactId>fscrawler-parent</artifactId>
+        <version>3.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>fscrawler-kibana-client</artifactId>
+    <name>FSCrawler Kibana Client</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>fr.pilato.elasticsearch.crawler</groupId>
+            <artifactId>fscrawler-framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>fr.pilato.elasticsearch.crawler</groupId>
+            <artifactId>fscrawler-settings</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.connectors</groupId>
+            <artifactId>jersey-apache5-connector</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>fr.pilato.elasticsearch.crawler</groupId>
+            <artifactId>fscrawler-test-framework</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/IKibanaClient.java
+++ b/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/IKibanaClient.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
+ */
+package fr.pilato.elasticsearch.crawler.fs.kibana;
+
+import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
+import java.io.Closeable;
+import java.io.IOException;
+
+public interface IKibanaClient extends Closeable {
+
+    /** Whether Kibana dashboard provisioning is enabled for these settings. */
+    static boolean isEnabled(FsSettings settings) {
+        return settings.getKibana() != null && settings.getKibana().isPushDashboard();
+    }
+
+    void start() throws KibanaClientException;
+
+    /** Returns {@code true} when Kibana responds to {@code GET /api/status}. */
+    boolean isAvailable() throws KibanaClientException;
+
+    /**
+     * Creates a data view for the job alias when it does not exist yet.
+     *
+     * @return {@code true} when a data view was created, {@code false} when it already existed
+     */
+    boolean createDataViewIfMissing(String dataViewId, String indexPattern, String timeField)
+            throws KibanaClientException;
+
+    /** Returns {@code true} when a dashboard with the given id exists. */
+    boolean dashboardExists(String dashboardId) throws KibanaClientException;
+
+    /**
+     * Creates a dashboard using the Kibana Dashboards API ({@code POST /api/dashboards}).
+     *
+     * @return the dashboard id returned by Kibana
+     */
+    String createDashboard(String dashboardPayload) throws KibanaClientException;
+
+    @Override
+    void close() throws IOException;
+}

--- a/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/IKibanaClient.java
+++ b/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/IKibanaClient.java
@@ -62,11 +62,12 @@ public interface IKibanaClient extends Closeable {
     boolean dashboardExists(String dashboardId) throws KibanaClientException;
 
     /**
-     * Creates a dashboard using the Kibana Dashboards API ({@code POST /api/dashboards}).
+     * Creates a dashboard with a known id using the Kibana Dashboards API ({@code PUT /api/dashboards/{id}} upsert).
+     * {@code POST /api/dashboards} does not accept an {@code id} in the body, so create-with-stable-id must use PUT.
      *
      * @return the dashboard id returned by Kibana
      */
-    String createDashboard(String dashboardPayload) throws KibanaClientException;
+    String createDashboard(String dashboardId, String dashboardPayload) throws KibanaClientException;
 
     /**
      * Updates an existing dashboard using the Kibana Dashboards API ({@code PUT /api/dashboards/{id}}).

--- a/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/IKibanaClient.java
+++ b/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/IKibanaClient.java
@@ -26,12 +26,26 @@ import java.io.IOException;
 
 public interface IKibanaClient extends Closeable {
 
+    /** Kibana Dashboards API became generally available in 9.5. */
+    int MIN_DASHBOARDS_API_MAJOR_VERSION = 9;
+
+    int MIN_DASHBOARDS_API_MINOR_VERSION = 5;
+
     /** Whether Kibana dashboard provisioning is enabled for these settings. */
     static boolean isEnabled(FsSettings settings) {
         return settings.getKibana() != null && settings.getKibana().isPushDashboard();
     }
 
     void start() throws KibanaClientException;
+
+    /** Kibana version reported by {@code GET /api/status}, or {@code null} before {@link #start()}. */
+    String getVersion();
+
+    /**
+     * Whether dashboard provisioning is still active after {@link #start()}. Becomes {@code false} when Kibana is older
+     * than 9.5.
+     */
+    boolean isDashboardProvisioningEnabled();
 
     /** Returns {@code true} when Kibana responds to {@code GET /api/status}. */
     boolean isAvailable() throws KibanaClientException;
@@ -53,6 +67,16 @@ public interface IKibanaClient extends Closeable {
      * @return the dashboard id returned by Kibana
      */
     String createDashboard(String dashboardPayload) throws KibanaClientException;
+
+    /**
+     * Updates an existing dashboard using the Kibana Dashboards API ({@code PUT /api/dashboards/{id}}).
+     *
+     * @return the dashboard id returned by Kibana
+     */
+    String updateDashboard(String dashboardId, String dashboardPayload) throws KibanaClientException;
+
+    /** Deletes a dashboard by id when it exists. */
+    void deleteDashboard(String dashboardId) throws KibanaClientException;
 
     @Override
     void close() throws IOException;

--- a/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaClient.java
+++ b/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaClient.java
@@ -157,14 +157,15 @@ public class KibanaClient implements IKibanaClient {
             return true;
         } catch (NotFoundException e) {
             return false;
-        } catch (WebApplicationException e) {
-            if (e.getResponse().getStatus() >= 500) {
-                throw new KibanaClientException(
-                        "Kibana status check failed with HTTP "
-                                + e.getResponse().getStatus(),
-                        e);
+        } catch (KibanaClientException e) {
+            if (e.getCause() instanceof WebApplicationException wae
+                    && wae.getResponse().getStatus() >= 500) {
+                throw e;
             }
-            return false;
+            if (e.getCause() instanceof WebApplicationException) {
+                return false;
+            }
+            throw e;
         }
     }
 
@@ -193,8 +194,9 @@ public class KibanaClient implements IKibanaClient {
     }
 
     @Override
-    public String createDashboard(String dashboardPayload) throws KibanaClientException {
-        String response = httpPost("api/dashboards", dashboardPayload);
+    public String createDashboard(String dashboardId, String dashboardPayload) throws KibanaClientException {
+        // POST /api/dashboards does not accept an id in the body. Use PUT upsert for stable ids.
+        String response = httpPut("api/dashboards/" + dashboardId, dashboardPayload);
         return JsonPath.read(response, "$.id");
     }
 
@@ -324,8 +326,16 @@ public class KibanaClient implements IKibanaClient {
             }
             logger.trace("{} {}/{} gives {}", method, baseUrl, apiPath, response);
             return response;
-        } catch (WebApplicationException e) {
+        } catch (NotFoundException e) {
             throw e;
+        } catch (WebApplicationException e) {
+            String errorBody = readErrorBody(e);
+            int status = e.getResponse().getStatus();
+            logger.debug("{} {}/{} failed with HTTP {}: {}", method, baseUrl, apiPath, status, errorBody);
+            throw new KibanaClientException(
+                    "Can not execute " + method + " " + baseUrl + "/" + apiPath + " (HTTP " + status + "): "
+                            + errorBody,
+                    e);
         } catch (ProcessingException e) {
             if (e.getCause() instanceof ConnectException) {
                 throw new KibanaClientException(
@@ -336,6 +346,17 @@ public class KibanaClient implements IKibanaClient {
             throw new KibanaClientException(
                     "Can not execute " + method + " " + baseUrl + "/" + apiPath + ": " + e.getMessage(), e);
         }
+    }
+
+    private static String readErrorBody(WebApplicationException e) {
+        try {
+            if (e.getResponse().hasEntity()) {
+                return e.getResponse().readEntity(String.class);
+            }
+        } catch (Exception ignored) {
+            // Fall through to status info when the entity cannot be read.
+        }
+        return e.getMessage() != null ? e.getMessage() : "no response body";
     }
 
     private String buildApiPath(String path) {

--- a/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaClient.java
+++ b/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaClient.java
@@ -1,0 +1,323 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
+ */
+package fr.pilato.elasticsearch.crawler.fs.kibana;
+
+import com.jayway.jsonpath.JsonPath;
+import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil;
+import fr.pilato.elasticsearch.crawler.fs.settings.Elasticsearch;
+import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
+import fr.pilato.elasticsearch.crawler.fs.settings.Kibana;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import java.io.File;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.glassfish.jersey.apache5.connector.Apache5ConnectorProvider;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
+
+/** HTTP client for the Kibana Dashboards and Data Views APIs. */
+public class KibanaClient implements IKibanaClient {
+
+    private static final Logger logger = LogManager.getLogger();
+
+    private static final String KBN_XSRF_HEADER = "kbn-xsrf";
+    private static final String KBN_XSRF_VALUE = "true";
+    private static final String USER_AGENT = "fscrawler-kibana-client";
+
+    private final FsSettings settings;
+    private final Kibana kibanaSettings;
+
+    private Client client;
+    private String authorizationHeader;
+
+    public KibanaClient(FsSettings settings) {
+        this.settings = settings;
+        this.kibanaSettings = settings.getKibana();
+    }
+
+    @Override
+    public void start() throws KibanaClientException {
+        if (client != null) {
+            return;
+        }
+        if (kibanaSettings == null) {
+            throw new KibanaClientException("Kibana settings are not configured");
+        }
+
+        ClientConfig config = new ClientConfig();
+        config.connectorProvider(new Apache5ConnectorProvider());
+
+        ClientBuilder clientBuilder = ClientBuilder.newBuilder()
+                .hostnameVerifier(new NullHostNameVerifier())
+                .withConfig(config);
+
+        configureSsl(clientBuilder);
+
+        authorizationHeader = resolveAuthorizationHeader();
+        if (authorizationHeader == null) {
+            HttpAuthenticationFeature feature = HttpAuthenticationFeature.basic(
+                    settings.getElasticsearch().getUsername(),
+                    settings.getElasticsearch().getPassword());
+            clientBuilder.register(feature);
+        }
+
+        client = clientBuilder.build();
+
+        try {
+            if (!isAvailable()) {
+                throw new KibanaClientException("Kibana is not available at " + kibanaSettings.getUrl());
+            }
+            logger.debug("Kibana client connected to {}", kibanaSettings.getUrl());
+        } catch (KibanaClientException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new KibanaClientException(
+                    "Failed to create Kibana client on " + kibanaSettings.getUrl() + ": " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public boolean isAvailable() throws KibanaClientException {
+        try {
+            httpGet("api/status");
+            return true;
+        } catch (NotFoundException e) {
+            return false;
+        } catch (WebApplicationException e) {
+            if (e.getResponse().getStatus() >= 500) {
+                throw new KibanaClientException(
+                        "Kibana status check failed with HTTP "
+                                + e.getResponse().getStatus(),
+                        e);
+            }
+            return false;
+        }
+    }
+
+    @Override
+    public boolean createDataViewIfMissing(String dataViewId, String indexPattern, String timeField)
+            throws KibanaClientException {
+        if (dataViewExists(dataViewId)) {
+            logger.debug("Kibana data view [{}] already exists", dataViewId);
+            return false;
+        }
+
+        String payload = KibanaDashboardBuilder.buildDataViewPayload(dataViewId, indexPattern, timeField);
+        httpPost("api/data_views/data_view", payload);
+        logger.info("Created Kibana data view [{}] for index pattern [{}]", dataViewId, indexPattern);
+        return true;
+    }
+
+    @Override
+    public boolean dashboardExists(String dashboardId) throws KibanaClientException {
+        try {
+            httpGet("api/dashboards/" + dashboardId);
+            return true;
+        } catch (NotFoundException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public String createDashboard(String dashboardPayload) throws KibanaClientException {
+        String response = httpPost("api/dashboards", dashboardPayload);
+        return JsonPath.read(response, "$.id");
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (client != null) {
+            client.close();
+            client = null;
+        }
+    }
+
+    private boolean dataViewExists(String dataViewId) throws KibanaClientException {
+        try {
+            httpGet("api/data_views/data_view/" + dataViewId);
+            return true;
+        } catch (NotFoundException e) {
+            return false;
+        }
+    }
+
+    private String resolveAuthorizationHeader() {
+        if (!FsCrawlerUtil.isNullOrEmpty(kibanaSettings.getApiKey())) {
+            return "ApiKey " + kibanaSettings.getApiKey();
+        }
+        Elasticsearch elasticsearch = settings.getElasticsearch();
+        if (!FsCrawlerUtil.isNullOrEmpty(elasticsearch.getApiKey())) {
+            return "ApiKey " + elasticsearch.getApiKey();
+        }
+        return null;
+    }
+
+    private void configureSsl(ClientBuilder clientBuilder) throws KibanaClientException {
+        Elasticsearch elasticsearch = settings.getElasticsearch();
+        if (elasticsearch.isSslVerification()) {
+            String caCertificatePath = elasticsearch.getCaCertificate();
+            if (caCertificatePath != null) {
+                File certFile = new File(caCertificatePath);
+                clientBuilder.sslContext(sslContextFromHttpCaCrt(certFile));
+            }
+            return;
+        }
+
+        try {
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, trustAllCerts, new SecureRandom());
+            clientBuilder.sslContext(sslContext);
+            logger.warn("Kibana SSL verification is disabled. This is not recommended for production.");
+        } catch (KeyManagementException | NoSuchAlgorithmException e) {
+            throw new KibanaClientException("Failed to initialize SSL context for Kibana client", e);
+        }
+    }
+
+    private SSLContext sslContextFromHttpCaCrt(File certFile) throws KibanaClientException {
+        try (var inputStream = java.nio.file.Files.newInputStream(certFile.toPath())) {
+            CertificateFactory factory = CertificateFactory.getInstance("X.509");
+            Certificate trustedCa = factory.generateCertificate(inputStream);
+            KeyStore trustStore = KeyStore.getInstance("pkcs12");
+            trustStore.load(null, null);
+            trustStore.setCertificateEntry("ca", trustedCa);
+
+            TrustManagerFactory trustManagerFactory =
+                    TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init(trustStore);
+
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, trustManagerFactory.getTrustManagers(), new SecureRandom());
+            return sslContext;
+        } catch (IOException
+                | CertificateException
+                | KeyStoreException
+                | NoSuchAlgorithmException
+                | KeyManagementException e) {
+            throw new KibanaClientException("Failed to load CA certificate from " + certFile, e);
+        }
+    }
+
+    private String httpGet(String path) throws KibanaClientException {
+        return httpCall("GET", path, null, false);
+    }
+
+    private String httpPost(String path, String payload) throws KibanaClientException {
+        return httpCall("POST", path, payload, true);
+    }
+
+    private String httpCall(String method, String path, String payload, boolean writeOperation)
+            throws KibanaClientException {
+        String baseUrl = kibanaSettings.getUrl();
+        String apiPath = buildApiPath(path);
+        logger.trace("Calling {} {}/{}", method, baseUrl, apiPath);
+        try {
+            WebTarget target = client.target(baseUrl).path(apiPath);
+            Invocation.Builder builder =
+                    target.request(MediaType.APPLICATION_JSON).header(HttpHeaders.CONTENT_TYPE, "application/json");
+            builder.header(HttpHeaders.USER_AGENT, USER_AGENT);
+            if (authorizationHeader != null) {
+                builder.header(HttpHeaders.AUTHORIZATION, authorizationHeader);
+            }
+            if (writeOperation) {
+                builder.header(KBN_XSRF_HEADER, KBN_XSRF_VALUE);
+            }
+
+            String response;
+            if (payload == null) {
+                response = builder.method(method, String.class);
+            } else {
+                response = builder.method(method, Entity.json(payload), String.class);
+            }
+            logger.trace("{} {}/{} gives {}", method, baseUrl, apiPath, response);
+            return response;
+        } catch (WebApplicationException e) {
+            throw e;
+        } catch (ProcessingException e) {
+            if (e.getCause() instanceof ConnectException) {
+                throw new KibanaClientException(
+                        "Can not connect to Kibana at " + baseUrl + ": "
+                                + e.getCause().getMessage(),
+                        e);
+            }
+            throw new KibanaClientException(
+                    "Can not execute " + method + " " + baseUrl + "/" + apiPath + ": " + e.getMessage(), e);
+        }
+    }
+
+    private String buildApiPath(String path) {
+        String space = kibanaSettings.getSpace();
+        if (FsCrawlerUtil.isNullOrEmpty(space)) {
+            return path;
+        }
+        return "s/" + space + "/" + path;
+    }
+
+    private static final TrustManager[] trustAllCerts = new TrustManager[] {
+        new X509TrustManager() {
+            @Override
+            public void checkClientTrusted(X509Certificate[] chain, String authType) {}
+
+            @Override
+            public void checkServerTrusted(X509Certificate[] chain, String authType) {}
+
+            @Override
+            public X509Certificate[] getAcceptedIssuers() {
+                return new X509Certificate[0];
+            }
+        }
+    };
+
+    public static class NullHostNameVerifier implements HostnameVerifier {
+        @Override
+        public boolean verify(String urlHostName, SSLSession session) {
+            if (!urlHostName.equalsIgnoreCase(session.getPeerHost())) {
+                logger.warn("URL host [{}] is different to SSLSession host [{}].", urlHostName, session.getPeerHost());
+            }
+            return true;
+        }
+    }
+}

--- a/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaClient.java
+++ b/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaClient.java
@@ -67,6 +67,7 @@ public class KibanaClient implements IKibanaClient {
     private static final String KBN_XSRF_HEADER = "kbn-xsrf";
     private static final String KBN_XSRF_VALUE = "true";
     private static final String USER_AGENT = "fscrawler-kibana-client";
+    private static final String DASHBOARDS_API_PATH = "api/dashboards/";
 
     private final FsSettings settings;
     private final Kibana kibanaSettings;
@@ -186,7 +187,7 @@ public class KibanaClient implements IKibanaClient {
     @Override
     public boolean dashboardExists(String dashboardId) throws KibanaClientException {
         try {
-            httpGet("api/dashboards/" + dashboardId);
+            httpGet(DASHBOARDS_API_PATH + dashboardId);
             return true;
         } catch (NotFoundException e) {
             return false;
@@ -196,20 +197,19 @@ public class KibanaClient implements IKibanaClient {
     @Override
     public String createDashboard(String dashboardId, String dashboardPayload) throws KibanaClientException {
         // POST /api/dashboards does not accept an id in the body. Use PUT upsert for stable ids.
-        String response = httpPut("api/dashboards/" + dashboardId, dashboardPayload);
-        return JsonPath.read(response, "$.id");
+        return updateDashboard(dashboardId, dashboardPayload);
     }
 
     @Override
     public String updateDashboard(String dashboardId, String dashboardPayload) throws KibanaClientException {
-        String response = httpPut("api/dashboards/" + dashboardId, dashboardPayload);
+        String response = httpPut(DASHBOARDS_API_PATH + dashboardId, dashboardPayload);
         return JsonPath.read(response, "$.id");
     }
 
     @Override
     public void deleteDashboard(String dashboardId) throws KibanaClientException {
         try {
-            httpCall("DELETE", "api/dashboards/" + dashboardId, null, true);
+            httpCall("DELETE", DASHBOARDS_API_PATH + dashboardId, null, true);
             logger.info("Deleted Kibana dashboard [{}]", dashboardId);
         } catch (NotFoundException e) {
             logger.debug("Kibana dashboard [{}] was already absent", dashboardId);
@@ -367,20 +367,29 @@ public class KibanaClient implements IKibanaClient {
         return "s/" + space + "/" + path;
     }
 
-    private static final TrustManager[] trustAllCerts = new TrustManager[] {
-        new X509TrustManager() {
-            @Override
-            public void checkClientTrusted(X509Certificate[] chain, String authType) {}
-
-            @Override
-            public void checkServerTrusted(X509Certificate[] chain, String authType) {}
-
-            @Override
-            public X509Certificate[] getAcceptedIssuers() {
-                return new X509Certificate[0];
-            }
+    /**
+     * Trust-all manager used only when {@code elasticsearch.ssl_verification} is false (tests / local clusters with
+     * self-signed certs). Production deployments should keep verification enabled.
+     */
+    @SuppressWarnings("java:S4830")
+    private static final class TrustAllX509TrustManager implements X509TrustManager {
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) {
+            // Intentionally empty: certificate validation is opted out via ssl_verification=false
         }
-    };
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) {
+            // Intentionally empty: certificate validation is opted out via ssl_verification=false
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
+    }
+
+    private static final TrustManager[] trustAllCerts = new TrustManager[] {new TrustAllX509TrustManager()};
 
     public static class NullHostNameVerifier implements HostnameVerifier {
         @Override

--- a/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaClient.java
+++ b/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaClient.java
@@ -73,10 +73,21 @@ public class KibanaClient implements IKibanaClient {
 
     private Client client;
     private String authorizationHeader;
+    private String version;
+    private boolean dashboardProvisioningEnabled;
 
     public KibanaClient(FsSettings settings) {
         this.settings = settings;
         this.kibanaSettings = settings.getKibana();
+        this.dashboardProvisioningEnabled = kibanaSettings != null && kibanaSettings.isPushDashboard();
+    }
+
+    /** Returns {@code true} when the Kibana Dashboards API is generally available (9.5+). */
+    public static boolean supportsDashboardsApi(String kibanaVersion) {
+        int major = FsCrawlerUtil.extractMajorVersion(kibanaVersion);
+        int minor = FsCrawlerUtil.extractMinorVersion(kibanaVersion);
+        return major > MIN_DASHBOARDS_API_MAJOR_VERSION
+                || (major == MIN_DASHBOARDS_API_MAJOR_VERSION && minor >= MIN_DASHBOARDS_API_MINOR_VERSION);
     }
 
     @Override
@@ -108,16 +119,35 @@ public class KibanaClient implements IKibanaClient {
         client = clientBuilder.build();
 
         try {
-            if (!isAvailable()) {
-                throw new KibanaClientException("Kibana is not available at " + kibanaSettings.getUrl());
+            String statusResponse = httpGet("api/status");
+            version = JsonPath.read(statusResponse, "$.version.number");
+            logger.debug("Kibana client connected to {} running version {}", kibanaSettings.getUrl(), version);
+
+            if (!supportsDashboardsApi(version)) {
+                logger.warn(
+                        "Kibana Dashboards API requires version {}.{}, but this cluster runs {}. "
+                                + "Disabling dashboard provisioning.",
+                        MIN_DASHBOARDS_API_MAJOR_VERSION,
+                        MIN_DASHBOARDS_API_MINOR_VERSION,
+                        version);
+                dashboardProvisioningEnabled = false;
             }
-            logger.debug("Kibana client connected to {}", kibanaSettings.getUrl());
         } catch (KibanaClientException e) {
             throw e;
         } catch (Exception e) {
             throw new KibanaClientException(
                     "Failed to create Kibana client on " + kibanaSettings.getUrl() + ": " + e.getMessage(), e);
         }
+    }
+
+    @Override
+    public String getVersion() {
+        return version;
+    }
+
+    @Override
+    public boolean isDashboardProvisioningEnabled() {
+        return dashboardProvisioningEnabled;
     }
 
     @Override
@@ -166,6 +196,22 @@ public class KibanaClient implements IKibanaClient {
     public String createDashboard(String dashboardPayload) throws KibanaClientException {
         String response = httpPost("api/dashboards", dashboardPayload);
         return JsonPath.read(response, "$.id");
+    }
+
+    @Override
+    public String updateDashboard(String dashboardId, String dashboardPayload) throws KibanaClientException {
+        String response = httpPut("api/dashboards/" + dashboardId, dashboardPayload);
+        return JsonPath.read(response, "$.id");
+    }
+
+    @Override
+    public void deleteDashboard(String dashboardId) throws KibanaClientException {
+        try {
+            httpCall("DELETE", "api/dashboards/" + dashboardId, null, true);
+            logger.info("Deleted Kibana dashboard [{}]", dashboardId);
+        } catch (NotFoundException e) {
+            logger.debug("Kibana dashboard [{}] was already absent", dashboardId);
+        }
     }
 
     @Override
@@ -247,6 +293,10 @@ public class KibanaClient implements IKibanaClient {
 
     private String httpPost(String path, String payload) throws KibanaClientException {
         return httpCall("POST", path, payload, true);
+    }
+
+    private String httpPut(String path, String payload) throws KibanaClientException {
+        return httpCall("PUT", path, payload, true);
     }
 
     private String httpCall(String method, String path, String payload, boolean writeOperation)

--- a/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaClientException.java
+++ b/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaClientException.java
@@ -18,19 +18,15 @@
  *
  * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
  */
-package fr.pilato.elasticsearch.crawler.fs.settings;
+package fr.pilato.elasticsearch.crawler.fs.kibana;
 
-import java.util.List;
+public class KibanaClientException extends Exception {
 
-public class Defaults {
-    public static final String DEFAULT_DIR = "/tmp/es";
-    public static final List<String> DEFAULT_EXCLUDED = List.of("*/~*", "*/.ds_store");
-    public static final String ELASTICSEARCH_URL_DEFAULT = "https://127.0.0.1:9200";
-    public static final String DEFAULT_META_FILENAME = ".meta.yml";
-    public static final String REST_URL_DEFAULT = "http://127.0.0.1:8080/fscrawler";
-    public static final String KIBANA_URL_DEFAULT = "http://127.0.0.1:5601";
-    public static final String JOB_NAME_DEFAULT = "fscrawler";
+    public KibanaClientException(String message) {
+        super(message);
+    }
 
-    // To make sur we don't create an instance of this class
-    private Defaults() {}
+    public KibanaClientException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaDashboardBuilder.java
+++ b/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaDashboardBuilder.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
+ */
+package fr.pilato.elasticsearch.crawler.fs.kibana;
+
+import fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil;
+import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds the default FSCrawler dashboard payload for the Kibana Dashboards API.
+ *
+ * <p>See <a href="https://elastic.github.io/dashboards-api-spec/dashboards">Kibana Dashboards API</a>.
+ */
+public final class KibanaDashboardBuilder {
+
+    public static final String DASHBOARD_ID_PREFIX = "fscrawler-";
+    public static final String DATA_VIEW_ID_PREFIX = "fscrawler-data-view-";
+    public static final String DEFAULT_TIME_FIELD = "file.indexing_date";
+
+    private KibanaDashboardBuilder() {}
+
+    public static String dashboardIdForJob(String jobName) {
+        return DASHBOARD_ID_PREFIX + jobName;
+    }
+
+    public static String dataViewIdForJob(String jobName) {
+        return DATA_VIEW_ID_PREFIX + jobName;
+    }
+
+    public static String dashboardTitleForJob(String jobName) {
+        return "FSCrawler - " + jobName;
+    }
+
+    public static String dataViewTitleForJob(String jobName) {
+        return "FSCrawler " + jobName;
+    }
+
+    public static String buildDataViewPayload(String dataViewId, String indexPattern, String timeField) {
+        Map<String, Object> dataView = new LinkedHashMap<>();
+        dataView.put("id", dataViewId);
+        dataView.put("title", indexPattern);
+        dataView.put("name", dataViewTitleForPattern(indexPattern));
+        dataView.put("timeFieldName", timeField);
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("data_view", dataView);
+        return JsonUtil.serialize(payload);
+    }
+
+    public static String buildDefaultDashboardPayload(FsSettings settings) {
+        String jobName = settings.getName();
+        String indexPattern = settings.getElasticsearch().getIndex();
+        String dataViewId = dataViewIdForJob(jobName);
+
+        Map<String, Object> metricDataSource = new LinkedHashMap<>();
+        metricDataSource.put("type", "data_view_spec");
+        metricDataSource.put("index_pattern", indexPattern);
+        metricDataSource.put("time_field", DEFAULT_TIME_FIELD);
+        metricDataSource.put("data_view_id", dataViewId);
+
+        Map<String, Object> metric = new LinkedHashMap<>();
+        metric.put("type", "primary");
+        metric.put("operation", "count");
+
+        Map<String, Object> metricPanelConfig = new LinkedHashMap<>();
+        metricPanelConfig.put("type", "metric");
+        metricPanelConfig.put("title", "Indexed documents");
+        metricPanelConfig.put("data_source", metricDataSource);
+        metricPanelConfig.put("metrics", List.of(metric));
+
+        Map<String, Object> metricPanel = new LinkedHashMap<>();
+        metricPanel.put("type", "vis");
+        metricPanel.put("grid", grid(0, 0, 24, 8));
+        metricPanel.put("config", metricPanelConfig);
+
+        Map<String, Object> extensionDataSource = new LinkedHashMap<>();
+        extensionDataSource.put("type", "data_view_spec");
+        extensionDataSource.put("index_pattern", indexPattern);
+        extensionDataSource.put("time_field", DEFAULT_TIME_FIELD);
+        extensionDataSource.put("data_view_id", dataViewId);
+
+        Map<String, Object> extensionLayer = new LinkedHashMap<>();
+        extensionLayer.put("type", "donut");
+        extensionLayer.put("data_source", extensionDataSource);
+        extensionLayer.put("breakdown", Map.of("field", "file.extension", "limit", 10));
+
+        Map<String, Object> extensionPanelConfig = new LinkedHashMap<>();
+        extensionPanelConfig.put("type", "partition");
+        extensionPanelConfig.put("title", "Documents by extension");
+        extensionPanelConfig.put("layers", List.of(extensionLayer));
+
+        Map<String, Object> extensionPanel = new LinkedHashMap<>();
+        extensionPanel.put("type", "vis");
+        extensionPanel.put("grid", grid(0, 8, 24, 12));
+        extensionPanel.put("config", extensionPanelConfig);
+
+        Map<String, Object> dashboard = new LinkedHashMap<>();
+        dashboard.put("id", dashboardIdForJob(jobName));
+        dashboard.put("title", dashboardTitleForJob(jobName));
+        dashboard.put("panels", List.of(metricPanel, extensionPanel));
+        return JsonUtil.serialize(dashboard);
+    }
+
+    private static Map<String, Integer> grid(int x, int y, int w, int h) {
+        Map<String, Integer> grid = new LinkedHashMap<>();
+        grid.put("x", x);
+        grid.put("y", y);
+        grid.put("w", w);
+        grid.put("h", h);
+        return grid;
+    }
+
+    private static String dataViewTitleForPattern(String indexPattern) {
+        return "FSCrawler " + indexPattern;
+    }
+}

--- a/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaDashboardBuilder.java
+++ b/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaDashboardBuilder.java
@@ -20,9 +20,14 @@
  */
 package fr.pilato.elasticsearch.crawler.fs.kibana;
 
+import fr.pilato.elasticsearch.crawler.fs.framework.ByteSizeValue;
 import fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil;
 import fr.pilato.elasticsearch.crawler.fs.framework.Version;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.OperatingSystemMXBean;
+import java.lang.management.RuntimeMXBean;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -40,6 +45,7 @@ public final class KibanaDashboardBuilder {
     public static final String DEFAULT_TIME_FIELD = "file.indexing_date";
 
     private static final String DOCS_URL = "https://fscrawler.readthedocs.io/en/latest/admin/fs/kibana.html";
+    private static final String PROJECT_URL = "https://fscrawler.readthedocs.io/";
 
     private static final String KEY_TITLE = "title";
     private static final String KEY_TYPE = "type";
@@ -57,6 +63,18 @@ public final class KibanaDashboardBuilder {
     private static final String TYPE_VIS = "vis";
     private static final String TYPE_XY = "xy";
     private static final String TYPE_PRIMARY = "primary";
+    private static final String FIELD_PATH_VIRTUAL_TREE = "path.virtual.tree";
+    private static final String FIELD_FILE_FILESIZE = "file.filesize";
+
+    private static final List<String> DISCOVER_COLUMNS = List.of(
+            "file.filename",
+            "path.virtual",
+            "file.extension",
+            "file.content_type",
+            "file.filesize",
+            "file.indexing_date",
+            "meta.title",
+            "meta.author");
 
     private KibanaDashboardBuilder() {}
 
@@ -91,26 +109,28 @@ public final class KibanaDashboardBuilder {
     public static String buildDefaultDashboardPayload(FsSettings settings) {
         String jobName = settings.getName();
         String indexPattern = settings.getElasticsearch().getIndex();
+        String rootUrl = settings.getFs() != null ? settings.getFs().getUrl() : null;
 
         List<Map<String, Object>> panels = new ArrayList<>();
 
-        // Intro markdown
-        panels.add(markdownPanel(0, 0, 48, 5, sampleDashboardMarkdown()));
+        // Intro + runtime markdown side by side
+        panels.add(markdownPanel(0, 0, 28, 7, sampleDashboardMarkdown(rootUrl)));
+        panels.add(markdownPanel(28, 0, 20, 7, runtimeMarkdown(jobName)));
 
         // Metric row
         panels.add(metricPanel(
-                0, 5, 16, 6, "Indexed documents", indexPattern, primaryMetric(OPERATION_COUNT, null, null)));
+                0, 7, 16, 6, "Indexed documents", indexPattern, primaryMetric(OPERATION_COUNT, null, null)));
         panels.add(metricPanel(
                 16,
-                5,
+                7,
                 16,
                 6,
                 "Total size",
                 indexPattern,
-                primaryMetric("sum", "file.filesize", Map.of(KEY_TYPE, "bytes", "decimals", 1))));
+                primaryMetric("sum", FIELD_FILE_FILESIZE, Map.of(KEY_TYPE, "bytes", "decimals", 1))));
         panels.add(metricPanel(
                 32,
-                5,
+                7,
                 16,
                 6,
                 "Unique extensions",
@@ -121,39 +141,80 @@ public final class KibanaDashboardBuilder {
         panels.add(section(
                 "Overview",
                 false,
-                11,
+                13,
                 List.of(
                         piePanel(0, 0, 24, 12, "Documents by extension", indexPattern, "file.extension", 10),
                         horizontalBarPanel(
                                 24, 0, 24, 12, "Top content types", indexPattern, "file.content_type", 10))));
 
+        // Directories (expanded) — path.virtual.tree treemaps with Discover drill-down
+        panels.add(section(
+                "Directories",
+                false,
+                26,
+                List.of(
+                        treemapPanel(
+                                0,
+                                0,
+                                24,
+                                14,
+                                "Directories by file count",
+                                indexPattern,
+                                FIELD_PATH_VIRTUAL_TREE,
+                                Map.of(KEY_OPERATION, OPERATION_COUNT),
+                                20),
+                        treemapPanel(
+                                24,
+                                0,
+                                24,
+                                14,
+                                "Directories by size",
+                                indexPattern,
+                                FIELD_PATH_VIRTUAL_TREE,
+                                Map.of(
+                                        KEY_OPERATION,
+                                        "sum",
+                                        KEY_FIELD,
+                                        FIELD_FILE_FILESIZE,
+                                        "format",
+                                        Map.of(KEY_TYPE, "bytes", "decimals", 1)),
+                                20))));
+
         // Timeline (expanded)
         panels.add(section(
                 "Timeline",
                 false,
-                24,
+                41,
                 List.of(dateHistogramPanel(
                         0, 0, 48, 12, "Indexing activity over time", indexPattern, DEFAULT_TIME_FIELD, "area"))));
+
+        // Discover session with principal fields
+        panels.add(section(
+                "Documents",
+                false,
+                54,
+                List.of(discoverSessionPanel(0, 0, 48, 16, "Indexed documents", indexPattern, DISCOVER_COLUMNS))));
 
         // File dates (collapsed)
         panels.add(section(
                 "File dates",
                 true,
-                37,
+                71,
                 List.of(
                         dateHistogramPanel(0, 0, 16, 10, "Created", indexPattern, "file.created", "line"),
                         dateHistogramPanel(16, 0, 16, 10, "Last modified", indexPattern, "file.last_modified", "line"),
                         dateHistogramPanel(
                                 32, 0, 16, 10, "Last accessed", indexPattern, "file.last_accessed", "line"))));
 
-        // Document metadata (collapsed)
+        // Document metadata (collapsed) — only keyword fields for terms aggs
         panels.add(section(
                 "Document metadata",
                 true,
-                40,
+                74,
                 List.of(
                         piePanel(0, 0, 24, 12, "Documents by language", indexPattern, "meta.language", 10),
-                        horizontalBarPanel(24, 0, 24, 12, "Top authors", indexPattern, "meta.author", 10))));
+                        horizontalBarPanel(
+                                24, 0, 24, 12, "Top creator tools", indexPattern, "meta.creator_tool", 10))));
 
         Map<String, Object> dashboard = new LinkedHashMap<>();
         // Do not put "id" in the body: POST rejects it; PUT takes the id from the path.
@@ -163,13 +224,58 @@ public final class KibanaDashboardBuilder {
         return JsonUtil.serialize(dashboard);
     }
 
-    static String sampleDashboardMarkdown() {
-        return "# Sample FSCrawler Dashboard\n\n"
-                + "Feel free to copy and edit this dashboard as you need to.\n"
-                + "It's provided as default one by FSCrawler. If you want to disable\n"
-                + "the automatic creation, set `kibana.push_dashboard` to `false` in your job settings.\n\n"
-                + "See [Doc](" + DOCS_URL + ") for more information.\n"
-                + "Created by FSCrawler v" + Version.getVersion();
+    static String sampleDashboardMarkdown(String rootUrl) {
+        StringBuilder md = new StringBuilder();
+        md.append("# Sample FSCrawler Dashboard\n\n");
+        md.append("Feel free to copy and edit this dashboard as you need to.\n");
+        md.append("It's provided as default one by FSCrawler. If you want to disable\n");
+        md.append("the automatic creation, set `kibana.push_dashboard` to `false` in your job settings.\n\n");
+        if (rootUrl != null && !rootUrl.isBlank()) {
+            md.append("**Root (`fs.url`):** `").append(rootUrl).append("`\n\n");
+        }
+        md.append("See [Doc](").append(DOCS_URL).append(") for more information.\n");
+        md.append("Created by [FSCrawler **v")
+                .append(Version.getVersion())
+                .append("**](")
+                .append(PROJECT_URL)
+                .append(")");
+        return md.toString();
+    }
+
+    static String runtimeMarkdown(String jobName) {
+        OperatingSystemMXBean os = ManagementFactory.getOperatingSystemMXBean();
+        RuntimeMXBean runtime = ManagementFactory.getRuntimeMXBean();
+        MemoryMXBean memory = ManagementFactory.getMemoryMXBean();
+        long heapUsed = memory.getHeapMemoryUsage().getUsed();
+        long heapMax = memory.getHeapMemoryUsage().getMax();
+
+        StringBuilder md = new StringBuilder();
+        md.append("## FSCrawler runtime\n\n");
+        md.append("- **Job:** `").append(jobName).append("`\n");
+        md.append("- **OS:** ")
+                .append(System.getProperty("os.name", "unknown"))
+                .append(" / ")
+                .append(System.getProperty("os.arch", "unknown"))
+                .append(" / ")
+                .append(System.getProperty("os.version", "unknown"))
+                .append('\n');
+        md.append("- **Java:** ")
+                .append(System.getProperty("java.version", "unknown"))
+                .append(" (")
+                .append(System.getProperty("java.vendor", "unknown"))
+                .append(")\n");
+        md.append("- **Heap:** ")
+                .append(new ByteSizeValue(Math.max(heapUsed, 0)).toString())
+                .append(" / ");
+        if (heapMax > 0) {
+            md.append(new ByteSizeValue(heapMax).toString());
+        } else {
+            md.append("unlimited");
+        }
+        md.append('\n');
+        md.append("- **Processors:** ").append(os.getAvailableProcessors()).append('\n');
+        md.append("- **JVM:** `").append(runtime.getVmName()).append("`");
+        return md.toString();
     }
 
     private static Map<String, Object> markdownPanel(int x, int y, int w, int h, String content) {
@@ -243,6 +349,34 @@ public final class KibanaDashboardBuilder {
         return visPanel(x, y, w, h, config);
     }
 
+    private static Map<String, Object> treemapPanel(
+            int x,
+            int y,
+            int w,
+            int h,
+            String title,
+            String indexPattern,
+            String groupByField,
+            Map<String, Object> metric,
+            int limit) {
+        Map<String, Object> groupBy = new LinkedHashMap<>();
+        groupBy.put(KEY_OPERATION, OPERATION_TERMS);
+        groupBy.put(KEY_FIELDS, List.of(groupByField));
+        groupBy.put("limit", limit);
+
+        Map<String, Object> config = new LinkedHashMap<>();
+        config.put(KEY_TYPE, "treemap");
+        config.put(KEY_TITLE, title);
+        config.put(KEY_DATA_SOURCE, dataViewSpec(indexPattern));
+        config.put(KEY_METRICS, List.of(metric));
+        config.put("group_by", List.of(groupBy));
+        config.put(
+                "drilldowns",
+                List.of(Map.of(
+                        KEY_TYPE, "discover_drilldown", "label", "Open in Discover", "trigger", "on_apply_filter")));
+        return visPanel(x, y, w, h, config);
+    }
+
     private static Map<String, Object> dateHistogramPanel(
             int x, int y, int w, int h, String title, String indexPattern, String dateField, String layerType) {
         Map<String, Object> xAxis = new LinkedHashMap<>();
@@ -265,6 +399,25 @@ public final class KibanaDashboardBuilder {
         config.put(KEY_LAYERS, List.of(layer));
         config.put("axis", Map.of("x", axisX));
         return visPanel(x, y, w, h, config);
+    }
+
+    private static Map<String, Object> discoverSessionPanel(
+            int x, int y, int w, int h, String title, String indexPattern, List<String> columns) {
+        Map<String, Object> tab = new LinkedHashMap<>();
+        tab.put(KEY_DATA_SOURCE, dataViewSpec(indexPattern));
+        tab.put("column_order", columns);
+        tab.put("sort", List.of(Map.of("name", DEFAULT_TIME_FIELD, "direction", "desc")));
+        tab.put("view_mode", "documents");
+
+        Map<String, Object> config = new LinkedHashMap<>();
+        config.put(KEY_TITLE, title);
+        config.put("tabs", List.of(tab));
+
+        Map<String, Object> panel = new LinkedHashMap<>();
+        panel.put(KEY_TYPE, "discover_session");
+        panel.put(KEY_GRID, grid(x, y, w, h));
+        panel.put(KEY_CONFIG, config);
+        return panel;
     }
 
     private static Map<String, Object> section(

--- a/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaDashboardBuilder.java
+++ b/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaDashboardBuilder.java
@@ -114,15 +114,15 @@ public final class KibanaDashboardBuilder {
         List<Map<String, Object>> panels = new ArrayList<>();
 
         // Intro + runtime markdown side by side
-        panels.add(markdownPanel(0, 0, 28, 7, sampleDashboardMarkdown(rootUrl)));
-        panels.add(markdownPanel(28, 0, 20, 7, runtimeMarkdown(jobName)));
+        panels.add(markdownPanel(0, 0, 28, 10, sampleDashboardMarkdown(rootUrl)));
+        panels.add(markdownPanel(28, 0, 20, 10, runtimeMarkdown(jobName)));
 
         // Metric row
         panels.add(metricPanel(
-                0, 7, 16, 6, "Indexed documents", indexPattern, primaryMetric(OPERATION_COUNT, null, null)));
+                0, 10, 16, 6, "Indexed documents", indexPattern, primaryMetric(OPERATION_COUNT, null, null)));
         panels.add(metricPanel(
                 16,
-                7,
+                10,
                 16,
                 6,
                 "Total size",
@@ -130,7 +130,7 @@ public final class KibanaDashboardBuilder {
                 primaryMetric("sum", FIELD_FILE_FILESIZE, Map.of(KEY_TYPE, "bytes", "decimals", 1))));
         panels.add(metricPanel(
                 32,
-                7,
+                10,
                 16,
                 6,
                 "Unique extensions",
@@ -141,7 +141,7 @@ public final class KibanaDashboardBuilder {
         panels.add(section(
                 "Overview",
                 false,
-                13,
+                16,
                 List.of(
                         piePanel(0, 0, 24, 12, "Documents by extension", indexPattern, "file.extension", 10),
                         horizontalBarPanel(
@@ -151,7 +151,7 @@ public final class KibanaDashboardBuilder {
         panels.add(section(
                 "Directories",
                 false,
-                26,
+                29,
                 List.of(
                         treemapPanel(
                                 0,
@@ -184,7 +184,7 @@ public final class KibanaDashboardBuilder {
         panels.add(section(
                 "Timeline",
                 false,
-                41,
+                44,
                 List.of(dateHistogramPanel(
                         0, 0, 48, 12, "Indexing activity over time", indexPattern, DEFAULT_TIME_FIELD, "area"))));
 
@@ -192,14 +192,14 @@ public final class KibanaDashboardBuilder {
         panels.add(section(
                 "Documents",
                 false,
-                54,
+                57,
                 List.of(discoverSessionPanel(0, 0, 48, 16, "Indexed documents", indexPattern, DISCOVER_COLUMNS))));
 
         // File dates (collapsed)
         panels.add(section(
                 "File dates",
                 true,
-                71,
+                74,
                 List.of(
                         dateHistogramPanel(0, 0, 16, 10, "Created", indexPattern, "file.created", "line"),
                         dateHistogramPanel(16, 0, 16, 10, "Last modified", indexPattern, "file.last_modified", "line"),
@@ -210,7 +210,7 @@ public final class KibanaDashboardBuilder {
         panels.add(section(
                 "Document metadata",
                 true,
-                74,
+                77,
                 List.of(
                         piePanel(0, 0, 24, 12, "Documents by language", indexPattern, "meta.language", 10),
                         horizontalBarPanel(

--- a/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaDashboardBuilder.java
+++ b/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaDashboardBuilder.java
@@ -143,7 +143,7 @@ public final class KibanaDashboardBuilder {
                 false,
                 16,
                 List.of(
-                        piePanel(0, 0, 24, 12, "Documents by extension", indexPattern, "file.extension", 10),
+                        tagCloudPanel(0, 0, 24, 12, "Documents by extension", indexPattern, "file.extension", 10),
                         horizontalBarPanel(
                                 24, 0, 24, 12, "Top content types", indexPattern, "file.content_type", 10))));
 
@@ -195,16 +195,17 @@ public final class KibanaDashboardBuilder {
                 57,
                 List.of(discoverSessionPanel(0, 0, 48, 16, "Indexed documents", indexPattern, DISCOVER_COLUMNS))));
 
-        // File dates (collapsed)
+        // File dates (collapsed) — ignore dashboard time picker (file.* dates ≠ indexing_date)
         panels.add(section(
                 "File dates",
                 true,
                 74,
                 List.of(
-                        dateHistogramPanel(0, 0, 16, 10, "Created", indexPattern, "file.created", "line"),
-                        dateHistogramPanel(16, 0, 16, 10, "Last modified", indexPattern, "file.last_modified", "line"),
+                        dateHistogramPanel(0, 0, 16, 10, "Created", indexPattern, "file.created", "line", true),
                         dateHistogramPanel(
-                                32, 0, 16, 10, "Last accessed", indexPattern, "file.last_accessed", "line"))));
+                                16, 0, 16, 10, "Last modified", indexPattern, "file.last_modified", "line", true),
+                        dateHistogramPanel(
+                                32, 0, 16, 10, "Last accessed", indexPattern, "file.last_accessed", "line", true))));
 
         // Document metadata (collapsed) — only keyword fields for terms aggs
         panels.add(section(
@@ -246,7 +247,6 @@ public final class KibanaDashboardBuilder {
         OperatingSystemMXBean os = ManagementFactory.getOperatingSystemMXBean();
         RuntimeMXBean runtime = ManagementFactory.getRuntimeMXBean();
         MemoryMXBean memory = ManagementFactory.getMemoryMXBean();
-        long heapUsed = memory.getHeapMemoryUsage().getUsed();
         long heapMax = memory.getHeapMemoryUsage().getMax();
 
         StringBuilder md = new StringBuilder();
@@ -264,9 +264,7 @@ public final class KibanaDashboardBuilder {
                 .append(" (")
                 .append(System.getProperty("java.vendor", "unknown"))
                 .append(")\n");
-        md.append("- **Heap:** ")
-                .append(new ByteSizeValue(Math.max(heapUsed, 0)).toString())
-                .append(" / ");
+        md.append("- **Heap max:** ");
         if (heapMax > 0) {
             md.append(new ByteSizeValue(heapMax).toString());
         } else {
@@ -329,6 +327,22 @@ public final class KibanaDashboardBuilder {
         return visPanel(x, y, w, h, config);
     }
 
+    private static Map<String, Object> tagCloudPanel(
+            int x, int y, int w, int h, String title, String indexPattern, String termsField, int limit) {
+        Map<String, Object> tagBy = new LinkedHashMap<>();
+        tagBy.put(KEY_OPERATION, OPERATION_TERMS);
+        tagBy.put(KEY_FIELDS, List.of(termsField));
+        tagBy.put("limit", limit);
+
+        Map<String, Object> config = new LinkedHashMap<>();
+        config.put(KEY_TYPE, "tag_cloud");
+        config.put(KEY_TITLE, title);
+        config.put(KEY_DATA_SOURCE, dataViewSpec(indexPattern));
+        config.put("tag_by", tagBy);
+        config.put("metric", Map.of(KEY_OPERATION, OPERATION_COUNT));
+        return visPanel(x, y, w, h, config);
+    }
+
     private static Map<String, Object> horizontalBarPanel(
             int x, int y, int w, int h, String title, String indexPattern, String termsField, int limit) {
         Map<String, Object> xAxis = new LinkedHashMap<>();
@@ -379,6 +393,19 @@ public final class KibanaDashboardBuilder {
 
     private static Map<String, Object> dateHistogramPanel(
             int x, int y, int w, int h, String title, String indexPattern, String dateField, String layerType) {
+        return dateHistogramPanel(x, y, w, h, title, indexPattern, dateField, layerType, false);
+    }
+
+    private static Map<String, Object> dateHistogramPanel(
+            int x,
+            int y,
+            int w,
+            int h,
+            String title,
+            String indexPattern,
+            String dateField,
+            String layerType,
+            boolean ignoreGlobalFilters) {
         Map<String, Object> xAxis = new LinkedHashMap<>();
         xAxis.put(KEY_OPERATION, "date_histogram");
         xAxis.put(KEY_FIELD, dateField);
@@ -386,6 +413,9 @@ public final class KibanaDashboardBuilder {
         Map<String, Object> layer = new LinkedHashMap<>();
         layer.put(KEY_TYPE, layerType);
         layer.put(KEY_DATA_SOURCE, dataViewSpec(indexPattern));
+        if (ignoreGlobalFilters) {
+            layer.put("ignore_global_filters", true);
+        }
         layer.put("x", xAxis);
         layer.put("y", List.of(Map.of(KEY_OPERATION, OPERATION_COUNT)));
 

--- a/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaDashboardBuilder.java
+++ b/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaDashboardBuilder.java
@@ -21,7 +21,9 @@
 package fr.pilato.elasticsearch.crawler.fs.kibana;
 
 import fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil;
+import fr.pilato.elasticsearch.crawler.fs.framework.Version;
 import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,13 +39,24 @@ public final class KibanaDashboardBuilder {
     public static final String DATA_VIEW_ID_PREFIX = "fscrawler-data-view-";
     public static final String DEFAULT_TIME_FIELD = "file.indexing_date";
 
+    private static final String DOCS_URL = "https://fscrawler.readthedocs.io/en/latest/admin/fs/kibana.html";
+
     private static final String KEY_TITLE = "title";
     private static final String KEY_TYPE = "type";
     private static final String KEY_OPERATION = "operation";
     private static final String KEY_DATA_SOURCE = "data_source";
     private static final String KEY_METRICS = "metrics";
     private static final String KEY_CONFIG = "config";
+    private static final String KEY_FIELD = "field";
+    private static final String KEY_FIELDS = "fields";
+    private static final String KEY_LAYERS = "layers";
+    private static final String KEY_PANELS = "panels";
+    private static final String KEY_GRID = "grid";
     private static final String OPERATION_COUNT = "count";
+    private static final String OPERATION_TERMS = "terms";
+    private static final String TYPE_VIS = "vis";
+    private static final String TYPE_XY = "xy";
+    private static final String TYPE_PRIMARY = "primary";
 
     private KibanaDashboardBuilder() {}
 
@@ -79,50 +92,197 @@ public final class KibanaDashboardBuilder {
         String jobName = settings.getName();
         String indexPattern = settings.getElasticsearch().getIndex();
 
-        Map<String, Object> metricDataSource = dataViewSpec(indexPattern);
+        List<Map<String, Object>> panels = new ArrayList<>();
 
-        Map<String, Object> metric = new LinkedHashMap<>();
-        metric.put(KEY_TYPE, "primary");
-        metric.put(KEY_OPERATION, OPERATION_COUNT);
+        // Intro markdown
+        panels.add(markdownPanel(0, 0, 48, 5, sampleDashboardMarkdown()));
 
-        Map<String, Object> metricPanelConfig = new LinkedHashMap<>();
-        metricPanelConfig.put(KEY_TYPE, "metric");
-        metricPanelConfig.put(KEY_TITLE, "Indexed documents");
-        metricPanelConfig.put(KEY_DATA_SOURCE, metricDataSource);
-        metricPanelConfig.put(KEY_METRICS, List.of(metric));
+        // Metric row
+        panels.add(metricPanel(
+                0, 5, 16, 6, "Indexed documents", indexPattern, primaryMetric(OPERATION_COUNT, null, null)));
+        panels.add(metricPanel(
+                16,
+                5,
+                16,
+                6,
+                "Total size",
+                indexPattern,
+                primaryMetric("sum", "file.filesize", Map.of(KEY_TYPE, "bytes", "decimals", 1))));
+        panels.add(metricPanel(
+                32,
+                5,
+                16,
+                6,
+                "Unique extensions",
+                indexPattern,
+                primaryMetric("unique_count", "file.extension", null)));
 
-        Map<String, Object> metricPanel = new LinkedHashMap<>();
-        metricPanel.put(KEY_TYPE, "vis");
-        metricPanel.put("grid", grid(0, 0, 24, 8));
-        metricPanel.put(KEY_CONFIG, metricPanelConfig);
+        // Overview (expanded)
+        panels.add(section(
+                "Overview",
+                false,
+                11,
+                List.of(
+                        piePanel(0, 0, 24, 12, "Documents by extension", indexPattern, "file.extension", 10),
+                        horizontalBarPanel(
+                                24, 0, 24, 12, "Top content types", indexPattern, "file.content_type", 10))));
 
-        Map<String, Object> extensionGroupBy = new LinkedHashMap<>();
-        extensionGroupBy.put(KEY_OPERATION, "terms");
-        extensionGroupBy.put("fields", List.of("file.extension"));
-        extensionGroupBy.put("limit", 10);
+        // Timeline (expanded)
+        panels.add(section(
+                "Timeline",
+                false,
+                24,
+                List.of(dateHistogramPanel(
+                        0, 0, 48, 12, "Indexing activity over time", indexPattern, DEFAULT_TIME_FIELD, "area"))));
 
-        Map<String, Object> extensionMetric = new LinkedHashMap<>();
-        extensionMetric.put(KEY_OPERATION, OPERATION_COUNT);
+        // File dates (collapsed)
+        panels.add(section(
+                "File dates",
+                true,
+                37,
+                List.of(
+                        dateHistogramPanel(0, 0, 16, 10, "Created", indexPattern, "file.created", "line"),
+                        dateHistogramPanel(16, 0, 16, 10, "Last modified", indexPattern, "file.last_modified", "line"),
+                        dateHistogramPanel(
+                                32, 0, 16, 10, "Last accessed", indexPattern, "file.last_accessed", "line"))));
 
-        Map<String, Object> extensionPanelConfig = new LinkedHashMap<>();
-        extensionPanelConfig.put(KEY_TYPE, "pie");
-        extensionPanelConfig.put(KEY_TITLE, "Documents by extension");
-        extensionPanelConfig.put(KEY_DATA_SOURCE, dataViewSpec(indexPattern));
-        extensionPanelConfig.put(KEY_METRICS, List.of(extensionMetric));
-        extensionPanelConfig.put("group_by", List.of(extensionGroupBy));
-        extensionPanelConfig.put("styling", Map.of("donut_hole", "m"));
-
-        Map<String, Object> extensionPanel = new LinkedHashMap<>();
-        extensionPanel.put(KEY_TYPE, "vis");
-        extensionPanel.put("grid", grid(0, 8, 24, 12));
-        extensionPanel.put(KEY_CONFIG, extensionPanelConfig);
+        // Document metadata (collapsed)
+        panels.add(section(
+                "Document metadata",
+                true,
+                40,
+                List.of(
+                        piePanel(0, 0, 24, 12, "Documents by language", indexPattern, "meta.language", 10),
+                        horizontalBarPanel(24, 0, 24, 12, "Top authors", indexPattern, "meta.author", 10))));
 
         Map<String, Object> dashboard = new LinkedHashMap<>();
         // Do not put "id" in the body: POST rejects it; PUT takes the id from the path.
         dashboard.put(KEY_TITLE, dashboardTitleForJob(jobName));
-        dashboard.put("panels", List.of(metricPanel, extensionPanel));
+        dashboard.put(KEY_PANELS, panels);
         dashboard.put("time_range", Map.of("from", "now-30d", "to", "now"));
         return JsonUtil.serialize(dashboard);
+    }
+
+    static String sampleDashboardMarkdown() {
+        return "# Sample FSCrawler Dashboard\n\n"
+                + "Feel free to copy and edit this dashboard as you need to.\n"
+                + "It's provided as default one by FSCrawler. If you want to disable\n"
+                + "the automatic creation, set `kibana.push_dashboard` to `false` in your job settings.\n\n"
+                + "See [Doc](" + DOCS_URL + ") for more information.\n"
+                + "Created by FSCrawler v" + Version.getVersion();
+    }
+
+    private static Map<String, Object> markdownPanel(int x, int y, int w, int h, String content) {
+        Map<String, Object> config = new LinkedHashMap<>();
+        config.put("content", content);
+
+        Map<String, Object> panel = new LinkedHashMap<>();
+        panel.put(KEY_TYPE, "markdown");
+        panel.put(KEY_GRID, grid(x, y, w, h));
+        panel.put(KEY_CONFIG, config);
+        return panel;
+    }
+
+    private static Map<String, Object> metricPanel(
+            int x, int y, int w, int h, String title, String indexPattern, Map<String, Object> metric) {
+        Map<String, Object> config = new LinkedHashMap<>();
+        config.put(KEY_TYPE, "metric");
+        config.put(KEY_TITLE, title);
+        config.put(KEY_DATA_SOURCE, dataViewSpec(indexPattern));
+        config.put(KEY_METRICS, List.of(metric));
+        return visPanel(x, y, w, h, config);
+    }
+
+    private static Map<String, Object> primaryMetric(String operation, String field, Map<String, Object> format) {
+        Map<String, Object> metric = new LinkedHashMap<>();
+        metric.put(KEY_TYPE, TYPE_PRIMARY);
+        metric.put(KEY_OPERATION, operation);
+        if (field != null) {
+            metric.put(KEY_FIELD, field);
+        }
+        if (format != null) {
+            metric.put("format", format);
+        }
+        return metric;
+    }
+
+    private static Map<String, Object> piePanel(
+            int x, int y, int w, int h, String title, String indexPattern, String groupByField, int limit) {
+        Map<String, Object> groupBy = new LinkedHashMap<>();
+        groupBy.put(KEY_OPERATION, OPERATION_TERMS);
+        groupBy.put(KEY_FIELDS, List.of(groupByField));
+        groupBy.put("limit", limit);
+
+        Map<String, Object> config = new LinkedHashMap<>();
+        config.put(KEY_TYPE, "pie");
+        config.put(KEY_TITLE, title);
+        config.put(KEY_DATA_SOURCE, dataViewSpec(indexPattern));
+        config.put(KEY_METRICS, List.of(Map.of(KEY_OPERATION, OPERATION_COUNT)));
+        config.put("group_by", List.of(groupBy));
+        config.put("styling", Map.of("donut_hole", "m"));
+        return visPanel(x, y, w, h, config);
+    }
+
+    private static Map<String, Object> horizontalBarPanel(
+            int x, int y, int w, int h, String title, String indexPattern, String termsField, int limit) {
+        Map<String, Object> xAxis = new LinkedHashMap<>();
+        xAxis.put(KEY_OPERATION, OPERATION_TERMS);
+        xAxis.put(KEY_FIELDS, List.of(termsField));
+        xAxis.put("limit", limit);
+
+        Map<String, Object> layer = new LinkedHashMap<>();
+        layer.put(KEY_TYPE, "bar_horizontal");
+        layer.put(KEY_DATA_SOURCE, dataViewSpec(indexPattern));
+        layer.put("x", xAxis);
+        layer.put("y", List.of(Map.of(KEY_OPERATION, OPERATION_COUNT)));
+
+        Map<String, Object> config = new LinkedHashMap<>();
+        config.put(KEY_TYPE, TYPE_XY);
+        config.put(KEY_TITLE, title);
+        config.put(KEY_LAYERS, List.of(layer));
+        return visPanel(x, y, w, h, config);
+    }
+
+    private static Map<String, Object> dateHistogramPanel(
+            int x, int y, int w, int h, String title, String indexPattern, String dateField, String layerType) {
+        Map<String, Object> xAxis = new LinkedHashMap<>();
+        xAxis.put(KEY_OPERATION, "date_histogram");
+        xAxis.put(KEY_FIELD, dateField);
+
+        Map<String, Object> layer = new LinkedHashMap<>();
+        layer.put(KEY_TYPE, layerType);
+        layer.put(KEY_DATA_SOURCE, dataViewSpec(indexPattern));
+        layer.put("x", xAxis);
+        layer.put("y", List.of(Map.of(KEY_OPERATION, OPERATION_COUNT)));
+
+        Map<String, Object> axisX = new LinkedHashMap<>();
+        axisX.put("scale", "temporal");
+        axisX.put("domain", Map.of(KEY_TYPE, "fit", "rounding", false));
+
+        Map<String, Object> config = new LinkedHashMap<>();
+        config.put(KEY_TYPE, TYPE_XY);
+        config.put(KEY_TITLE, title);
+        config.put(KEY_LAYERS, List.of(layer));
+        config.put("axis", Map.of("x", axisX));
+        return visPanel(x, y, w, h, config);
+    }
+
+    private static Map<String, Object> section(
+            String title, boolean collapsed, int y, List<Map<String, Object>> nestedPanels) {
+        Map<String, Object> section = new LinkedHashMap<>();
+        section.put(KEY_TITLE, title);
+        section.put("collapsed", collapsed);
+        section.put(KEY_GRID, Map.of("y", y));
+        section.put(KEY_PANELS, nestedPanels);
+        return section;
+    }
+
+    private static Map<String, Object> visPanel(int x, int y, int w, int h, Map<String, Object> config) {
+        Map<String, Object> panel = new LinkedHashMap<>();
+        panel.put(KEY_TYPE, TYPE_VIS);
+        panel.put(KEY_GRID, grid(x, y, w, h));
+        panel.put(KEY_CONFIG, config);
+        return panel;
     }
 
     private static Map<String, Object> dataViewSpec(String indexPattern) {

--- a/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaDashboardBuilder.java
+++ b/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaDashboardBuilder.java
@@ -70,13 +70,8 @@ public final class KibanaDashboardBuilder {
     public static String buildDefaultDashboardPayload(FsSettings settings) {
         String jobName = settings.getName();
         String indexPattern = settings.getElasticsearch().getIndex();
-        String dataViewId = dataViewIdForJob(jobName);
 
-        Map<String, Object> metricDataSource = new LinkedHashMap<>();
-        metricDataSource.put("type", "data_view_spec");
-        metricDataSource.put("index_pattern", indexPattern);
-        metricDataSource.put("time_field", DEFAULT_TIME_FIELD);
-        metricDataSource.put("data_view_id", dataViewId);
+        Map<String, Object> metricDataSource = dataViewSpec(indexPattern);
 
         Map<String, Object> metric = new LinkedHashMap<>();
         metric.put("type", "primary");
@@ -93,21 +88,21 @@ public final class KibanaDashboardBuilder {
         metricPanel.put("grid", grid(0, 0, 24, 8));
         metricPanel.put("config", metricPanelConfig);
 
-        Map<String, Object> extensionDataSource = new LinkedHashMap<>();
-        extensionDataSource.put("type", "data_view_spec");
-        extensionDataSource.put("index_pattern", indexPattern);
-        extensionDataSource.put("time_field", DEFAULT_TIME_FIELD);
-        extensionDataSource.put("data_view_id", dataViewId);
+        Map<String, Object> extensionGroupBy = new LinkedHashMap<>();
+        extensionGroupBy.put("operation", "terms");
+        extensionGroupBy.put("fields", List.of("file.extension"));
+        extensionGroupBy.put("limit", 10);
 
-        Map<String, Object> extensionLayer = new LinkedHashMap<>();
-        extensionLayer.put("type", "donut");
-        extensionLayer.put("data_source", extensionDataSource);
-        extensionLayer.put("breakdown", Map.of("field", "file.extension", "limit", 10));
+        Map<String, Object> extensionMetric = new LinkedHashMap<>();
+        extensionMetric.put("operation", "count");
 
         Map<String, Object> extensionPanelConfig = new LinkedHashMap<>();
-        extensionPanelConfig.put("type", "partition");
+        extensionPanelConfig.put("type", "pie");
         extensionPanelConfig.put("title", "Documents by extension");
-        extensionPanelConfig.put("layers", List.of(extensionLayer));
+        extensionPanelConfig.put("data_source", dataViewSpec(indexPattern));
+        extensionPanelConfig.put("metrics", List.of(extensionMetric));
+        extensionPanelConfig.put("group_by", List.of(extensionGroupBy));
+        extensionPanelConfig.put("styling", Map.of("donut_hole", "m"));
 
         Map<String, Object> extensionPanel = new LinkedHashMap<>();
         extensionPanel.put("type", "vis");
@@ -115,10 +110,20 @@ public final class KibanaDashboardBuilder {
         extensionPanel.put("config", extensionPanelConfig);
 
         Map<String, Object> dashboard = new LinkedHashMap<>();
-        dashboard.put("id", dashboardIdForJob(jobName));
+        // Do not put "id" in the body: POST rejects it; PUT takes the id from the path.
         dashboard.put("title", dashboardTitleForJob(jobName));
         dashboard.put("panels", List.of(metricPanel, extensionPanel));
+        dashboard.put("time_range", Map.of("from", "now-30d", "to", "now"));
         return JsonUtil.serialize(dashboard);
+    }
+
+    private static Map<String, Object> dataViewSpec(String indexPattern) {
+        // data_view_spec has additionalProperties:false — only type/index_pattern/time_field/…
+        Map<String, Object> dataSource = new LinkedHashMap<>();
+        dataSource.put("type", "data_view_spec");
+        dataSource.put("index_pattern", indexPattern);
+        dataSource.put("time_field", DEFAULT_TIME_FIELD);
+        return dataSource;
     }
 
     private static Map<String, Integer> grid(int x, int y, int w, int h) {

--- a/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaDashboardBuilder.java
+++ b/kibana-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaDashboardBuilder.java
@@ -37,6 +37,14 @@ public final class KibanaDashboardBuilder {
     public static final String DATA_VIEW_ID_PREFIX = "fscrawler-data-view-";
     public static final String DEFAULT_TIME_FIELD = "file.indexing_date";
 
+    private static final String KEY_TITLE = "title";
+    private static final String KEY_TYPE = "type";
+    private static final String KEY_OPERATION = "operation";
+    private static final String KEY_DATA_SOURCE = "data_source";
+    private static final String KEY_METRICS = "metrics";
+    private static final String KEY_CONFIG = "config";
+    private static final String OPERATION_COUNT = "count";
+
     private KibanaDashboardBuilder() {}
 
     public static String dashboardIdForJob(String jobName) {
@@ -58,7 +66,7 @@ public final class KibanaDashboardBuilder {
     public static String buildDataViewPayload(String dataViewId, String indexPattern, String timeField) {
         Map<String, Object> dataView = new LinkedHashMap<>();
         dataView.put("id", dataViewId);
-        dataView.put("title", indexPattern);
+        dataView.put(KEY_TITLE, indexPattern);
         dataView.put("name", dataViewTitleForPattern(indexPattern));
         dataView.put("timeFieldName", timeField);
 
@@ -74,44 +82,44 @@ public final class KibanaDashboardBuilder {
         Map<String, Object> metricDataSource = dataViewSpec(indexPattern);
 
         Map<String, Object> metric = new LinkedHashMap<>();
-        metric.put("type", "primary");
-        metric.put("operation", "count");
+        metric.put(KEY_TYPE, "primary");
+        metric.put(KEY_OPERATION, OPERATION_COUNT);
 
         Map<String, Object> metricPanelConfig = new LinkedHashMap<>();
-        metricPanelConfig.put("type", "metric");
-        metricPanelConfig.put("title", "Indexed documents");
-        metricPanelConfig.put("data_source", metricDataSource);
-        metricPanelConfig.put("metrics", List.of(metric));
+        metricPanelConfig.put(KEY_TYPE, "metric");
+        metricPanelConfig.put(KEY_TITLE, "Indexed documents");
+        metricPanelConfig.put(KEY_DATA_SOURCE, metricDataSource);
+        metricPanelConfig.put(KEY_METRICS, List.of(metric));
 
         Map<String, Object> metricPanel = new LinkedHashMap<>();
-        metricPanel.put("type", "vis");
+        metricPanel.put(KEY_TYPE, "vis");
         metricPanel.put("grid", grid(0, 0, 24, 8));
-        metricPanel.put("config", metricPanelConfig);
+        metricPanel.put(KEY_CONFIG, metricPanelConfig);
 
         Map<String, Object> extensionGroupBy = new LinkedHashMap<>();
-        extensionGroupBy.put("operation", "terms");
+        extensionGroupBy.put(KEY_OPERATION, "terms");
         extensionGroupBy.put("fields", List.of("file.extension"));
         extensionGroupBy.put("limit", 10);
 
         Map<String, Object> extensionMetric = new LinkedHashMap<>();
-        extensionMetric.put("operation", "count");
+        extensionMetric.put(KEY_OPERATION, OPERATION_COUNT);
 
         Map<String, Object> extensionPanelConfig = new LinkedHashMap<>();
-        extensionPanelConfig.put("type", "pie");
-        extensionPanelConfig.put("title", "Documents by extension");
-        extensionPanelConfig.put("data_source", dataViewSpec(indexPattern));
-        extensionPanelConfig.put("metrics", List.of(extensionMetric));
+        extensionPanelConfig.put(KEY_TYPE, "pie");
+        extensionPanelConfig.put(KEY_TITLE, "Documents by extension");
+        extensionPanelConfig.put(KEY_DATA_SOURCE, dataViewSpec(indexPattern));
+        extensionPanelConfig.put(KEY_METRICS, List.of(extensionMetric));
         extensionPanelConfig.put("group_by", List.of(extensionGroupBy));
         extensionPanelConfig.put("styling", Map.of("donut_hole", "m"));
 
         Map<String, Object> extensionPanel = new LinkedHashMap<>();
-        extensionPanel.put("type", "vis");
+        extensionPanel.put(KEY_TYPE, "vis");
         extensionPanel.put("grid", grid(0, 8, 24, 12));
-        extensionPanel.put("config", extensionPanelConfig);
+        extensionPanel.put(KEY_CONFIG, extensionPanelConfig);
 
         Map<String, Object> dashboard = new LinkedHashMap<>();
         // Do not put "id" in the body: POST rejects it; PUT takes the id from the path.
-        dashboard.put("title", dashboardTitleForJob(jobName));
+        dashboard.put(KEY_TITLE, dashboardTitleForJob(jobName));
         dashboard.put("panels", List.of(metricPanel, extensionPanel));
         dashboard.put("time_range", Map.of("from", "now-30d", "to", "now"));
         return JsonUtil.serialize(dashboard);
@@ -120,7 +128,7 @@ public final class KibanaDashboardBuilder {
     private static Map<String, Object> dataViewSpec(String indexPattern) {
         // data_view_spec has additionalProperties:false — only type/index_pattern/time_field/…
         Map<String, Object> dataSource = new LinkedHashMap<>();
-        dataSource.put("type", "data_view_spec");
+        dataSource.put(KEY_TYPE, "data_view_spec");
         dataSource.put("index_pattern", indexPattern);
         dataSource.put("time_field", DEFAULT_TIME_FIELD);
         return dataSource;

--- a/kibana-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaClientTest.java
+++ b/kibana-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaClientTest.java
@@ -237,7 +237,8 @@ class KibanaClientTest extends AbstractFSCrawlerTestCase {
                 .contains("## FSCrawler runtime")
                 .contains("**OS:**")
                 .contains("**Java:**")
-                .contains("**Heap:**")
+                .contains("**Heap max:**")
+                .doesNotContain("**Heap:**")
                 .contains("**Job:** `" + jobName + "`");
 
         Assertions.assertThat((String) JsonPath.read(payload, "$.panels[2].config.type"))
@@ -260,9 +261,13 @@ class KibanaClientTest extends AbstractFSCrawlerTestCase {
         Assertions.assertThat((Boolean) JsonPath.read(payload, "$.panels[5].collapsed"))
                 .isFalse();
         Assertions.assertThat((String) JsonPath.read(payload, "$.panels[5].panels[0].config.type"))
-                .isEqualTo("pie");
-        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[5].panels[0].config.styling.donut_hole"))
-                .isEqualTo("m");
+                .isEqualTo("tag_cloud");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[5].panels[0].config.title"))
+                .isEqualTo("Documents by extension");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[5].panels[0].config.tag_by.fields[0]"))
+                .isEqualTo("file.extension");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[5].panels[0].config.metric.operation"))
+                .isEqualTo("count");
         Assertions.assertThat((String) JsonPath.read(payload, "$.panels[5].panels[1].config.type"))
                 .isEqualTo("xy");
         Assertions.assertThat((String) JsonPath.read(payload, "$.panels[5].panels[1].config.layers[0].x.fields[0]"))
@@ -329,6 +334,21 @@ class KibanaClientTest extends AbstractFSCrawlerTestCase {
                 .isEqualTo("File dates");
         Assertions.assertThat((Boolean) JsonPath.read(payload, "$.panels[9].collapsed"))
                 .isTrue();
+        Assertions.assertThat((Boolean)
+                        JsonPath.read(payload, "$.panels[9].panels[0].config.layers[0].ignore_global_filters"))
+                .isTrue();
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[9].panels[0].config.layers[0].x.field"))
+                .isEqualTo("file.created");
+        Assertions.assertThat((Boolean)
+                        JsonPath.read(payload, "$.panels[9].panels[1].config.layers[0].ignore_global_filters"))
+                .isTrue();
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[9].panels[1].config.layers[0].x.field"))
+                .isEqualTo("file.last_modified");
+        Assertions.assertThat((Boolean)
+                        JsonPath.read(payload, "$.panels[9].panels[2].config.layers[0].ignore_global_filters"))
+                .isTrue();
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[9].panels[2].config.layers[0].x.field"))
+                .isEqualTo("file.last_accessed");
         Assertions.assertThat((String) JsonPath.read(payload, "$.panels[10].title"))
                 .isEqualTo("Document metadata");
         Assertions.assertThat((Boolean) JsonPath.read(payload, "$.panels[10].collapsed"))

--- a/kibana-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaClientTest.java
+++ b/kibana-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaClientTest.java
@@ -207,26 +207,67 @@ class KibanaClientTest extends AbstractFSCrawlerTestCase {
         settings.getElasticsearch().setIndex("myjob_docs");
 
         String payload = KibanaDashboardBuilder.buildDefaultDashboardPayload(settings);
+        String version = fr.pilato.elasticsearch.crawler.fs.framework.Version.getVersion();
 
         // POST/PUT body must not include id (id is taken from the URL path on PUT).
         Assertions.assertThatThrownBy(() -> JsonPath.read(payload, "$.id"))
                 .isInstanceOf(com.jayway.jsonpath.PathNotFoundException.class);
         Assertions.assertThat((String) JsonPath.read(payload, "$.title")).isEqualTo("FSCrawler - myjob");
-        Assertions.assertThat((List<?>) JsonPath.read(payload, "$.panels")).hasSize(2);
-        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[0].config.type"))
-                .isEqualTo("metric");
-        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[0].config.data_source.type"))
-                .isEqualTo("data_view_spec");
-        Assertions.assertThatThrownBy(() -> JsonPath.read(payload, "$.panels[0].config.data_source.data_view_id"))
-                .isInstanceOf(com.jayway.jsonpath.PathNotFoundException.class);
+
+        // Top-level: markdown + 3 metrics + 4 sections
+        Assertions.assertThat((List<?>) JsonPath.read(payload, "$.panels")).hasSize(8);
+
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[0].type"))
+                .isEqualTo("markdown");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[0].config.content"))
+                .contains("# Sample FSCrawler Dashboard")
+                .contains("`kibana.push_dashboard`")
+                .contains("https://fscrawler.readthedocs.io/en/latest/admin/fs/kibana.html")
+                .contains("Created by FSCrawler v" + version);
+
         Assertions.assertThat((String) JsonPath.read(payload, "$.panels[1].config.type"))
+                .isEqualTo("metric");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[1].config.title"))
+                .isEqualTo("Indexed documents");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[2].config.title"))
+                .isEqualTo("Total size");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[2].config.metrics[0].operation"))
+                .isEqualTo("sum");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[2].config.metrics[0].field"))
+                .isEqualTo("file.filesize");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[3].config.title"))
+                .isEqualTo("Unique extensions");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[3].config.metrics[0].operation"))
+                .isEqualTo("unique_count");
+
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[4].title"))
+                .isEqualTo("Overview");
+        Assertions.assertThat((Boolean) JsonPath.read(payload, "$.panels[4].collapsed"))
+                .isFalse();
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[4].panels[0].config.type"))
                 .isEqualTo("pie");
-        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[1].config.styling.donut_hole"))
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[4].panels[0].config.styling.donut_hole"))
                 .isEqualTo("m");
-        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[1].config.group_by[0].operation"))
-                .isEqualTo("terms");
-        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[1].config.group_by[0].fields[0]"))
-                .isEqualTo("file.extension");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[4].panels[1].config.type"))
+                .isEqualTo("xy");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[4].panels[1].config.layers[0].x.fields[0]"))
+                .isEqualTo("file.content_type");
+
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[5].title"))
+                .isEqualTo("Timeline");
+        Assertions.assertThat((Boolean) JsonPath.read(payload, "$.panels[5].collapsed"))
+                .isFalse();
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[5].panels[0].config.layers[0].x.field"))
+                .isEqualTo("file.indexing_date");
+
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[6].title"))
+                .isEqualTo("File dates");
+        Assertions.assertThat((Boolean) JsonPath.read(payload, "$.panels[6].collapsed"))
+                .isTrue();
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[7].title"))
+                .isEqualTo("Document metadata");
+        Assertions.assertThat((Boolean) JsonPath.read(payload, "$.panels[7].collapsed"))
+                .isTrue();
     }
 
     private void stubStatus(String version) {

--- a/kibana-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaClientTest.java
+++ b/kibana-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaClientTest.java
@@ -21,6 +21,7 @@
 package fr.pilato.elasticsearch.crawler.fs.kibana;
 
 import com.carrotsearch.randomizedtesting.jupiter.DetectThreadLeaks;
+import com.carrotsearch.randomizedtesting.jupiter.RandomizedTest;
 import com.carrotsearch.randomizedtesting.jupiter.SystemThreadFilter;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -202,9 +203,13 @@ class KibanaClientTest extends AbstractFSCrawlerTestCase {
 
     @Test
     void buildDefaultDashboardPayload_containsJobPanels() {
+        String jobName = RandomizedTest.randomAsciiLettersOfLengthBetween(randomizedRandomForTests, 6, 12)
+                .toLowerCase();
+        String rootUrl = "/data/" + RandomizedTest.randomAsciiLettersOfLengthBetween(randomizedRandomForTests, 4, 10);
         FsSettings settings = FsSettingsLoader.load();
-        settings.setName("myjob");
-        settings.getElasticsearch().setIndex("myjob_docs");
+        settings.setName(jobName);
+        settings.getFs().setUrl(rootUrl);
+        settings.getElasticsearch().setIndex(jobName + "_docs");
 
         String payload = KibanaDashboardBuilder.buildDefaultDashboardPayload(settings);
         String version = fr.pilato.elasticsearch.crawler.fs.framework.Version.getVersion();
@@ -212,10 +217,10 @@ class KibanaClientTest extends AbstractFSCrawlerTestCase {
         // POST/PUT body must not include id (id is taken from the URL path on PUT).
         Assertions.assertThatThrownBy(() -> JsonPath.read(payload, "$.id"))
                 .isInstanceOf(com.jayway.jsonpath.PathNotFoundException.class);
-        Assertions.assertThat((String) JsonPath.read(payload, "$.title")).isEqualTo("FSCrawler - myjob");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.title")).isEqualTo("FSCrawler - " + jobName);
 
-        // Top-level: markdown + 3 metrics + 4 sections
-        Assertions.assertThat((List<?>) JsonPath.read(payload, "$.panels")).hasSize(8);
+        // Top-level: intro + tech markdown + 3 metrics + 6 sections
+        Assertions.assertThat((List<?>) JsonPath.read(payload, "$.panels")).hasSize(11);
 
         Assertions.assertThat((String) JsonPath.read(payload, "$.panels[0].type"))
                 .isEqualTo("markdown");
@@ -223,51 +228,117 @@ class KibanaClientTest extends AbstractFSCrawlerTestCase {
                 .contains("# Sample FSCrawler Dashboard")
                 .contains("`kibana.push_dashboard`")
                 .contains("https://fscrawler.readthedocs.io/en/latest/admin/fs/kibana.html")
-                .contains("Created by FSCrawler v" + version);
+                .contains("Created by [FSCrawler **v" + version + "**](https://fscrawler.readthedocs.io/)")
+                .contains("**Root (`fs.url`):** `" + rootUrl + "`");
 
-        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[1].config.type"))
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[1].type"))
+                .isEqualTo("markdown");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[1].config.content"))
+                .contains("## FSCrawler runtime")
+                .contains("**OS:**")
+                .contains("**Java:**")
+                .contains("**Heap:**")
+                .contains("**Job:** `" + jobName + "`");
+
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[2].config.type"))
                 .isEqualTo("metric");
-        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[1].config.title"))
-                .isEqualTo("Indexed documents");
         Assertions.assertThat((String) JsonPath.read(payload, "$.panels[2].config.title"))
-                .isEqualTo("Total size");
-        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[2].config.metrics[0].operation"))
-                .isEqualTo("sum");
-        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[2].config.metrics[0].field"))
-                .isEqualTo("file.filesize");
+                .isEqualTo("Indexed documents");
         Assertions.assertThat((String) JsonPath.read(payload, "$.panels[3].config.title"))
-                .isEqualTo("Unique extensions");
+                .isEqualTo("Total size");
         Assertions.assertThat((String) JsonPath.read(payload, "$.panels[3].config.metrics[0].operation"))
+                .isEqualTo("sum");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[3].config.metrics[0].field"))
+                .isEqualTo("file.filesize");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[4].config.title"))
+                .isEqualTo("Unique extensions");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[4].config.metrics[0].operation"))
                 .isEqualTo("unique_count");
 
-        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[4].title"))
-                .isEqualTo("Overview");
-        Assertions.assertThat((Boolean) JsonPath.read(payload, "$.panels[4].collapsed"))
-                .isFalse();
-        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[4].panels[0].config.type"))
-                .isEqualTo("pie");
-        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[4].panels[0].config.styling.donut_hole"))
-                .isEqualTo("m");
-        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[4].panels[1].config.type"))
-                .isEqualTo("xy");
-        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[4].panels[1].config.layers[0].x.fields[0]"))
-                .isEqualTo("file.content_type");
-
         Assertions.assertThat((String) JsonPath.read(payload, "$.panels[5].title"))
-                .isEqualTo("Timeline");
+                .isEqualTo("Overview");
         Assertions.assertThat((Boolean) JsonPath.read(payload, "$.panels[5].collapsed"))
                 .isFalse();
-        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[5].panels[0].config.layers[0].x.field"))
-                .isEqualTo("file.indexing_date");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[5].panels[0].config.type"))
+                .isEqualTo("pie");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[5].panels[0].config.styling.donut_hole"))
+                .isEqualTo("m");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[5].panels[1].config.type"))
+                .isEqualTo("xy");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[5].panels[1].config.layers[0].x.fields[0]"))
+                .isEqualTo("file.content_type");
 
         Assertions.assertThat((String) JsonPath.read(payload, "$.panels[6].title"))
-                .isEqualTo("File dates");
+                .isEqualTo("Directories");
         Assertions.assertThat((Boolean) JsonPath.read(payload, "$.panels[6].collapsed"))
-                .isTrue();
+                .isFalse();
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[6].panels[0].config.type"))
+                .isEqualTo("treemap");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[6].panels[0].config.title"))
+                .isEqualTo("Directories by file count");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[6].panels[0].config.group_by[0].fields[0]"))
+                .isEqualTo("path.virtual.tree");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[6].panels[0].config.metrics[0].operation"))
+                .isEqualTo("count");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[6].panels[0].config.drilldowns[0].type"))
+                .isEqualTo("discover_drilldown");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[6].panels[1].config.type"))
+                .isEqualTo("treemap");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[6].panels[1].config.title"))
+                .isEqualTo("Directories by size");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[6].panels[1].config.group_by[0].fields[0]"))
+                .isEqualTo("path.virtual.tree");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[6].panels[1].config.metrics[0].operation"))
+                .isEqualTo("sum");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[6].panels[1].config.metrics[0].field"))
+                .isEqualTo("file.filesize");
+
         Assertions.assertThat((String) JsonPath.read(payload, "$.panels[7].title"))
-                .isEqualTo("Document metadata");
+                .isEqualTo("Timeline");
         Assertions.assertThat((Boolean) JsonPath.read(payload, "$.panels[7].collapsed"))
+                .isFalse();
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[7].panels[0].config.layers[0].x.field"))
+                .isEqualTo("file.indexing_date");
+
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[8].title"))
+                .isEqualTo("Documents");
+        Assertions.assertThat((Boolean) JsonPath.read(payload, "$.panels[8].collapsed"))
+                .isFalse();
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[8].panels[0].type"))
+                .isEqualTo("discover_session");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[8].panels[0].config.title"))
+                .isEqualTo("Indexed documents");
+        @SuppressWarnings("unchecked")
+        List<String> discoverColumns =
+                (List<String>) JsonPath.read(payload, "$.panels[8].panels[0].config.tabs[0].column_order");
+        Assertions.assertThat(discoverColumns)
+                .containsExactly(
+                        "file.filename",
+                        "path.virtual",
+                        "file.extension",
+                        "file.content_type",
+                        "file.filesize",
+                        "file.indexing_date",
+                        "meta.title",
+                        "meta.author");
+        Assertions.assertThat((String)
+                        JsonPath.read(payload, "$.panels[8].panels[0].config.tabs[0].data_source.index_pattern"))
+                .isEqualTo(jobName + "_docs");
+
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[9].title"))
+                .isEqualTo("File dates");
+        Assertions.assertThat((Boolean) JsonPath.read(payload, "$.panels[9].collapsed"))
                 .isTrue();
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[10].title"))
+                .isEqualTo("Document metadata");
+        Assertions.assertThat((Boolean) JsonPath.read(payload, "$.panels[10].collapsed"))
+                .isTrue();
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[10].panels[0].config.group_by[0].fields[0]"))
+                .isEqualTo("meta.language");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[10].panels[1].config.layers[0].x.fields[0]"))
+                .isEqualTo("meta.creator_tool");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[10].panels[1].config.title"))
+                .isEqualTo("Top creator tools");
     }
 
     private void stubStatus(String version) {

--- a/kibana-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaClientTest.java
+++ b/kibana-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaClientTest.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
+ */
+package fr.pilato.elasticsearch.crawler.fs.kibana;
+
+import com.carrotsearch.randomizedtesting.jupiter.DetectThreadLeaks;
+import com.carrotsearch.randomizedtesting.jupiter.SystemThreadFilter;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import com.jayway.jsonpath.JsonPath;
+import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
+import fr.pilato.elasticsearch.crawler.fs.settings.FsSettingsLoader;
+import fr.pilato.elasticsearch.crawler.fs.settings.Kibana;
+import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
+import fr.pilato.elasticsearch.crawler.fs.test.framework.IntelliJThreadsFilter;
+import fr.pilato.elasticsearch.crawler.fs.test.framework.JNACleanerThreadFilter;
+import fr.pilato.elasticsearch.crawler.fs.test.framework.JUnitThreadsFilter;
+import fr.pilato.elasticsearch.crawler.fs.test.framework.TestContainerThreadFilter;
+import fr.pilato.elasticsearch.crawler.fs.test.framework.WindowsSpecificThreadFilter;
+import fr.pilato.elasticsearch.crawler.fs.test.framework.WireMockThreadFilter;
+import java.util.List;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@DetectThreadLeaks.ExcludeThreads({
+    WireMockThreadFilter.class,
+    SystemThreadFilter.class,
+    WindowsSpecificThreadFilter.class,
+    TestContainerThreadFilter.class,
+    JNACleanerThreadFilter.class,
+    IntelliJThreadsFilter.class,
+    JUnitThreadsFilter.class
+})
+@Execution(ExecutionMode.SAME_THREAD)
+class KibanaClientTest extends AbstractFSCrawlerTestCase {
+
+    private static WireMockServer wireMockServer;
+
+    @BeforeAll
+    static void startWireMock() {
+        wireMockServer =
+                new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+        wireMockServer.start();
+        WireMock.configureFor("localhost", wireMockServer.port());
+    }
+
+    @AfterAll
+    static void stopWireMock() {
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
+    }
+
+    @BeforeEach
+    void resetWireMock() {
+        wireMockServer.resetAll();
+    }
+
+    @Test
+    void createDashboard_sendsKbnXsrfHeader() throws Exception {
+        String dashboardId = "fscrawler-" + UUID.randomUUID();
+        String payload = "{\"id\":\"" + dashboardId + "\",\"title\":\"Test dashboard\",\"panels\":[]}";
+
+        WireMock.stubFor(WireMock.post(WireMock.urlEqualTo("/api/dashboards"))
+                .withHeader("kbn-xsrf", WireMock.equalTo("true"))
+                .withHeader("Authorization", WireMock.equalTo("ApiKey test-api-key"))
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"id\":\"" + dashboardId + "\"}")));
+
+        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/api/status"))
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withBody("{\"status\":{\"overall\":{\"level\":\"available\"}}}")));
+
+        KibanaClient client = new KibanaClient(settingsForWireMock());
+        client.start();
+
+        String createdId = client.createDashboard(payload);
+
+        Assertions.assertThat(createdId).isEqualTo(dashboardId);
+        client.close();
+    }
+
+    @Test
+    void createDataViewIfMissing_createsOnlyWhenAbsent() throws Exception {
+        String dataViewId = "fscrawler-data-view-" + UUID.randomUUID();
+
+        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/api/status"))
+                .willReturn(WireMock.aResponse().withStatus(200).withBody("{\"status\":{}}")));
+
+        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/api/data_views/data_view/" + dataViewId))
+                .inScenario("data-view")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(WireMock.aResponse().withStatus(404))
+                .willSetStateTo("created"));
+
+        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/api/data_views/data_view/" + dataViewId))
+                .inScenario("data-view")
+                .whenScenarioStateIs("created")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"data_view\":{\"id\":\"" + dataViewId + "\"}}")));
+
+        WireMock.stubFor(WireMock.post(WireMock.urlEqualTo("/api/data_views/data_view"))
+                .withHeader("kbn-xsrf", WireMock.equalTo("true"))
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"data_view\":{\"id\":\"" + dataViewId + "\"}}")));
+
+        KibanaClient client = new KibanaClient(settingsForWireMock());
+        client.start();
+
+        Assertions.assertThat(client.createDataViewIfMissing(
+                        dataViewId, "job_docs", KibanaDashboardBuilder.DEFAULT_TIME_FIELD))
+                .isTrue();
+        Assertions.assertThat(client.createDataViewIfMissing(
+                        dataViewId, "job_docs", KibanaDashboardBuilder.DEFAULT_TIME_FIELD))
+                .isFalse();
+
+        client.close();
+    }
+
+    @Test
+    void buildDefaultDashboardPayload_containsJobPanels() {
+        FsSettings settings = FsSettingsLoader.load();
+        settings.setName("myjob");
+        settings.getElasticsearch().setIndex("myjob_docs");
+
+        String payload = KibanaDashboardBuilder.buildDefaultDashboardPayload(settings);
+
+        Assertions.assertThat((String) JsonPath.read(payload, "$.id")).isEqualTo("fscrawler-myjob");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.title")).isEqualTo("FSCrawler - myjob");
+        Assertions.assertThat((List<?>) JsonPath.read(payload, "$.panels")).hasSize(2);
+    }
+
+    private FsSettings settingsForWireMock() {
+        FsSettings settings = FsSettingsLoader.load();
+        settings.setName("wiremock");
+        settings.getElasticsearch().setApiKey("test-api-key");
+        settings.getElasticsearch().setSslVerification(false);
+
+        Kibana kibana = new Kibana();
+        kibana.setUrl("http://localhost:" + wireMockServer.port());
+        kibana.setPushDashboard(true);
+        settings.setKibana(kibana);
+        return settings;
+    }
+}

--- a/kibana-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaClientTest.java
+++ b/kibana-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaClientTest.java
@@ -115,11 +115,12 @@ class KibanaClientTest extends AbstractFSCrawlerTestCase {
     }
 
     @Test
-    void createDashboard_sendsKbnXsrfHeader() throws Exception {
+    void createDashboard_usesPutWithKnownIdAndSendsKbnXsrfHeader() throws Exception {
         String dashboardId = "fscrawler-" + UUID.randomUUID();
-        String payload = "{\"id\":\"" + dashboardId + "\",\"title\":\"Test dashboard\",\"panels\":[]}";
+        String payload = "{\"title\":\"Test dashboard\",\"panels\":[]}";
 
-        WireMock.stubFor(WireMock.post(WireMock.urlEqualTo("/api/dashboards"))
+        // POST /api/dashboards does not accept an id; create with a stable id via PUT upsert.
+        WireMock.stubFor(WireMock.put(WireMock.urlEqualTo("/api/dashboards/" + dashboardId))
                 .withHeader("kbn-xsrf", WireMock.equalTo("true"))
                 .withHeader("Authorization", WireMock.equalTo("ApiKey test-api-key"))
                 .willReturn(WireMock.aResponse()
@@ -132,9 +133,30 @@ class KibanaClientTest extends AbstractFSCrawlerTestCase {
         KibanaClient client = new KibanaClient(settingsForWireMock());
         client.start();
 
-        String createdId = client.createDashboard(payload);
+        String createdId = client.createDashboard(dashboardId, payload);
 
         Assertions.assertThat(createdId).isEqualTo(dashboardId);
+        client.close();
+    }
+
+    @Test
+    void httpCall_wrapsBadRequestAsKibanaClientExceptionWithBody() throws Exception {
+        stubStatus("9.5.2");
+
+        WireMock.stubFor(WireMock.put(WireMock.urlEqualTo("/api/dashboards/fscrawler-bad"))
+                .willReturn(WireMock.aResponse()
+                        .withStatus(400)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"message\":\"id is not allowed\"}")));
+
+        KibanaClient client = new KibanaClient(settingsForWireMock());
+        client.start();
+
+        Assertions.assertThatThrownBy(() -> client.createDashboard("fscrawler-bad", "{\"title\":\"x\",\"panels\":[]}"))
+                .isInstanceOf(KibanaClientException.class)
+                .hasMessageContaining("HTTP 400")
+                .hasMessageContaining("id is not allowed");
+
         client.close();
     }
 
@@ -186,9 +208,25 @@ class KibanaClientTest extends AbstractFSCrawlerTestCase {
 
         String payload = KibanaDashboardBuilder.buildDefaultDashboardPayload(settings);
 
-        Assertions.assertThat((String) JsonPath.read(payload, "$.id")).isEqualTo("fscrawler-myjob");
+        // POST/PUT body must not include id (id is taken from the URL path on PUT).
+        Assertions.assertThatThrownBy(() -> JsonPath.read(payload, "$.id"))
+                .isInstanceOf(com.jayway.jsonpath.PathNotFoundException.class);
         Assertions.assertThat((String) JsonPath.read(payload, "$.title")).isEqualTo("FSCrawler - myjob");
         Assertions.assertThat((List<?>) JsonPath.read(payload, "$.panels")).hasSize(2);
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[0].config.type"))
+                .isEqualTo("metric");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[0].config.data_source.type"))
+                .isEqualTo("data_view_spec");
+        Assertions.assertThatThrownBy(() -> JsonPath.read(payload, "$.panels[0].config.data_source.data_view_id"))
+                .isInstanceOf(com.jayway.jsonpath.PathNotFoundException.class);
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[1].config.type"))
+                .isEqualTo("pie");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[1].config.styling.donut_hole"))
+                .isEqualTo("m");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[1].config.group_by[0].operation"))
+                .isEqualTo("terms");
+        Assertions.assertThat((String) JsonPath.read(payload, "$.panels[1].config.group_by[0].fields[0]"))
+                .isEqualTo("file.extension");
     }
 
     private void stubStatus(String version) {

--- a/kibana-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaClientTest.java
+++ b/kibana-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/kibana/KibanaClientTest.java
@@ -82,6 +82,39 @@ class KibanaClientTest extends AbstractFSCrawlerTestCase {
     }
 
     @Test
+    void supportsDashboardsApi_requiresKibana95() {
+        Assertions.assertThat(KibanaClient.supportsDashboardsApi("9.5.0")).isTrue();
+        Assertions.assertThat(KibanaClient.supportsDashboardsApi("9.5.2")).isTrue();
+        Assertions.assertThat(KibanaClient.supportsDashboardsApi("10.0.0")).isTrue();
+        Assertions.assertThat(KibanaClient.supportsDashboardsApi("9.4.3")).isFalse();
+        Assertions.assertThat(KibanaClient.supportsDashboardsApi("8.19.5")).isFalse();
+    }
+
+    @Test
+    void start_disablesProvisioningWhenKibanaVersionBelow95() throws Exception {
+        stubStatus("8.19.5");
+
+        KibanaClient client = new KibanaClient(settingsForWireMock());
+        client.start();
+
+        Assertions.assertThat(client.isDashboardProvisioningEnabled()).isFalse();
+        Assertions.assertThat(client.getVersion()).isEqualTo("8.19.5");
+        client.close();
+    }
+
+    @Test
+    void start_keepsProvisioningEnabledWhenKibanaVersionIs95OrHigher() throws Exception {
+        stubStatus("9.5.2");
+
+        KibanaClient client = new KibanaClient(settingsForWireMock());
+        client.start();
+
+        Assertions.assertThat(client.isDashboardProvisioningEnabled()).isTrue();
+        Assertions.assertThat(client.getVersion()).isEqualTo("9.5.2");
+        client.close();
+    }
+
+    @Test
     void createDashboard_sendsKbnXsrfHeader() throws Exception {
         String dashboardId = "fscrawler-" + UUID.randomUUID();
         String payload = "{\"id\":\"" + dashboardId + "\",\"title\":\"Test dashboard\",\"panels\":[]}";
@@ -94,10 +127,7 @@ class KibanaClientTest extends AbstractFSCrawlerTestCase {
                         .withHeader("Content-Type", "application/json")
                         .withBody("{\"id\":\"" + dashboardId + "\"}")));
 
-        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/api/status"))
-                .willReturn(WireMock.aResponse()
-                        .withStatus(200)
-                        .withBody("{\"status\":{\"overall\":{\"level\":\"available\"}}}")));
+        stubStatus("9.5.2");
 
         KibanaClient client = new KibanaClient(settingsForWireMock());
         client.start();
@@ -112,8 +142,7 @@ class KibanaClientTest extends AbstractFSCrawlerTestCase {
     void createDataViewIfMissing_createsOnlyWhenAbsent() throws Exception {
         String dataViewId = "fscrawler-data-view-" + UUID.randomUUID();
 
-        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/api/status"))
-                .willReturn(WireMock.aResponse().withStatus(200).withBody("{\"status\":{}}")));
+        stubStatus("9.5.2");
 
         WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/api/data_views/data_view/" + dataViewId))
                 .inScenario("data-view")
@@ -160,6 +189,15 @@ class KibanaClientTest extends AbstractFSCrawlerTestCase {
         Assertions.assertThat((String) JsonPath.read(payload, "$.id")).isEqualTo("fscrawler-myjob");
         Assertions.assertThat((String) JsonPath.read(payload, "$.title")).isEqualTo("FSCrawler - myjob");
         Assertions.assertThat((List<?>) JsonPath.read(payload, "$.panels")).hasSize(2);
+    }
+
+    private void stubStatus(String version) {
+        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/api/status"))
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"version\":{\"number\":\"" + version
+                                + "\"},\"status\":{\"overall\":{\"level\":\"available\"}}}")));
     }
 
     private FsSettings settingsForWireMock() {

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
         <tests.cluster.url/>
         <tests.cluster.apiKey/>
         <tests.cluster.check_ssl>true</tests.cluster.check_ssl>
+        <tests.kibana.url/>
         <tests.index.prefix/>
         <tests.rest.port>0</tests.rest.port>
         <testcontainers.version>2.0.5</testcontainers.version>
@@ -900,6 +901,7 @@
                             <tests.cluster.url>${tests.cluster.url}</tests.cluster.url>
                             <tests.cluster.apiKey>${tests.cluster.apiKey}</tests.cluster.apiKey>
                             <tests.cluster.check_ssl>${tests.cluster.check_ssl}</tests.cluster.check_ssl>
+                            <tests.kibana.url>${tests.kibana.url}</tests.kibana.url>
                             <tests.index.prefix>${tests.index.prefix}</tests.index.prefix>
                             <tests.rest.port>${tests.rest.port}</tests.rest.port>
                             <tests.leaveTemporary>${tests.leaveTemporary}</tests.leaveTemporary>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <module>beans</module>
         <module>plugin</module>
         <module>elasticsearch-client</module>
+        <module>kibana-client</module>
         <module>core</module>
         <module>plugins</module>
         <module>integration-tests</module>
@@ -179,6 +180,11 @@
             <dependency>
                 <groupId>fr.pilato.elasticsearch.crawler</groupId>
                 <artifactId>fscrawler-elasticsearch-client</artifactId>
+                <version>3.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>fr.pilato.elasticsearch.crawler</groupId>
+                <artifactId>fscrawler-kibana-client</artifactId>
                 <version>3.0-SNAPSHOT</version>
             </dependency>
             <dependency>

--- a/prepare-kibana-dashboard-test.sh
+++ b/prepare-kibana-dashboard-test.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+#
+# Setup script for manual Kibana dashboard testing (issue #2477).
+# Run from the project root. Ensures: Elasticsearch + Kibana check, Maven build,
+# unzip distribution, job config with kibana.push_dashboard, and optionally starts FSCrawler.
+#
+# Prerequisites: Elasticsearch + Kibana (start-local), Java 17+.
+#
+# Example:
+#   ./prepare-kibana-dashboard-test.sh
+#   RUN_FSCRAWLER=1 ./prepare-kibana-dashboard-test.sh
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$SCRIPT_DIR"
+DIST_TARGET="$PROJECT_ROOT/distribution/target"
+DOCS_SOURCE="$PROJECT_ROOT/test-documents/target/classes/documents"
+JOB_NAME="${FSCRAWLER_JOB:-kibana_dashboard_test}"
+ES_URL="${ELASTICSEARCH_URL:-http://127.0.0.1:9200}"
+KIBANA_URL="${KIBANA_URL:-http://127.0.0.1:5601}"
+ES_PASSWORD="${ES_LOCAL_PASSWORD:-changeme}"
+FSCRAWLER_HOME="${FSCRAWLER_HOME:-}"
+
+echo "=== FSCrawler Kibana dashboard test – setup ==="
+echo "  Project root: $PROJECT_ROOT"
+echo "  Job name:     $JOB_NAME"
+echo "  Docs path:    $DOCS_SOURCE"
+echo "  Elasticsearch: $ES_URL"
+echo "  Kibana:       $KIBANA_URL"
+echo ""
+
+# 0. Check Elasticsearch
+echo "--- 0. Check Elasticsearch ---"
+ES_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$ES_URL" 2>/dev/null || echo "000")
+if [ "$ES_STATUS" != "200" ] && [ "$ES_STATUS" != "401" ]; then
+	echo "Elasticsearch does not appear to be running at $ES_URL (got HTTP $ES_STATUS)."
+	echo ""
+	echo "Start Elasticsearch + Kibana with:"
+	echo "  curl -fsSL https://elastic.co/start-local | ES_LOCAL_PASSWORD=\"changeme\" sh"
+	echo ""
+	echo "Then re-run this script."
+	exit 1
+fi
+echo "Elasticsearch is running at $ES_URL"
+
+# 1. Check Kibana
+echo "--- 1. Check Kibana ---"
+KIBANA_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$KIBANA_URL/api/status" 2>/dev/null || echo "000")
+if [ "$KIBANA_STATUS" != "200" ] && [ "$KIBANA_STATUS" != "401" ]; then
+	echo "Kibana does not appear to be running at $KIBANA_URL (got HTTP $KIBANA_STATUS)."
+	echo ""
+	echo "start-local includes Kibana on http://localhost:5601. Wait until it is ready, then re-run."
+	exit 1
+fi
+KIBANA_VERSION=$(curl -s "$KIBANA_URL/api/status" 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin).get('version',{}).get('number',''))" 2>/dev/null || true)
+if [ -n "$KIBANA_VERSION" ]; then
+	echo "Kibana is running at $KIBANA_URL (version $KIBANA_VERSION)"
+	MAJOR=$(echo "$KIBANA_VERSION" | cut -d. -f1)
+	MINOR=$(echo "$KIBANA_VERSION" | cut -d. -f2)
+	if [ "$MAJOR" -lt 9 ] || { [ "$MAJOR" -eq 9 ] && [ "$MINOR" -lt 5 ]; }; then
+		echo "WARNING: Dashboards API requires Kibana 9.5+. FSCrawler will soft-disable dashboard provisioning."
+	fi
+else
+	echo "Kibana is running at $KIBANA_URL"
+fi
+
+# 2. Maven build
+echo "--- 2. Maven build ---"
+if ! [ -d "$DOCS_SOURCE" ]; then
+	echo "Building test-documents and distribution..."
+	mvn clean compile -pl test-documents -q
+	mvn package -DskipTests -pl distribution -am -q
+else
+	echo "Building distribution (test-documents already present)..."
+	mvn package -DskipTests -pl distribution -am -q
+fi
+
+# 3. Unzip distribution
+echo "--- 3. Unzip distribution ---"
+ZIP=$(ls "$DIST_TARGET"/fscrawler*.zip 2>/dev/null | head -1)
+if [ -z "$ZIP" ]; then
+	echo "No zip found in $DIST_TARGET. Run: mvn package -DskipTests -pl distribution -am"
+	exit 1
+fi
+echo "Using: $ZIP"
+cd "$DIST_TARGET"
+unzip -o -q "$(basename "$ZIP")"
+EXTRACTED=$(find . -maxdepth 1 -type d -name 'fscrawler*' ! -name '.' | head -1)
+if [ -z "$EXTRACTED" ]; then
+	EXTRACTED="."
+fi
+FSCRAWLER_HOME="$DIST_TARGET/${EXTRACTED#./}"
+cd "$PROJECT_ROOT"
+echo "FSCrawler home: $FSCRAWLER_HOME"
+
+# 4. Create job config
+echo "--- 4. Create job: $JOB_NAME ---"
+if ! [ -d "$DOCS_SOURCE" ]; then
+	echo "ERROR: Documents dir not found: $DOCS_SOURCE"
+	echo "Run: mvn compile -pl test-documents"
+	exit 1
+fi
+DOCS_ABS=$(cd "$DOCS_SOURCE" && pwd)
+CONFIG_DIR="$FSCRAWLER_HOME/config"
+JOB_DIR="$CONFIG_DIR/$JOB_NAME"
+mkdir -p "$JOB_DIR"
+
+ELASTIC_API_KEY=""
+API_KEY_RESPONSE=$(curl -s -u "elastic:$ES_PASSWORD" -X POST -H "Content-Type: application/json" \
+	-d "{\"name\":\"fscrawler-$JOB_NAME\",\"expiration\":\"7d\"}" \
+	"$ES_URL/_security/api_key" 2>/dev/null || true)
+if command -v jq >/dev/null 2>&1; then
+	ELASTIC_API_KEY=$(echo "$API_KEY_RESPONSE" | jq -r '.encoded // empty')
+elif python3 -c 'import json' 2>/dev/null; then
+	ELASTIC_API_KEY=$(python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('encoded',''))" <<<"$API_KEY_RESPONSE" 2>/dev/null)
+fi
+if [ -z "$ELASTIC_API_KEY" ]; then
+	echo "WARNING: Could not create Elasticsearch API key (check ES_LOCAL_PASSWORD?). Using username/password."
+	ELASTIC_AUTH="  username: \"elastic\"
+  password: \"$ES_PASSWORD\""
+else
+	echo "Elasticsearch API key created for FSCrawler."
+	ELASTIC_AUTH="  api_key: \"$ELASTIC_API_KEY\""
+fi
+
+cat >"$JOB_DIR/_settings.yaml" <<EOF
+name: "$JOB_NAME"
+
+fs:
+  url: "$DOCS_ABS"
+  update_rate: "15m"
+  index_content: true
+  index_folders: true
+
+elasticsearch:
+  urls: ["$ES_URL"]
+$ELASTIC_AUTH
+
+kibana:
+  url: "$KIBANA_URL"
+EOF
+echo "Job config: $JOB_DIR/_settings.yaml"
+echo "Config dir: $CONFIG_DIR"
+
+DASHBOARD_ID="fscrawler-$JOB_NAME"
+echo ""
+echo "After the crawl, open:"
+echo "  $KIBANA_URL/app/dashboards"
+echo "  Dashboard id: $DASHBOARD_ID"
+echo "  Title:        FSCrawler - $JOB_NAME"
+echo ""
+
+# 5. Launch FSCrawler (optional)
+echo "--- 5. Launch FSCrawler (loop 1) ---"
+echo "To start FSCrawler run:"
+echo "  $FSCRAWLER_HOME/bin/fscrawler $JOB_NAME --loop 1 --config_dir $CONFIG_DIR"
+echo ""
+if [ "${RUN_FSCRAWLER:-0}" = "1" ]; then
+	echo "Starting FSCrawler (RUN_FSCRAWLER=1)..."
+	exec "$FSCRAWLER_HOME/bin/fscrawler" "$JOB_NAME" --loop 1 --config_dir "$CONFIG_DIR"
+else
+	echo "Setup done. Set RUN_FSCRAWLER=1 to start automatically, or run the command above."
+fi

--- a/prepare-kibana-dashboard-test.sh
+++ b/prepare-kibana-dashboard-test.sh
@@ -140,6 +140,7 @@ $ELASTIC_AUTH
 
 kibana:
   url: "$KIBANA_URL"
+  force_push_dashboard: true
 EOF
 echo "Job config: $JOB_DIR/_settings.yaml"
 echo "Config dir: $CONFIG_DIR"

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsCrawlerValidator.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsCrawlerValidator.java
@@ -79,6 +79,10 @@ public class FsCrawlerValidator {
             return true;
         }
 
+        if (validateKibanaSettings(logger, settings)) {
+            return true;
+        }
+
         // We just warn the user if he is running on Windows but want to get attributes
         if (OsValidator.WINDOWS && settings.getFs().isAttributesSupport()) {
             logger.info(
@@ -158,6 +162,26 @@ public class FsCrawlerValidator {
             logger.error(
                     "Hash algorithm [{}] not found. Disabling crawler",
                     settings.getFs().getHashAlgorithm());
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean validateKibanaSettings(Logger logger, FsSettings settings) {
+        Kibana kibana = settings.getKibana();
+        if (kibana == null || !kibana.isPushDashboard()) {
+            return false;
+        }
+        if (FsCrawlerUtil.isNullOrEmpty(kibana.getUrl())) {
+            logger.error("kibana.url must be set when kibana.push_dashboard is true. Disabling crawler");
+            return true;
+        }
+        Elasticsearch elasticsearch = settings.getElasticsearch();
+        if (FsCrawlerUtil.isNullOrEmpty(kibana.getApiKey())
+                && FsCrawlerUtil.isNullOrEmpty(elasticsearch.getApiKey())
+                && FsCrawlerUtil.isNullOrEmpty(elasticsearch.getUsername())) {
+            logger.error("kibana.push_dashboard is enabled but no credentials were found. "
+                    + "Set elasticsearch.api_key or kibana.api_key. Disabling crawler");
             return true;
         }
         return false;

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsCrawlerValidator.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsCrawlerValidator.java
@@ -173,16 +173,19 @@ public class FsCrawlerValidator {
             return false;
         }
         if (FsCrawlerUtil.isNullOrEmpty(kibana.getUrl())) {
-            logger.error("kibana.url must be set when kibana.push_dashboard is true. Disabling crawler");
-            return true;
+            logger.warn("kibana.push_dashboard is enabled but kibana.url is not set. "
+                    + "Disabling dashboard provisioning.");
+            kibana.setPushDashboard(false);
+            return false;
         }
         Elasticsearch elasticsearch = settings.getElasticsearch();
         if (FsCrawlerUtil.isNullOrEmpty(kibana.getApiKey())
                 && FsCrawlerUtil.isNullOrEmpty(elasticsearch.getApiKey())
                 && FsCrawlerUtil.isNullOrEmpty(elasticsearch.getUsername())) {
-            logger.error("kibana.push_dashboard is enabled but no credentials were found. "
-                    + "Set elasticsearch.api_key or kibana.api_key. Disabling crawler");
-            return true;
+            logger.warn("kibana.push_dashboard is enabled but no credentials were found. "
+                    + "Set elasticsearch.api_key or kibana.api_key. Disabling dashboard provisioning.");
+            kibana.setPushDashboard(false);
+            return false;
         }
         return false;
     }

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettings.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettings.java
@@ -32,6 +32,7 @@ public class FsSettings {
     private Elasticsearch elasticsearch;
     private Rest rest;
     private Tags tags;
+    private Kibana kibana;
 
     public String getName() {
         return name;
@@ -89,6 +90,14 @@ public class FsSettings {
         this.tags = tags;
     }
 
+    public Kibana getKibana() {
+        return kibana;
+    }
+
+    public void setKibana(Kibana kibana) {
+        this.kibana = kibana;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -102,6 +111,7 @@ public class FsSettings {
         if (!Objects.equals(server, that.server)) return false;
         if (!Objects.equals(rest, that.rest)) return false;
         if (!Objects.equals(tags, that.tags)) return false;
+        if (!Objects.equals(kibana, that.kibana)) return false;
         return Objects.equals(elasticsearch, that.elasticsearch);
     }
 
@@ -113,6 +123,7 @@ public class FsSettings {
         result = 31 * result + (server != null ? server.hashCode() : 0);
         result = 31 * result + (rest != null ? rest.hashCode() : 0);
         result = 31 * result + (tags != null ? tags.hashCode() : 0);
+        result = 31 * result + (kibana != null ? kibana.hashCode() : 0);
         result = 31 * result + (elasticsearch != null ? elasticsearch.hashCode() : 0);
         return result;
     }
@@ -125,6 +136,7 @@ public class FsSettings {
                 + server + ", elasticsearch="
                 + elasticsearch + ", rest="
                 + rest + ", tags="
-                + tags + '}';
+                + tags + ", kibana="
+                + kibana + '}';
     }
 }

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsLoader.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsLoader.java
@@ -172,6 +172,7 @@ public class FsSettingsLoader extends MetaFileHandler {
             settings.setTags(gestalt.getConfigOptional("tags", Tags.class).orElse(null));
             settings.setServer(gestalt.getConfigOptional("server", Server.class).orElse(null));
             settings.setRest(gestalt.getConfigOptional("rest", Rest.class).orElse(null));
+            settings.setKibana(gestalt.getConfigOptional("kibana", Kibana.class).orElse(null));
 
             logger.debug(
                     "Successfully loaded settings from classpath [fscrawler-default.properties] and files {}",

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Kibana.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Kibana.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
+ */
+package fr.pilato.elasticsearch.crawler.fs.settings;
+
+import jakarta.annotation.Nullable;
+import java.util.Objects;
+import org.github.gestalt.config.annotations.Config;
+
+public class Kibana {
+
+    @Config(defaultVal = Defaults.KIBANA_URL_DEFAULT)
+    @Nullable
+    private String url;
+
+    /** When {@code true}, FSCrawler creates or updates a default Kibana dashboard for this job on startup. */
+    @Config(defaultVal = "false")
+    private boolean pushDashboard;
+
+    /** Optional Kibana space id. When unset, the default space is used. */
+    @Config
+    @Nullable
+    private String space;
+
+    /** Optional API key for Kibana. When unset, {@link Elasticsearch#getApiKey()} is used. */
+    @Config
+    @Nullable
+    private String apiKey;
+
+    @Nullable
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(@Nullable String url) {
+        this.url = url;
+    }
+
+    public boolean isPushDashboard() {
+        return pushDashboard;
+    }
+
+    public void setPushDashboard(boolean pushDashboard) {
+        this.pushDashboard = pushDashboard;
+    }
+
+    @Nullable
+    public String getSpace() {
+        return space;
+    }
+
+    public void setSpace(@Nullable String space) {
+        this.space = space;
+    }
+
+    @Nullable
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public void setApiKey(@Nullable String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Kibana kibana = (Kibana) o;
+
+        if (pushDashboard != kibana.pushDashboard) return false;
+        if (!Objects.equals(url, kibana.url)) return false;
+        if (!Objects.equals(space, kibana.space)) return false;
+        return Objects.equals(apiKey, kibana.apiKey);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = url != null ? url.hashCode() : 0;
+        result = 31 * result + (pushDashboard ? 1 : 0);
+        result = 31 * result + (space != null ? space.hashCode() : 0);
+        result = 31 * result + (apiKey != null ? apiKey.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Kibana{" + "url='" + url + '\'' + ", pushDashboard=" + pushDashboard + ", space='" + space + '\''
+                + ", apiKey='" + apiKey + '\'' + '}';
+    }
+}

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Kibana.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Kibana.java
@@ -31,8 +31,15 @@ public class Kibana {
     private String url;
 
     /** When {@code true}, FSCrawler creates or updates a default Kibana dashboard for this job on startup. */
-    @Config(defaultVal = "false")
+    @Config(defaultVal = "true")
     private boolean pushDashboard;
+
+    /**
+     * When {@code true}, overwrite an existing FSCrawler dashboard on startup. When {@code false} (default), skip
+     * creation if the dashboard already exists — same pattern as {@code elasticsearch.force_push_templates}.
+     */
+    @Config(defaultVal = "false")
+    private boolean forcePushDashboard;
 
     /** Optional Kibana space id. When unset, the default space is used. */
     @Config
@@ -61,6 +68,14 @@ public class Kibana {
         this.pushDashboard = pushDashboard;
     }
 
+    public boolean isForcePushDashboard() {
+        return forcePushDashboard;
+    }
+
+    public void setForcePushDashboard(boolean forcePushDashboard) {
+        this.forcePushDashboard = forcePushDashboard;
+    }
+
     @Nullable
     public String getSpace() {
         return space;
@@ -87,6 +102,7 @@ public class Kibana {
         Kibana kibana = (Kibana) o;
 
         if (pushDashboard != kibana.pushDashboard) return false;
+        if (forcePushDashboard != kibana.forcePushDashboard) return false;
         if (!Objects.equals(url, kibana.url)) return false;
         if (!Objects.equals(space, kibana.space)) return false;
         return Objects.equals(apiKey, kibana.apiKey);
@@ -96,6 +112,7 @@ public class Kibana {
     public int hashCode() {
         int result = url != null ? url.hashCode() : 0;
         result = 31 * result + (pushDashboard ? 1 : 0);
+        result = 31 * result + (forcePushDashboard ? 1 : 0);
         result = 31 * result + (space != null ? space.hashCode() : 0);
         result = 31 * result + (apiKey != null ? apiKey.hashCode() : 0);
         return result;
@@ -103,7 +120,11 @@ public class Kibana {
 
     @Override
     public String toString() {
-        return "Kibana{" + "url='" + url + '\'' + ", pushDashboard=" + pushDashboard + ", space='" + space + '\''
-                + ", apiKey='" + apiKey + '\'' + '}';
+        return "Kibana{" + "url='"
+                + url + '\'' + ", pushDashboard="
+                + pushDashboard + ", forcePushDashboard="
+                + forcePushDashboard + ", space='"
+                + space + '\'' + ", apiKey='"
+                + apiKey + '\'' + '}';
     }
 }

--- a/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/settings/fscrawler-default.properties
+++ b/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/settings/fscrawler-default.properties
@@ -56,3 +56,8 @@ elasticsearch.ssl_verification=true
 # rest object
 rest.url=http://127.0.0.1:8080
 rest.enable_cors=false
+
+# kibana object
+kibana.url=http://127.0.0.1:5601
+kibana.push_dashboard=true
+kibana.force_push_dashboard=false

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsCrawlerValidatorTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsCrawlerValidatorTest.java
@@ -150,22 +150,34 @@ class FsCrawlerValidatorTest extends AbstractFSCrawlerTestCase {
         Assertions.assertThat(FsCrawlerValidator.validateSettings(logger, settings))
                 .isFalse();
 
-        // kibana.push_dashboard requires url and credentials
+        // kibana.push_dashboard defaults to true; missing url/credentials soft-disable provisioning
         settings = FsSettingsLoader.load();
         Kibana kibana = new Kibana();
         kibana.setPushDashboard(true);
         settings.setKibana(kibana);
         Assertions.assertThat(FsCrawlerValidator.validateSettings(logger, settings))
-                .isTrue();
+                .isFalse();
+        Assertions.assertThat(settings.getKibana().isPushDashboard()).isFalse();
 
-        settings.getKibana().setUrl("http://127.0.0.1:5601");
+        settings = FsSettingsLoader.load();
+        kibana = new Kibana();
+        kibana.setPushDashboard(true);
+        kibana.setUrl("http://127.0.0.1:5601");
+        settings.setKibana(kibana);
         settings.getElasticsearch().setApiKey(null);
         settings.getElasticsearch().setUsername(null);
         Assertions.assertThat(FsCrawlerValidator.validateSettings(logger, settings))
-                .isTrue();
+                .isFalse();
+        Assertions.assertThat(settings.getKibana().isPushDashboard()).isFalse();
 
+        settings = FsSettingsLoader.load();
+        kibana = new Kibana();
+        kibana.setPushDashboard(true);
+        kibana.setUrl("http://127.0.0.1:5601");
+        settings.setKibana(kibana);
         settings.getElasticsearch().setApiKey("test-api-key");
         Assertions.assertThat(FsCrawlerValidator.validateSettings(logger, settings))
                 .isFalse();
+        Assertions.assertThat(settings.getKibana().isPushDashboard()).isTrue();
     }
 }

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsCrawlerValidatorTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsCrawlerValidatorTest.java
@@ -149,5 +149,23 @@ class FsCrawlerValidatorTest extends AbstractFSCrawlerTestCase {
         settings.getElasticsearch().setBulkOperation(BulkOperation.INDEX);
         Assertions.assertThat(FsCrawlerValidator.validateSettings(logger, settings))
                 .isFalse();
+
+        // kibana.push_dashboard requires url and credentials
+        settings = FsSettingsLoader.load();
+        Kibana kibana = new Kibana();
+        kibana.setPushDashboard(true);
+        settings.setKibana(kibana);
+        Assertions.assertThat(FsCrawlerValidator.validateSettings(logger, settings))
+                .isTrue();
+
+        settings.getKibana().setUrl("http://127.0.0.1:5601");
+        settings.getElasticsearch().setApiKey(null);
+        settings.getElasticsearch().setUsername(null);
+        Assertions.assertThat(FsCrawlerValidator.validateSettings(logger, settings))
+                .isTrue();
+
+        settings.getElasticsearch().setApiKey("test-api-key");
+        Assertions.assertThat(FsCrawlerValidator.validateSettings(logger, settings))
+                .isFalse();
     }
 }

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsLoaderTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsLoaderTest.java
@@ -276,6 +276,16 @@ class FsSettingsLoaderTest extends AbstractFSCrawlerTestCase {
     // System properties set here (name, fs.url, fs.xml_support) are cleared before and after each test by
     // cleanupSystemProperties(), so no per-test save/restore is needed.
     @Test
+    void loadYamlKibana() throws IOException {
+        FsSettings settings = new FsSettingsLoader(configPath).read("yaml-kibana");
+        Assertions.assertThat(settings.getKibana()).isNotNull();
+        Assertions.assertThat(settings.getKibana().getUrl()).isEqualTo("http://127.0.0.1:5601");
+        Assertions.assertThat(settings.getKibana().isPushDashboard()).isTrue();
+        Assertions.assertThat(settings.getKibana().getSpace()).isEqualTo("default");
+        Assertions.assertThat(settings.getKibana().getApiKey()).isEqualTo("test-kibana-api-key");
+    }
+
+    @Test
     void withDefaultNamesForEnvVariables() throws Exception {
         System.setProperty("name", "foo");
         System.setProperty("fs.url", "/tmp/test");

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsLoaderTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsLoaderTest.java
@@ -215,6 +215,7 @@ class FsSettingsLoaderTest extends AbstractFSCrawlerTestCase {
                 .as("Checking Elasticsearch")
                 .isEqualTo(expected.getElasticsearch());
         Assertions.assertThat(settings.getRest()).as("Checking Rest").isEqualTo(expected.getRest());
+        Assertions.assertThat(settings.getKibana()).as("Checking Kibana").isEqualTo(expected.getKibana());
         Assertions.assertThat(settings).as("Checking whole settings").isEqualTo(expected);
     }
 
@@ -269,6 +270,12 @@ class FsSettingsLoaderTest extends AbstractFSCrawlerTestCase {
         rest.setUrl("http://127.0.0.1:8080");
         rest.setEnableCors(false);
         expected.setRest(rest);
+
+        Kibana kibana = new Kibana();
+        kibana.setUrl("http://127.0.0.1:5601");
+        kibana.setPushDashboard(true);
+        kibana.setForcePushDashboard(false);
+        expected.setKibana(kibana);
 
         return expected;
     }

--- a/settings/src/test/resources/config/yaml-kibana/_settings.yaml
+++ b/settings/src/test/resources/config/yaml-kibana/_settings.yaml
@@ -1,0 +1,6 @@
+name: yaml-kibana
+kibana:
+  url: http://127.0.0.1:5601
+  push_dashboard: true
+  space: default
+  api_key: test-kibana-api-key


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Provisions a default Kibana dashboard via the Dashboards API when Kibana ≥ 9.5 (issue #2477)
- Soft-fails dashboard push; supports `force_push_dashboard`
- Enriched panels: intro/runtime markdown, metrics, directories treemaps, Discover session, metadata

## Test plan
- [ ] CI green on PR
- [ ] Dashboard IT against Kibana ≥ 9.5


<img width="1602" height="3044" alt="fscrawler-kibana-dashboard" src="https://github.com/user-attachments/assets/cbef940b-3916-48d2-97ce-f73e3f5e77a6" />

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-768b9131-2513-42df-8900-a42cb738cc65?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-768b9131-2513-42df-8900-a42cb738cc65&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

