### PR TITLE
feat(settings): exclude .DS_Store by default

### DIFF
--- a/docs/source/admin/fs/index.md
+++ b/docs/source/admin/fs/index.md
@@ -94,7 +94,7 @@ fs:
   # scan every 5 minutes for changes in url defined above
   update_rate: "5m"
 
-  # opional: define includes and excludes, "~" files are excluded by default if not defined below
+  # optional: define includes and excludes; "~" and ".DS_Store" files are excluded by default if not defined below
   includes:
   - "*.doc"
   - "*.xls"

--- a/docs/source/admin/fs/local-fs.md
+++ b/docs/source/admin/fs/local-fs.md
@@ -13,7 +13,7 @@ Here is a list of Local FS settings (under `fs.` prefix):
 | `fs.url`                 | `FSCRAWLER_FS_URL`                 | `"/tmp/es"`     | [Root directory](#root-directory)                       |
 | `fs.update_rate`         | `FSCRAWLER_FS_UPDATE_RATE`         | `"15m"`         | [Update Rate](#update-rate)                             |
 | `fs.includes`            | `FSCRAWLER_FS_INCLUDES`            | `null`          | [Includes and excludes](#includes-and-excludes)         |
-| `fs.excludes`            | `FSCRAWLER_FS_EXCLUDES`            | `["*/~*"]`      | [Includes and excludes](#includes-and-excludes)         |
+| `fs.excludes`            | `FSCRAWLER_FS_EXCLUDES`            | `["*/~*", "*/.ds_store"]` | [Includes and excludes](#includes-and-excludes)         |
 | `fs.filters`             | `FSCRAWLER_FS_FILTERS`             | `null`          | [Filter content](#filter-content)                       |
 | `fs.json_support`        | `FSCRAWLER_FS_JSON_SUPPORT`        | `false`         | [Indexing JSON docs](#indexing-json-docs)               |
 | `fs.xml_support`         | `FSCRAWLER_FS_XML_SUPPORT`         | `false`         | [Indexing XML docs](#indexing-xml-docs)                 |
@@ -163,7 +163,8 @@ fs:
   - "*/resume*"
 ```
 
-By default, FSCrawler will exclude files starting with `~`.
+By default, FSCrawler will exclude files starting with `~` and macOS Finder
+metadata files named `.DS_Store` (matched case-insensitively via `*/.ds_store`).
 
 It also applies to directory names. So if you want to ignore `.ignore`
 dir, just add `.ignore` as an excluded name. Note that `includes` and `excludes`

--- a/docs/source/admin/fs/rest.md
+++ b/docs/source/admin/fs/rest.md
@@ -65,7 +65,7 @@ It will give you a response similar to:
       "add_filesize" : true,
       "attributes_support" : false,
       "continue_on_error" : false,
-      "excludes" : [ "*/~*" ],
+      "excludes" : [ "*/~*", "*/.ds_store" ],
       "filename_as_id" : false,
       "follow_symlinks" : false,
       "index_content" : true,

--- a/docs/source/release/3.0.md
+++ b/docs/source/release/3.0.md
@@ -40,6 +40,9 @@
 
 ## New
 
+- Default `fs.excludes` now also skips macOS Finder metadata files (`.DS_Store`), via the
+  case-insensitive pattern `*/.ds_store`, in addition to `*/~*`. See {ref}`includes_excludes`.
+  Thanks to dadoonet.
 - The crawler system has been unified using a plugin architecture. You can now specify the crawler provider using
   `fs.provider` instead of `server.protocol`. Available providers are `local` (default), `ftp`, and `ssh`.
   See {ref}`crawler-provider`. Thanks to dadoonet.

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Defaults.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Defaults.java
@@ -20,12 +20,11 @@
  */
 package fr.pilato.elasticsearch.crawler.fs.settings;
 
-import java.util.Collections;
 import java.util.List;
 
 public class Defaults {
     public static final String DEFAULT_DIR = "/tmp/es";
-    public static final List<String> DEFAULT_EXCLUDED = Collections.singletonList("*/~*");
+    public static final List<String> DEFAULT_EXCLUDED = List.of("*/~*", "*/.ds_store");
     public static final String ELASTICSEARCH_URL_DEFAULT = "https://127.0.0.1:9200";
     public static final String DEFAULT_META_FILENAME = ".meta.yml";
     public static final String REST_URL_DEFAULT = "http://127.0.0.1:8080/fscrawler";

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Fs.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/Fs.java
@@ -42,7 +42,7 @@ public class Fs {
     @Nullable
     private List<String> includes;
 
-    @Config(defaultVal = "*/~*")
+    @Config(defaultVal = "*/~*,*/.ds_store")
     private List<String> excludes;
 
     @Config

--- a/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsCrawlerValidator.java
+++ b/settings/src/main/java/fr/pilato/elasticsearch/crawler/fs/settings/FsCrawlerValidator.java
@@ -32,8 +32,9 @@ public class FsCrawlerValidator {
     @SuppressWarnings("java:S2068")
     private static final String SIDECAR_SUFFIX = "password";
 
-    private static final List<String> DOCUMENT_SIDECAR_EXCLUDES =
-            List.of("*." + SIDECAR_SUFFIX, "*/." + SIDECAR_SUFFIX);
+    /** Patterns always merged into {@code fs.excludes} during validation when missing. */
+    private static final List<String> BUILTIN_EXCLUDES =
+            List.of("*." + SIDECAR_SUFFIX, "*/." + SIDECAR_SUFFIX, "*/.ds_store");
 
     private FsCrawlerValidator() {
         // Utility class, do not instantiate
@@ -47,7 +48,7 @@ public class FsCrawlerValidator {
      * @return true if we found fatal errors and should prevent from starting
      */
     public static boolean validateSettings(Logger logger, FsSettings settings) {
-        ensurePasswordSidecarExcludes(settings);
+        ensureBuiltinExcludes(settings);
 
         if (settings.getElasticsearch().getUsername() != null
                 || settings.getElasticsearch().getPassword() != null) {
@@ -92,24 +93,23 @@ public class FsCrawlerValidator {
     }
 
     /**
-     * Ensure password sidecar files are never crawled as documents.
+     * Ensure built-in exclude patterns are present.
      *
-     * <p>The disk password provider stores secrets next to documents as {@code <file>.password} or directory
-     * {@code .password} files. Those must stay out of the index, so this method merges the built-in sidecar exclude
-     * patterns ({@link #DOCUMENT_SIDECAR_EXCLUDES}) into {@code fs.excludes} when missing. Existing excludes are
-     * preserved; the list is rewritten only when something is added (including when {@code fs.excludes} was
-     * {@code null}).
+     * <p>Merges password sidecar patterns ({@code *.password}, directory {@code .password} files) and the macOS Finder
+     * metadata pattern for {@code .DS_Store} files (matched case-insensitively) into {@code fs.excludes} when missing.
+     * Existing excludes are preserved; the list is rewritten only when something is added (including when
+     * {@code fs.excludes} was {@code null}).
      *
      * @param settings settings mutated in place during validation
      */
-    private static void ensurePasswordSidecarExcludes(FsSettings settings) {
+    private static void ensureBuiltinExcludes(FsSettings settings) {
         List<String> excludes = settings.getFs().getExcludes();
         List<String> mergedExcludes = excludes == null ? new ArrayList<>() : new ArrayList<>(excludes);
         boolean updated = excludes == null;
 
-        for (String passwordSidecarExclude : DOCUMENT_SIDECAR_EXCLUDES) {
-            if (!mergedExcludes.contains(passwordSidecarExclude)) {
-                mergedExcludes.add(passwordSidecarExclude);
+        for (String builtinExclude : BUILTIN_EXCLUDES) {
+            if (!mergedExcludes.contains(builtinExclude)) {
+                mergedExcludes.add(builtinExclude);
                 updated = true;
             }
         }

--- a/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/settings/fscrawler-default.properties
+++ b/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/settings/fscrawler-default.properties
@@ -5,6 +5,7 @@ name=fscrawler
 fs.url=/tmp/es
 fs.update_rate=15m
 fs.excludes[0]=*/~*
+fs.excludes[1]=*/.ds_store
 fs.json_support=false
 fs.xml_support=false
 fs.add_as_inner_object=false

--- a/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/settings/fscrawler-default.yaml
+++ b/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/settings/fscrawler-default.yaml
@@ -7,7 +7,7 @@ fs:
   #url: "/tmp/es"
   # optional: scan every 15 minutes for changes in url defined above
   #update_rate: "15m"
-  # optional: define includes and excludes, "~" files are excluded by default if not defined below
+  # optional: define includes and excludes; "~" and ".DS_Store" files are excluded by default if not defined below
   #includes:
   #  - "*.doc"
   #  - "*.xls"

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsCrawlerValidatorTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsCrawlerValidatorTest.java
@@ -38,12 +38,15 @@ class FsCrawlerValidatorTest extends AbstractFSCrawlerTestCase {
 
         Assertions.assertThat(FsCrawlerValidator.validateSettings(logger, settings))
                 .isFalse();
-        Assertions.assertThat(settings.getFs().getExcludes()).contains("*.password", "*/.password");
+        Assertions.assertThat(settings.getFs().getExcludes()).contains("*.password", "*/.password", "*/.ds_store");
         Assertions.assertThat(FsCrawlerUtil.isExcluded(
                         "foo.txt.password", settings.getFs().getExcludes()))
                 .isTrue();
         Assertions.assertThat(FsCrawlerUtil.isExcluded(
                         "foo/.password", settings.getFs().getExcludes()))
+                .isTrue();
+        Assertions.assertThat(FsCrawlerUtil.isExcluded(
+                        "subdir/.DS_Store", settings.getFs().getExcludes()))
                 .isTrue();
         Assertions.assertThat(
                         FsCrawlerUtil.isExcluded("foo.txt", settings.getFs().getExcludes()))

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsMatchFilesTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsMatchFilesTest.java
@@ -38,5 +38,20 @@ class FsMatchFilesTest extends AbstractFSCrawlerTestCase {
                 .isTrue();
         Assertions.assertThat(FsCrawlerUtil.isIndexable(false, "/mydoc~", new ArrayList<>(), Defaults.DEFAULT_EXCLUDED))
                 .isTrue();
+
+        // macOS Finder metadata — matching is case-insensitive, pattern is lowercase
+        Assertions.assertThat(Defaults.DEFAULT_EXCLUDED).contains("*/.ds_store");
+        Assertions.assertThat(
+                        FsCrawlerUtil.isIndexable(false, "/.DS_Store", new ArrayList<>(), Defaults.DEFAULT_EXCLUDED))
+                .isFalse();
+        Assertions.assertThat(FsCrawlerUtil.isIndexable(
+                        false, "/subdir/.DS_Store", new ArrayList<>(), Defaults.DEFAULT_EXCLUDED))
+                .isFalse();
+        Assertions.assertThat(FsCrawlerUtil.isIndexable(
+                        false, "/subdir/.ds_store", new ArrayList<>(), Defaults.DEFAULT_EXCLUDED))
+                .isFalse();
+        Assertions.assertThat(
+                        FsCrawlerUtil.isIndexable(false, "/DS_Store", new ArrayList<>(), Defaults.DEFAULT_EXCLUDED))
+                .isTrue();
     }
 }

--- a/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsLoaderTest.java
+++ b/settings/src/test/java/fr/pilato/elasticsearch/crawler/fs/settings/FsSettingsLoaderTest.java
@@ -132,7 +132,7 @@ class FsSettingsLoaderTest extends AbstractFSCrawlerTestCase {
         expected.getFs().setUrl("/path/to/docs");
         expected.getFs().setUpdateRate(TimeValue.timeValueMinutes(5));
         expected.getFs().setIncludes(List.of("*.doc", "*.xls"));
-        expected.getFs().setExcludes(List.of("resume.doc"));
+        expected.getFs().setExcludes(List.of("resume.doc", "*/.ds_store"));
         expected.getFs().setFilters(List.of(".*foo.*", "^4\\d{3}([\\ \\-]?)\\d{4}\\1\\d{4}\\1\\d{4}$"));
         expected.getFs().setJsonSupport(true);
         expected.getFs().setAddAsInnerObject(true);
@@ -222,7 +222,7 @@ class FsSettingsLoaderTest extends AbstractFSCrawlerTestCase {
         Fs fs = new Fs();
         fs.setUrl("/tmp/es");
         fs.setUpdateRate(TimeValue.timeValueMinutes(15));
-        fs.setExcludes(List.of("*/~*"));
+        fs.setExcludes(List.of("*/~*", "*/.ds_store"));
         fs.setRemoveDeleted(true);
         fs.setIndexContent(true);
         fs.setAddFilesize(true);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds macOS Finder metadata files to FSCrawler default excludes.

- Pattern: `*/.ds_store` (lowercase) — matching is already case-insensitive, so `.DS_Store` is covered
- Present in `Defaults.DEFAULT_EXCLUDED`, Gestalt defaults, and `fscrawler-default.properties`
- Also merged during validation (same approach as password sidecar excludes), so custom `fs.excludes` still get it unless already listed

## Test plan

- [x] `FsMatchFilesTest#default_ignored_file`
- [x] `FsSettingsLoaderTest`
- [x] `FsCrawlerValidatorTest`
- [ ] CI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-768b9131-2513-42df-8900-a42cb738cc65?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-768b9131-2513-42df-8900-a42cb738cc65&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

