### PR TITLE
fix(es-client): surface clear bulk/retry error details at WARN

### DIFF
--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -34,7 +34,6 @@ import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.ProcessingException;
-import jakarta.ws.rs.ServiceUnavailableException;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
@@ -353,7 +352,8 @@ public class ElasticsearchClient implements IElasticsearchClient {
                 logger.error(
                         "Bulk request failed after retries ({} actions): {}",
                         request.numberOfActions(),
-                        response.getException().getMessage());
+                        response.getException().getMessage(),
+                        response.getException());
                 recordFatalBulkFailure(response.getException());
             }
         }
@@ -366,7 +366,8 @@ public class ElasticsearchClient implements IElasticsearchClient {
                     request.numberOfActions(),
                     failure.getMessage() != null
                             ? failure.getMessage()
-                            : failure.getClass().getName());
+                            : failure.getClass().getName(),
+                    failure);
             Exception asException = failure instanceof Exception e
                     ? e
                     : new ElasticsearchClientException("Bulk request failed", failure);
@@ -1238,11 +1239,8 @@ public class ElasticsearchClient implements IElasticsearchClient {
         } catch (NotFoundException e) {
             logger.debug("index {} does not exist.", request.getIndex());
             throw new ElasticsearchIndexNotFoundException(request.getIndex());
-        } catch (ServiceUnavailableException e) {
-            logger.warn(
-                    "search on index [{}] still unavailable after retries ({}). Shards may not be allocated yet.",
-                    request.getIndex(),
-                    e.getResponse().getStatus());
+        } catch (ElasticsearchClientException e) {
+            logger.warn("search on index [{}] failed after retries: {}", request.getIndex(), e.getMessage());
             throw e;
         }
     }
@@ -1659,7 +1657,8 @@ public class ElasticsearchClient implements IElasticsearchClient {
             boolean handle429,
             Map.Entry<String, Object>... params)
             throws ElasticsearchClientException {
-        AtomicReference<WebApplicationException> lastServerError = new AtomicReference<>();
+        AtomicReference<Throwable> lastError = new AtomicReference<>();
+        AtomicReference<String> lastErrorDetail = new AtomicReference<>();
 
         try {
             String result = Awaitility.await()
@@ -1681,12 +1680,14 @@ public class ElasticsearchClient implements IElasticsearchClient {
 
                                     // Handle server errors (5xx) - always retry
                                     if (isServerError) {
+                                        String detail = describeHttpError(e);
                                         logger.warn(
-                                                "Server error {} on {} {}. Retrying...",
-                                                status,
+                                                "Server error on {} {}. {}. Retrying...",
                                                 method,
-                                                path == null ? "" : path);
-                                        lastServerError.set(e);
+                                                path == null ? "" : path,
+                                                detail);
+                                        lastError.set(e);
+                                        lastErrorDetail.set(detail);
                                         return null;
                                     }
 
@@ -1694,12 +1695,15 @@ public class ElasticsearchClient implements IElasticsearchClient {
                                     if (isTooManyRequests) {
                                         if (handle429) {
                                             // We're already in 429 retry mode, continue retrying
+                                            String detail = describeHttpError(e);
                                             logger.warn(
-                                                    "Rate limited (429) on {} {}. Retrying in up to {}...",
+                                                    "Rate limited (429) on {} {}. {}. Retrying in up to {}...",
                                                     method,
                                                     path == null ? "" : path,
+                                                    detail,
                                                     maxDelay);
-                                            lastServerError.set(e);
+                                            lastError.set(e);
+                                            lastErrorDetail.set(detail);
                                             return null;
                                         } else {
                                             // Signal to switch to 429 retry mode
@@ -1711,6 +1715,11 @@ public class ElasticsearchClient implements IElasticsearchClient {
                                     throw new RuntimeException(e);
                                 } catch (ElasticsearchClientException e) {
                                     // Connection errors should not be retried (httpCall already handles node failover)
+                                    lastError.set(e);
+                                    lastErrorDetail.set(
+                                            e.getMessage() != null
+                                                    ? e.getMessage()
+                                                    : e.getClass().getName());
                                     throw new RuntimeException(e);
                                 }
                             },
@@ -1718,17 +1727,18 @@ public class ElasticsearchClient implements IElasticsearchClient {
             // Convert marker back to null for HEAD requests
             return SUCCESS_MARKER.equals(result) ? null : result;
         } catch (ConditionTimeoutException e) {
+            String detail =
+                    lastErrorDetail.get() != null ? lastErrorDetail.get() : formatLastRetryError(lastError.get());
             logger.error(
                     "Retries exhausted for {} {} after {}. Last error: {}",
                     method,
                     path == null ? "" : path,
                     maxDuration,
-                    lastServerError.get() != null ? lastServerError.get().getMessage() : "unknown");
-            if (lastServerError.get() != null) {
-                throw lastServerError.get();
-            }
+                    detail);
+            Throwable cause = lastError.get() != null ? lastError.get() : e;
             throw new ElasticsearchClientException(
-                    "Retries exhausted for " + method + " " + (path == null ? "" : path), e);
+                    "Retries exhausted for " + method + " " + (path == null ? "" : path) + ". Last error: " + detail,
+                    cause);
         } catch (RateLimitedException e) {
             // Propagate to switch retry configuration
             throw e;
@@ -1744,6 +1754,69 @@ public class ElasticsearchClient implements IElasticsearchClient {
         }
     }
 
+    /**
+     * Build a short, user-visible description of an HTTP error (status + reason + response body when available).
+     *
+     * <p>Reads the response entity once; subsequent reads may be empty.
+     */
+    static String describeHttpError(WebApplicationException e) {
+        Response response = e.getResponse();
+        int status = response.getStatus();
+        String reason =
+                response.getStatusInfo() != null ? response.getStatusInfo().getReasonPhrase() : null;
+        String body = readResponseBodySafely(response);
+        if (body != null) {
+            body = body.strip();
+        }
+        StringBuilder detail = new StringBuilder();
+        detail.append("HTTP ").append(status);
+        if (reason != null && !reason.isBlank()) {
+            detail.append(' ').append(reason);
+        }
+        if (body != null && !body.isBlank()) {
+            detail.append(": ").append(truncateForLog(body, 500));
+        }
+        return detail.toString();
+    }
+
+    private static String formatLastRetryError(Throwable lastError) {
+        if (lastError == null) {
+            return "no response received within the retry window (request may still have been in flight)";
+        }
+        if (lastError instanceof WebApplicationException wae) {
+            // Entity may already have been consumed; fall back to message if body is gone.
+            String described = describeHttpError(wae);
+            if (described.contains(": ")) {
+                return described;
+            }
+            String message = wae.getMessage();
+            return message != null && !message.isBlank() ? message : described;
+        }
+        String message = lastError.getMessage();
+        if (message != null && !message.isBlank()) {
+            return message;
+        }
+        return lastError.getClass().getName();
+    }
+
+    private static String readResponseBodySafely(Response response) {
+        try {
+            if (response != null && response.hasEntity()) {
+                return response.readEntity(String.class);
+            }
+        } catch (Exception e) {
+            // Entity already consumed or not readable — ignore.
+        }
+        return null;
+    }
+
+    private static String truncateForLog(String value, int maxLength) {
+        if (value == null || value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength) + "...";
+    }
+
     @SafeVarargs
     private String httpCall(String method, String localPath, Object data, Map.Entry<String, Object>... params)
             throws ElasticsearchClientException {
@@ -1757,7 +1830,22 @@ public class ElasticsearchClient implements IElasticsearchClient {
             Invocation.Builder callBuilder = prepareHttpCall(node, path, params);
             return invokeHttp(callBuilder, method, node, path, data);
         } catch (WebApplicationException e) {
-            handleWebApplicationError(e, method, node, path);
+            // Don't read the entity here — executeWithRetry / callers need it for error details.
+            if (e.getResponse().getStatusInfo().getFamily() == Response.Status.Family.SERVER_ERROR) {
+                logger.debug(
+                        "Server-side HTTP error on {} {}/{}: {}",
+                        method,
+                        node,
+                        path == null ? "" : path,
+                        e.getResponse().getStatus());
+            } else {
+                logger.trace(
+                        "Error while running {} {}/{}: HTTP {}",
+                        method,
+                        node,
+                        path == null ? "" : path,
+                        e.getResponse().getStatus());
+            }
             throw e;
         } catch (ProcessingException e) {
             if (e.getCause() instanceof ConnectException && initialHosts.size() > 1) {
@@ -1785,23 +1873,6 @@ public class ElasticsearchClient implements IElasticsearchClient {
         String response = callBuilder.method(method, Entity.json(data), String.class);
         logger.trace("{} {}/{} gives {}", method, node, path == null ? "" : path, response);
         return response;
-    }
-
-    private void handleWebApplicationError(WebApplicationException e, String method, String node, String path) {
-        if (e.getResponse().getStatusInfo().getFamily() == Response.Status.Family.SERVER_ERROR) {
-            logger.error(
-                    "Error on server side. {} -> {} / {}",
-                    e.getResponse().getStatus(),
-                    e.getResponse().getStatusInfo().getReasonPhrase(),
-                    e.getResponse().readEntity(String.class));
-        } else {
-            logger.trace(
-                    "Error while running {} {}/{}: {}",
-                    method,
-                    node,
-                    path == null ? "" : path,
-                    e.getResponse().readEntity(String.class));
-        }
     }
 
     /**

--- a/elasticsearch-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchBulkResponseTest.java
+++ b/elasticsearch-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchBulkResponseTest.java
@@ -90,6 +90,9 @@ class ElasticsearchBulkResponseTest extends AbstractFSCrawlerTestCase {
         Assertions.assertThat(bulkResponse.getItems().get(0).isFailed()).isTrue();
         Assertions.assertThat(bulkResponse.getItems().get(0).getFailureMessage())
                 .contains("failed to parse field");
+        Assertions.assertThat(bulkResponse.buildFailureMessage().getMessage())
+                .contains("failed to parse field")
+                .contains("1 failure");
     }
 
     @Test

--- a/elasticsearch-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClientRetryTest.java
+++ b/elasticsearch-client/src/test/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClientRetryTest.java
@@ -36,7 +36,6 @@ import fr.pilato.elasticsearch.crawler.fs.test.framework.Slow;
 import fr.pilato.elasticsearch.crawler.fs.test.framework.TestContainerThreadFilter;
 import fr.pilato.elasticsearch.crawler.fs.test.framework.WindowsSpecificThreadFilter;
 import fr.pilato.elasticsearch.crawler.fs.test.framework.WireMockThreadFilter;
-import jakarta.ws.rs.ServiceUnavailableException;
 import jakarta.ws.rs.client.Client;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -157,7 +156,10 @@ class ElasticsearchClientRetryTest extends AbstractFSCrawlerTestCase {
 
         try (ElasticsearchClient client = createClient()) {
             // start() calls getVersion() which should fail after retries are exhausted
-            Assertions.assertThatThrownBy(client::start).isInstanceOf(ServiceUnavailableException.class);
+            Assertions.assertThatThrownBy(client::start)
+                    .isInstanceOf(ElasticsearchClientException.class)
+                    .hasMessageContaining("Retries exhausted")
+                    .hasMessageContaining("503");
         }
 
         // Verify that multiple retry attempts were made
@@ -482,13 +484,49 @@ class ElasticsearchClientRetryTest extends AbstractFSCrawlerTestCase {
             client.start();
             wireMockServer.resetRequests();
 
-            Assertions.assertThatExceptionOfType(ServiceUnavailableException.class)
-                    .isThrownBy(() -> client.search(new ESSearchRequest().withIndex("test-index")));
+            Assertions.assertThatExceptionOfType(ElasticsearchClientException.class)
+                    .isThrownBy(() -> client.search(new ESSearchRequest().withIndex("test-index")))
+                    .withMessageContaining("Retries exhausted")
+                    .withMessageContaining("503")
+                    .withMessageContaining("no_shard_available_action_exception");
         }
 
         WireMock.verify(
                 WireMock.moreThan(1), WireMock.postRequestedFor(WireMock.urlPathEqualTo("/test-index/_search")));
         logger.info("Test passed: search retries exhausted and exception propagated");
+    }
+
+    /** Direct {@code bulk()} call exposes status and response body when retries are exhausted. */
+    @Test
+    @Slow
+    void testBulkRetriesExhaustedExposesServerErrorDetail() throws IOException, ElasticsearchClientException {
+        wireMockServer.resetAll();
+
+        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/"))
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"version\": {\"number\": \"" + elasticsearchVersion + "\"}}")));
+
+        WireMock.stubFor(WireMock.post(WireMock.urlPathEqualTo("/test-index/_bulk"))
+                .willReturn(WireMock.aResponse().withStatus(503).withBody("""
+                                {"error":{"type":"no_shard_available_action_exception","reason":"no shard available","status":503}}
+                                """)));
+
+        try (ElasticsearchClient client = createClient()) {
+            client.start();
+            wireMockServer.resetRequests();
+
+            Assertions.assertThatExceptionOfType(ElasticsearchClientException.class)
+                    .isThrownBy(() -> client.bulk("test-index", "{}\n{}\n"))
+                    .withMessageContaining("Retries exhausted")
+                    .withMessageContaining("503")
+                    .withMessageContaining("no_shard_available_action_exception")
+                    .withMessageNotContaining("unknown");
+        }
+
+        WireMock.verify(WireMock.moreThan(1), WireMock.postRequestedFor(WireMock.urlPathEqualTo("/test-index/_bulk")));
+        logger.info("Test passed: bulk retries exhausted with clear server error detail");
     }
 
     /** Test that {@code _bulk} retries on 503 and eventually succeeds. */

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerBulkResponse.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerBulkResponse.java
@@ -22,13 +22,9 @@ package fr.pilato.elasticsearch.crawler.fs.framework.bulk;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 @SuppressWarnings("CanBeFinal")
 public abstract class FsCrawlerBulkResponse<O extends FsCrawlerOperation<O>> {
-
-    private static final Logger logger = LogManager.getLogger();
 
     protected boolean errors;
     protected List<BulkItemResponse<O>> items = new ArrayList<>();
@@ -57,20 +53,18 @@ public abstract class FsCrawlerBulkResponse<O extends FsCrawlerOperation<O>> {
         int failures = 0;
         for (BulkItemResponse<O> item : items) {
             if (item.failed) {
-                if (logger.isTraceEnabled()) {
-                    sbf.append(item.getOperation());
-                    sbf.append(":")
-                            .append(item.getOperation().toString())
-                            .append(":")
-                            .append(item.getFailureMessage());
+                if (failures > 0) {
+                    sbf.append("; ");
                 }
+                sbf.append(item.getOperation()).append(": ").append(item.getFailureMessage());
                 failures++;
             }
         }
-        if (logger.isTraceEnabled()) {
-            sbf.append("\n");
+        if (failures == 0) {
+            sbf.append("unknown failures");
+        } else {
+            sbf.insert(0, failures + " failure(s): ");
         }
-        sbf.append(failures).append(" failures");
         return new RuntimeException(sbf.toString());
     }
 

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerSimpleBulkProcessorListener.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerSimpleBulkProcessorListener.java
@@ -39,26 +39,29 @@ public class FsCrawlerSimpleBulkProcessorListener<
     public void afterBulk(long executionId, Q request, S response) {
         logger.debug("Executed bulk composed of {} actions", request.numberOfActions());
         if (response.hasFailures()) {
-            if (logger.isDebugEnabled()) {
-                logger.warn("There was failures while executing bulk.", response.buildFailureMessage());
-                for (FsCrawlerBulkResponse.BulkItemResponse<O> item : response.getItems()) {
-                    if (item.isFailed()) {
-                        logger.warn("Error for [{}]: {}", item.getOperation(), item.getFailureMessage());
-                    }
+            Throwable failure = response.buildFailureMessage();
+            logger.warn(
+                    "There were failures while executing bulk of {} actions: {}",
+                    request.numberOfActions(),
+                    failure.getMessage(),
+                    failure);
+            for (FsCrawlerBulkResponse.BulkItemResponse<O> item : response.getItems()) {
+                if (item.isFailed()) {
+                    logger.warn("Bulk item failure for [{}]: {}", item.getOperation(), item.getFailureMessage());
                 }
-            } else {
-                logger.warn(
-                        "There was failures while executing bulk. If you want to see the details, "
-                                + "please activate DEBUG mode with FS_JAVA_OPTS=\"-DLOG_LEVEL=debug\". "
-                                + "See https://fscrawler.readthedocs.io/en/latest/admin/logger.html for more details.",
-                        response.buildFailureMessage());
             }
         }
     }
 
     @Override
     public void afterBulk(long executionId, Q request, Throwable failure) {
-        logger.warn("Error executing bulk", failure);
+        logger.warn(
+                "Error executing bulk of {} actions: {}",
+                request.numberOfActions(),
+                failure.getMessage() != null
+                        ? failure.getMessage()
+                        : failure.getClass().getName(),
+                failure);
     }
 
     @Override


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bulk / HTTP retry failures often showed `Last error: unknown` and told users to enable DEBUG to see details.

### Changes

- Capture HTTP status + response body on each retryable failure; include them in the final `Retries exhausted ... Last error: ...` message (no more `unknown` when a response was received)
- Always throw `ElasticsearchClientException` with that detail after retries are exhausted (instead of a bare `ServiceUnavailableException`)
- Bulk listener logs item-level and transport failures at **WARN** with messages (no DEBUG required)
- `buildFailureMessage()` includes failure reasons by default

### Example log after the fix

```
WARN  Server error on POST index/_bulk. HTTP 503 Service Unavailable: {"error":{"type":"no_shard_available_action_exception",...}}. Retrying...
ERROR Retries exhausted for POST index/_bulk after PT10S. Last error: HTTP 503 Service Unavailable: {"error":{...}}
WARN  There were failures while executing bulk of 1 actions: Retries exhausted for POST index/_bulk. Last error: ...
```

## Test plan

- [x] `ElasticsearchClientRetryTest` (including new bulk exhausted detail test)
- [x] `ElasticsearchBulkResponseTest`
- [ ] CI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-768b9131-2513-42df-8900-a42cb738cc65?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-768b9131-2513-42df-8900-a42cb738cc65&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

