### PR TITLE
Quiet PDFBox missing ToUnicode WARN by default

### DIFF
--- a/cli/src/main/resources/log4j2-file.xml
+++ b/cli/src/main/resources/log4j2-file.xml
@@ -62,6 +62,10 @@
       <Logger name="org.apache.tika.parser.ocr.TesseractOCRParser" level="error" additivity="false">
          <AppenderRef ref="RollingFile" />
       </Logger>
+      <!-- PDFBox warns on missing ToUnicode CMaps (subset fonts); extraction continues -->
+      <Logger name="org.apache.pdfbox" level="error" additivity="false">
+         <AppenderRef ref="RollingFile" />
+      </Logger>
       <Logger name="com.gargoylesoftware" level="error" additivity="false">
          <AppenderRef ref="RollingFile"/>
       </Logger>

--- a/cli/src/main/resources/log4j2.xml
+++ b/cli/src/main/resources/log4j2.xml
@@ -69,6 +69,11 @@
          <AppenderRef ref="Console" />
          <AppenderRef ref="RollingFile" />
       </Logger>
+      <!-- PDFBox warns on missing ToUnicode CMaps (subset fonts); extraction continues -->
+      <Logger name="org.apache.pdfbox" level="error" additivity="false">
+         <AppenderRef ref="Console" />
+         <AppenderRef ref="RollingFile" />
+      </Logger>
       <Logger name="com.gargoylesoftware" level="error" additivity="false">
          <AppenderRef ref="Console"/>
          <AppenderRef ref="RollingFile" />

--- a/docs/source/admin/logger.md
+++ b/docs/source/admin/logger.md
@@ -35,6 +35,11 @@ Two log files are generated:
 You can change this strategy by modifying the `config/log4j2.xml` file.
 Please read [Log4J2 documentation](https://logging.apache.org/log4j/2.x/manual/index.html) on how to configure Log4J.
 
+By default, noisy third-party warnings that do not stop indexing are dialed down. In particular,
+`org.apache.pdfbox` is set to `error` so messages like `No Unicode mapping for CID+…` (subset fonts
+missing a ToUnicode CMap) do not flood the logs. Raise that logger if you need to diagnose PDF
+extraction issues.
+
 ```{note}
 
  FSCrawler detects automatically on Linux machines when it's running in background or foreground.

--- a/docs/source/release/3.0.md
+++ b/docs/source/release/3.0.md
@@ -102,6 +102,8 @@ XML implementation and to betofilippi for the switch to JSON.
 - Bulk `_bulk` HTTP calls now retry on `429`/`5xx` and no longer treat a failed bulk as success.
   Exhausted retries mark the crawl checkpoint as `ERROR` and REST uploads return `ok: false`.
   Thanks to dadoonet.
+- Default Log4J config sets `org.apache.pdfbox` to `error` to avoid flooding logs with
+  `No Unicode mapping for CID+…` warnings from subset fonts. Thanks to dadoonet.
 
 ## Deprecated
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Sets `org.apache.pdfbox` to `error` in default `log4j2.xml` and `log4j2-file.xml`
- Avoids log floods from `No Unicode mapping for CID+…` (subset fonts); extraction still runs
- Documents the default in logger docs and release notes

## Test plan
- [ ] Confirm shipped configs include the PDFBox logger
- [ ] Crawl a PDF that previously logged the WARN and verify it no longer appears at default levels

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-768b9131-2513-42df-8900-a42cb738cc65?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-768b9131-2513-42df-8900-a42cb738cc65&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

