### PR TITLE
Log bulk failure details to bulk-failures.log

### DIFF
--- a/cli/src/main/resources/log4j2-file.xml
+++ b/cli/src/main/resources/log4j2-file.xml
@@ -33,6 +33,17 @@
          </Policies>
          <DefaultRolloverStrategy max="7"/>
       </RollingFile>
+
+      <RollingFile name="BulkFailures" fileName="${sys:LOG_DIR}/bulk-failures.log"
+                   filePattern="${sys:LOG_DIR}/bulk-failures-%d{yyyy-MM-dd}-%i.log.gz">
+         <PatternLayout pattern="%d{ABSOLUTE} %-5p %m%n"/>
+         <Policies>
+            <OnStartupTriggeringPolicy />
+            <SizeBasedTriggeringPolicy size="20 MB" />
+            <TimeBasedTriggeringPolicy />
+         </Policies>
+         <DefaultRolloverStrategy max="7"/>
+      </RollingFile>
    </Appenders>
    <Loggers>
       <!-- This logger is used for the console -->
@@ -44,6 +55,10 @@
       <!-- This logger is used to trace all information about documents -->
       <Logger name="fscrawler.document" level="${sys:DOC_LEVEL}" additivity="false">
          <AppenderRef ref="Documents" />
+      </Logger>
+      <!-- Failed bulk actions (IDs / truncated payloads at TRACE) -->
+      <Logger name="fscrawler.bulk.failure" level="warn" additivity="false">
+         <AppenderRef ref="BulkFailures" />
       </Logger>
 
       <!-- This logger is used to log FSCrawler code execution -->

--- a/cli/src/main/resources/log4j2.xml
+++ b/cli/src/main/resources/log4j2.xml
@@ -35,6 +35,17 @@
          </Policies>
          <DefaultRolloverStrategy max="7"/>
       </RollingFile>
+
+      <RollingFile name="BulkFailures" fileName="${sys:LOG_DIR}/bulk-failures.log"
+                   filePattern="${sys:LOG_DIR}/bulk-failures-%d{yyyy-MM-dd}-%i.log.gz">
+         <PatternLayout pattern="%d{ABSOLUTE} %-5p %m%n"/>
+         <Policies>
+            <OnStartupTriggeringPolicy />
+            <SizeBasedTriggeringPolicy size="20 MB" />
+            <TimeBasedTriggeringPolicy />
+         </Policies>
+         <DefaultRolloverStrategy max="7"/>
+      </RollingFile>
    </Appenders>
    <Loggers>
       <!-- This logger is used for the console -->
@@ -48,6 +59,10 @@
       </Logger>
       <Logger name="fscrawler.metadata" level="${sys:METADATA_LEVEL}" additivity="false">
          <AppenderRef ref="Documents"/>
+      </Logger>
+      <!-- Failed bulk actions (IDs / truncated payloads at TRACE) -->
+      <Logger name="fscrawler.bulk.failure" level="warn" additivity="false">
+         <AppenderRef ref="BulkFailures" />
       </Logger>
 
       <!-- This logger is used to log FSCrawler code execution -->

--- a/docs/source/admin/layout.md
+++ b/docs/source/admin/layout.md
@@ -17,6 +17,7 @@ The directory layout of the project is as follows:
  ├── external
  ├── lib
  └── logs
+     ├── bulk-failures.log
      ├── documents.log
      └── fscrawler.log
 ```

--- a/docs/source/admin/logger.md
+++ b/docs/source/admin/logger.md
@@ -31,6 +31,11 @@ Two log files are generated:
   rotated every day or after 20mb of logs and gzipped. Logs are removed after 7 days.
 * One is used to trace all information about documents, named `documents.log`. It's automatically
   rotated every day or after 20mb of logs and gzipped. Logs are removed after 7 days.
+* One is used when bulk indexing fails, named `bulk-failures.log`. Each line starts with the
+  failure reason in brackets (for example `[Read timed out]`), then the bulk `executionId` and
+  the affected actions (`_index` / `_id`). Enable TRACE on logger `fscrawler.bulk.failure` to also
+  dump truncated document payloads (8 KiB max per document). Console / `fscrawler.log` WARNs point
+  to this file.
 
 You can change this strategy by modifying the `config/log4j2.xml` file.
 Please read [Log4J2 documentation](https://logging.apache.org/log4j/2.x/manual/index.html) on how to configure Log4J.
@@ -39,6 +44,14 @@ By default, noisy third-party warnings that do not stop indexing are dialed down
 `org.apache.pdfbox` is set to `error` so messages like `No Unicode mapping for CID+…` (subset fonts
 missing a ToUnicode CMap) do not flood the logs. Raise that logger if you need to diagnose PDF
 extraction issues.
+
+To dump failed bulk payloads:
+
+```xml
+<Logger name="fscrawler.bulk.failure" level="trace" additivity="false">
+   <AppenderRef ref="BulkFailures" />
+</Logger>
+```
 
 ```{note}
 

--- a/docs/source/release/3.0.md
+++ b/docs/source/release/3.0.md
@@ -104,6 +104,8 @@ XML implementation and to betofilippi for the switch to JSON.
   Thanks to dadoonet.
 - Default Log4J config sets `org.apache.pdfbox` to `error` to avoid flooding logs with
   `No Unicode mapping for CID+…` warnings from subset fonts. Thanks to dadoonet.
+- Failed bulk actions are detailed in `logs/bulk-failures.log` (reason-prefixed lines; truncated
+  payloads at TRACE). Console / `fscrawler.log` point to that file. Thanks to dadoonet.
 
 ## Deprecated
 

--- a/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
+++ b/elasticsearch-client/src/main/java/fr/pilato/elasticsearch/crawler/fs/client/ElasticsearchClient.java
@@ -24,6 +24,7 @@ import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.PathNotFoundException;
 import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
 import fr.pilato.elasticsearch.crawler.fs.framework.ExponentialBackoffPollInterval;
+import fr.pilato.elasticsearch.crawler.fs.framework.FSCrawlerLogger;
 import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil;
 import fr.pilato.elasticsearch.crawler.fs.framework.JsonUtil;
 import fr.pilato.elasticsearch.crawler.fs.framework.TimeValue;
@@ -354,9 +355,10 @@ public class ElasticsearchClient implements IElasticsearchClient {
             super.afterBulk(executionId, request, response);
             if (response.getException() != null) {
                 logger.error(
-                        "Bulk request failed after retries ({} actions): {}",
+                        "Bulk request failed after retries ({} actions): {}. See {} for action details.",
                         request.numberOfActions(),
                         response.getException().getMessage(),
+                        FSCrawlerLogger.BULK_FAILURES_LOG_FILE,
                         response.getException());
                 recordFatalBulkFailure(response.getException());
             }
@@ -366,16 +368,33 @@ public class ElasticsearchClient implements IElasticsearchClient {
         public void afterBulk(long executionId, ElasticsearchBulkRequest request, Throwable failure) {
             super.afterBulk(executionId, request, failure);
             logger.error(
-                    "Bulk request failed ({} actions): {}",
+                    "Bulk request failed ({} actions): {}. See {} for action details.",
                     request.numberOfActions(),
                     failure.getMessage() != null
                             ? failure.getMessage()
                             : failure.getClass().getName(),
+                    FSCrawlerLogger.BULK_FAILURES_LOG_FILE,
                     failure);
             Exception asException = failure instanceof Exception e
                     ? e
                     : new ElasticsearchClientException("Bulk request failed", failure);
             recordFatalBulkFailure(asException);
+        }
+
+        @Override
+        protected void logOperationPayloadTrace(String reason, long executionId, ElasticsearchOperation operation) {
+            if (operation instanceof ElasticsearchInsertOperation insert) {
+                FSCrawlerLogger.bulkFailureTrace(
+                        reason,
+                        "executionId={} {} {}/{} payload={}",
+                        executionId,
+                        insert.getOperation(),
+                        insert.getIndex(),
+                        insert.getId(),
+                        FSCrawlerLogger.truncateForBulkFailureLog(insert.getJson()));
+            } else {
+                super.logOperationPayloadTrace(reason, executionId, operation);
+            }
         }
     }
 

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/FSCrawlerLogger.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/FSCrawlerLogger.java
@@ -25,6 +25,18 @@ import org.apache.logging.log4j.Logger;
 
 public class FSCrawlerLogger {
 
+    /** Logger name for detailed bulk failure dumps ({@code logs/bulk-failures.log} by default). */
+    public static final String BULK_FAILURE_LOGGER_NAME = "fscrawler.bulk.failure";
+
+    /**
+     * Default relative path of the bulk-failure log file shipped in {@code config/log4j2.xml}. Mentioned from console /
+     * {@code fscrawler.log} WARNs so operators know where to look.
+     */
+    public static final String BULK_FAILURES_LOG_FILE = "logs/bulk-failures.log";
+
+    /** Max characters of a document body dumped at TRACE into the bulk-failure log. */
+    public static final int BULK_FAILURE_PAYLOAD_MAX_CHARS = 8_192;
+
     private FSCrawlerLogger() {
         // Utility class, do not instantiate
     }
@@ -37,6 +49,9 @@ public class FSCrawlerLogger {
 
     /** This logger is used to help writing the test cases */
     private static final Logger metadataLogger = LogManager.getLogger("fscrawler.metadata");
+
+    /** Dedicated logger for bulk failure details (actions / truncated payloads). */
+    private static final Logger bulkFailureLogger = LogManager.getLogger(BULK_FAILURE_LOGGER_NAME);
 
     /**
      * Print something to the console
@@ -78,5 +93,47 @@ public class FSCrawlerLogger {
      */
     public static void metadata(String message, Object... params) {
         metadataLogger.debug(message, params);
+    }
+
+    /**
+     * Log a bulk-failure detail line at WARN. {@code reason} is always prefixed so lines are greppable.
+     *
+     * @param reason short failure reason (HTTP error, item error, …)
+     * @param message message template after the reason prefix
+     * @param params template parameters
+     */
+    public static void bulkFailureWarn(String reason, String message, Object... params) {
+        bulkFailureLogger.warn("[{}] " + message, prepend(reason, params));
+    }
+
+    /**
+     * Log a truncated payload / extra context at TRACE under the bulk-failure logger.
+     *
+     * @param reason short failure reason
+     * @param message message template after the reason prefix
+     * @param params template parameters
+     */
+    public static void bulkFailureTrace(String reason, String message, Object... params) {
+        if (bulkFailureLogger.isTraceEnabled()) {
+            bulkFailureLogger.trace("[{}] " + message, prepend(reason, params));
+        }
+    }
+
+    /** Truncate a bulk document body for TRACE dumps. */
+    public static String truncateForBulkFailureLog(String payload) {
+        if (payload == null) {
+            return "null";
+        }
+        if (payload.length() <= BULK_FAILURE_PAYLOAD_MAX_CHARS) {
+            return payload;
+        }
+        return payload.substring(0, BULK_FAILURE_PAYLOAD_MAX_CHARS) + "...(truncated)";
+    }
+
+    private static Object[] prepend(String reason, Object... params) {
+        Object[] all = new Object[params.length + 1];
+        all[0] = reason == null || reason.isBlank() ? "unknown" : reason;
+        System.arraycopy(params, 0, all, 1, params.length);
+        return all;
     }
 }

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerSimpleBulkProcessorListener.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerSimpleBulkProcessorListener.java
@@ -20,6 +20,7 @@
  */
 package fr.pilato.elasticsearch.crawler.fs.framework.bulk;
 
+import fr.pilato.elasticsearch.crawler.fs.framework.FSCrawlerLogger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -40,14 +41,27 @@ public class FsCrawlerSimpleBulkProcessorListener<
         logger.debug("Executed bulk composed of {} actions", request.numberOfActions());
         if (response.hasFailures()) {
             Throwable failure = response.buildFailureMessage();
+            String reason = shortReason(failure);
             logger.warn(
-                    "There were failures while executing bulk of {} actions: {}",
+                    "There were failures while executing bulk of {} actions: {}. See {} for action details.",
                     request.numberOfActions(),
                     failure.getMessage(),
+                    FSCrawlerLogger.BULK_FAILURES_LOG_FILE,
                     failure);
+            FSCrawlerLogger.bulkFailureWarn(
+                    reason,
+                    "Bulk executionId={} item failures for {} actions. Request may have been partially applied.",
+                    executionId,
+                    request.numberOfActions());
             for (FsCrawlerBulkResponse.BulkItemResponse<O> item : response.getItems()) {
                 if (item.isFailed()) {
+                    String itemReason = shortReason(item.getFailureMessage());
                     logger.warn("Bulk item failure for [{}]: {}", item.getOperation(), item.getFailureMessage());
+                    FSCrawlerLogger.bulkFailureWarn(
+                            itemReason, "executionId={} failed item: {}", executionId, item.getOperation());
+                    FSCrawlerLogger.bulkFailureTrace(
+                            itemReason, "executionId={} failed item detail: {}", executionId, item.getFailureMessage());
+                    logOperationPayloadTrace(itemReason, executionId, item.getOperation());
                 }
             }
         }
@@ -55,17 +69,65 @@ public class FsCrawlerSimpleBulkProcessorListener<
 
     @Override
     public void afterBulk(long executionId, Q request, Throwable failure) {
+        String reason = shortReason(failure);
         logger.warn(
-                "Error executing bulk of {} actions: {}",
+                "Error executing bulk of {} actions: {}. See {} for action details.",
                 request.numberOfActions(),
                 failure.getMessage() != null
                         ? failure.getMessage()
                         : failure.getClass().getName(),
+                FSCrawlerLogger.BULK_FAILURES_LOG_FILE,
                 failure);
+        FSCrawlerLogger.bulkFailureWarn(
+                reason,
+                "Bulk executionId={} failed for {} actions (whole request; may have been partially applied).",
+                executionId,
+                request.numberOfActions());
+        int i = 0;
+        for (O operation : request.getOperations()) {
+            i++;
+            FSCrawlerLogger.bulkFailureWarn(
+                    reason, "executionId={} action {}/{}: {}", executionId, i, request.numberOfActions(), operation);
+            logOperationPayloadTrace(reason, executionId, operation);
+        }
     }
 
     @Override
     public void setBulkProcessor(FsCrawlerBulkProcessor<O, Q, S> bulkProcessor) {
         this.bulkProcessor = bulkProcessor;
+    }
+
+    /**
+     * Optional TRACE dump of an operation payload. Overridden where the concrete operation type carries a document body
+     * (e.g. Elasticsearch insert).
+     */
+    protected void logOperationPayloadTrace(String reason, long executionId, O operation) {
+        FSCrawlerLogger.bulkFailureTrace(reason, "executionId={} operation detail: {}", executionId, operation);
+    }
+
+    static String shortReason(Throwable failure) {
+        if (failure == null) {
+            return "unknown";
+        }
+        return shortReason(
+                failure.getMessage() != null
+                        ? failure.getMessage()
+                        : failure.getClass().getSimpleName());
+    }
+
+    static String shortReason(String message) {
+        if (message == null || message.isBlank()) {
+            return "unknown";
+        }
+        String trimmed = message.strip();
+        // Keep a single-line, greppable prefix (HTTP timeouts often end with "Read timed out")
+        int newline = trimmed.indexOf('\n');
+        if (newline > 0) {
+            trimmed = trimmed.substring(0, newline).strip();
+        }
+        if (trimmed.length() > 200) {
+            trimmed = trimmed.substring(0, 200) + "…";
+        }
+        return trimmed;
     }
 }

--- a/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerSimpleBulkProcessorListener.java
+++ b/framework/src/main/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerSimpleBulkProcessorListener.java
@@ -41,11 +41,12 @@ public class FsCrawlerSimpleBulkProcessorListener<
         logger.debug("Executed bulk composed of {} actions", request.numberOfActions());
         if (response.hasFailures()) {
             Throwable failure = response.buildFailureMessage();
-            String reason = shortReason(failure);
+            String failureMessage = messageOf(failure);
+            String reason = shortReason(failureMessage);
             logger.warn(
                     "There were failures while executing bulk of {} actions: {}. See {} for action details.",
                     request.numberOfActions(),
-                    failure.getMessage(),
+                    failureMessage,
                     FSCrawlerLogger.BULK_FAILURES_LOG_FILE,
                     failure);
             FSCrawlerLogger.bulkFailureWarn(
@@ -69,13 +70,12 @@ public class FsCrawlerSimpleBulkProcessorListener<
 
     @Override
     public void afterBulk(long executionId, Q request, Throwable failure) {
-        String reason = shortReason(failure);
+        String failureMessage = messageOf(failure);
+        String reason = shortReason(failureMessage);
         logger.warn(
                 "Error executing bulk of {} actions: {}. See {} for action details.",
                 request.numberOfActions(),
-                failure.getMessage() != null
-                        ? failure.getMessage()
-                        : failure.getClass().getName(),
+                failureMessage,
                 FSCrawlerLogger.BULK_FAILURES_LOG_FILE,
                 failure);
         FSCrawlerLogger.bulkFailureWarn(
@@ -105,14 +105,14 @@ public class FsCrawlerSimpleBulkProcessorListener<
         FSCrawlerLogger.bulkFailureTrace(reason, "executionId={} operation detail: {}", executionId, operation);
     }
 
-    static String shortReason(Throwable failure) {
+    static String messageOf(Throwable failure) {
         if (failure == null) {
             return "unknown";
         }
-        return shortReason(
-                failure.getMessage() != null
-                        ? failure.getMessage()
-                        : failure.getClass().getSimpleName());
+        String message = failure.getMessage();
+        return message != null && !message.isBlank()
+                ? message
+                : failure.getClass().getName();
     }
 
     static String shortReason(String message) {

--- a/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerSimpleBulkProcessorListenerTest.java
+++ b/framework/src/test/java/fr/pilato/elasticsearch/crawler/fs/framework/bulk/FsCrawlerSimpleBulkProcessorListenerTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
+ */
+package fr.pilato.elasticsearch.crawler.fs.framework.bulk;
+
+import com.carrotsearch.randomizedtesting.jupiter.RandomizedTest;
+import fr.pilato.elasticsearch.crawler.fs.framework.FSCrawlerLogger;
+import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
+import java.io.StringWriter;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.WriterAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class FsCrawlerSimpleBulkProcessorListenerTest extends AbstractFSCrawlerTestCase {
+
+    private static final String APPENDER_NAME = "bulk-failure-test-writer";
+
+    private StringWriter bulkFailureWriter;
+    private WriterAppender writerAppender;
+    private Level previousLevel;
+
+    @BeforeEach
+    void attachBulkFailureAppender() {
+        bulkFailureWriter = new StringWriter();
+        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        Configuration config = ctx.getConfiguration();
+
+        writerAppender = WriterAppender.newBuilder()
+                .setName(APPENDER_NAME)
+                .setTarget(bulkFailureWriter)
+                .setLayout(PatternLayout.newBuilder().withPattern("%p %m%n").build())
+                .build();
+        writerAppender.start();
+        config.addAppender(writerAppender);
+
+        LoggerConfig loggerConfig = config.getLoggerConfig(FSCrawlerLogger.BULK_FAILURE_LOGGER_NAME);
+        previousLevel = loggerConfig.getLevel();
+        if (!FSCrawlerLogger.BULK_FAILURE_LOGGER_NAME.equals(loggerConfig.getName())) {
+            loggerConfig = new LoggerConfig(FSCrawlerLogger.BULK_FAILURE_LOGGER_NAME, Level.TRACE, false);
+            config.addLogger(FSCrawlerLogger.BULK_FAILURE_LOGGER_NAME, loggerConfig);
+        } else {
+            loggerConfig.setLevel(Level.TRACE);
+        }
+        loggerConfig.addAppender(writerAppender, Level.TRACE, null);
+        ctx.updateLoggers();
+    }
+
+    @AfterEach
+    void detachBulkFailureAppender() {
+        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        Configuration config = ctx.getConfiguration();
+        LoggerConfig loggerConfig = config.getLoggerConfig(FSCrawlerLogger.BULK_FAILURE_LOGGER_NAME);
+        loggerConfig.removeAppender(APPENDER_NAME);
+        if (previousLevel != null && FSCrawlerLogger.BULK_FAILURE_LOGGER_NAME.equals(loggerConfig.getName())) {
+            loggerConfig.setLevel(previousLevel);
+        }
+        if (writerAppender != null) {
+            writerAppender.stop();
+        }
+        config.getAppenders().remove(APPENDER_NAME);
+        ctx.updateLoggers();
+    }
+
+    @Test
+    void afterBulkThrowable_logsReasonFirstAndHintsAtBulkFailuresFile() {
+        String reason = "Read timed out";
+        String id = RandomizedTest.randomAsciiLettersOfLengthBetween(randomizedRandomForTests, 6, 12);
+        TestOperation op = new TestOperation(new TestBean(id));
+        TestBulkRequest request = new TestBulkRequest();
+        request.add(op);
+
+        FsCrawlerSimpleBulkProcessorListener<TestOperation, TestBulkRequest, TestBulkResponse> listener =
+                new FsCrawlerSimpleBulkProcessorListener<>();
+        listener.afterBulk(1L, request, new RuntimeException(reason));
+
+        String logged = bulkFailureWriter.toString();
+        Assertions.assertThat(logged)
+                .contains("[" + reason + "]")
+                .contains("executionId=1")
+                .contains("failed for 1 actions")
+                .contains(op.toString());
+        Assertions.assertThat(FSCrawlerLogger.BULK_FAILURES_LOG_FILE).isEqualTo("logs/bulk-failures.log");
+    }
+
+    @Test
+    void afterBulkItemFailures_logsPerItemReasonFirst() {
+        String reason = "mapper_parsing_exception";
+        String id = RandomizedTest.randomAsciiLettersOfLengthBetween(randomizedRandomForTests, 6, 12);
+        TestOperation op = new TestOperation(new TestBean(id));
+        TestBulkRequest request = new TestBulkRequest();
+        request.add(op);
+
+        TestBulkResponse response = new TestBulkResponse();
+        response.errors = true;
+        FsCrawlerBulkResponse.BulkItemResponse<TestOperation> item = new FsCrawlerBulkResponse.BulkItemResponse<>();
+        item.setFailed(true);
+        item.setOperation(op);
+        item.setFailureMessage(reason);
+        response.getItems().add(item);
+
+        FsCrawlerSimpleBulkProcessorListener<TestOperation, TestBulkRequest, TestBulkResponse> listener =
+                new FsCrawlerSimpleBulkProcessorListener<>();
+        listener.afterBulk(7L, request, response);
+
+        String logged = bulkFailureWriter.toString();
+        Assertions.assertThat(logged)
+                .contains("[" + reason + "]")
+                .contains("executionId=7")
+                .contains(op.toString());
+    }
+
+    @Test
+    void truncateForBulkFailureLog_limitsPayload() {
+        String longPayload = "x".repeat(FSCrawlerLogger.BULK_FAILURE_PAYLOAD_MAX_CHARS + 50);
+        String truncated = FSCrawlerLogger.truncateForBulkFailureLog(longPayload);
+        Assertions.assertThat(truncated)
+                .hasSize(FSCrawlerLogger.BULK_FAILURE_PAYLOAD_MAX_CHARS + "...(truncated)".length())
+                .endsWith("...(truncated)");
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds `logs/bulk-failures.log` via logger `fscrawler.bulk.failure`
- On whole-bulk HTTP failures (e.g. `Read timed out`) and per-item failures, writes reason-prefixed lines with `executionId` and actions (`_index` / `_id`)
- Console / `fscrawler.log` WARN/ERROR messages point to `logs/bulk-failures.log`
- TRACE on `fscrawler.bulk.failure` dumps truncated payloads (8 KiB max) for insert operations

## Test plan
- [x] `FsCrawlerSimpleBulkProcessorListenerTest`
- [x] `ElasticsearchClientRetryTest` / `ElasticsearchBulkResponseTest`
- [ ] CI green
- [ ] Manual: force a bulk timeout and confirm console points to `logs/bulk-failures.log` with action IDs listed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-768b9131-2513-42df-8900-a42cb738cc65?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-768b9131-2513-42df-8900-a42cb738cc65&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

