### PR TITLE
Prepare 3.0 documentation for release

### DIFF
--- a/.claude/commands/document.md
+++ b/.claude/commands/document.md
@@ -8,19 +8,19 @@ For each commit, identify:
 - What changed (feature, fix, config option, API endpoint, etc.)
 - Which user-facing behaviour is affected
 
-### 2. Update RST documentation
-The user docs live in `docs/source/` (reStructuredText, built by ReadTheDocs — https://fscrawler.readthedocs.io/).
+### 2. Update documentation
+The user docs live in `docs/source/` (MyST Markdown, built by ReadTheDocs — https://fscrawler.readthedocs.io/).
 
 For each user-facing change:
-- Locate the relevant `.rst` file in `docs/source/`
+- Locate the relevant `.md` file in `docs/source/`
 - Add or update the description, examples, and configuration options
-- Follow the existing RST style (headings, code blocks, notes)
+- Follow the existing MyST style (headings, code blocks, notes)
 
 Key doc files:
 - `docs/source/admin/fs/` — filesystem crawler settings
-- `docs/source/admin/elasticsearch/` — Elasticsearch settings
-- `docs/source/admin/rest/` — REST API reference
-- `docs/source/installation.rst` — installation guide
+- `docs/source/admin/fs/elasticsearch.md` — Elasticsearch settings
+- `docs/source/admin/fs/rest.md` — REST API reference
+- `docs/source/installation.md` — installation guide
 - `docs/source/dev/` — developer documentation
 
 ### 3. Generate changelog summary

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -124,6 +124,6 @@ FS_JAVA_OPTS="-DLOG_LEVEL=debug" bin/fscrawler job-name
 ```
 
 Common issues:
-1. **ES connection**: Check `elasticsearch.nodes` configuration
+1. **ES connection**: Check `elasticsearch.urls` configuration
 2. **Document parsing**: Check Tika logs for parsing errors
 3. **Memory issues**: `FS_JAVA_OPTS="-Xmx2g"` to increase heap

--- a/.claude/rules/build-commands.md
+++ b/.claude/rules/build-commands.md
@@ -72,14 +72,14 @@ Placeholders are also supported inside settings files (resolved from env vars or
 fs:
   url: "${HOME}/docs"
 elasticsearch:
-  nodes:
-    - url: "${ES_NODE1:=https://127.0.0.1:9200}"
+  urls:
+    - "${ES_NODE1:=https://127.0.0.1:9200}"
   api_key: "${ES_API_KEY}"
 ```
 
 > **Note**: if both a settings file and env vars are defined, the settings file takes precedence.
 
-See also: `docs/source/admin/fs/index.rst`
+See also: `docs/source/admin/fs/index.md`
 
 ## CI/CD
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,7 +71,7 @@ or the Docker image genrated by the build, then start one Elasticsearch instance
 ```bash
 # Elasticsearch 9.x: you cna check the expected version in the main `pom.xml`:
 # <elasticsearch.version>${elasticsearch9.version}</elasticsearch.version>
-docker run -d --name elasticsearch -p 9200:9200 -e "discovery.type=single-node" -e "xpack.security.enabled=false" docker.elastic.co/elasticsearch/elasticsearch:9.3.0
+docker run -d --name elasticsearch -p 9200:9200 -e "discovery.type=single-node" -e "xpack.security.enabled=false" docker.elastic.co/elasticsearch/elasticsearch:9.5.2
 
 # Verify it's running
 curl http://localhost:9200
@@ -167,7 +167,7 @@ Closes #xxxx.
 ## Documentation
 
 - Main docs: https://fscrawler.readthedocs.io/
-- Build docs: `docs/source/dev/build.rst`
+- Build docs: `docs/source/dev/build.md`
 - Contributing: `CONTRIBUTING.md`
 - Local docs build: Check `docs/pom.xml`
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ docs/build
 .idea
 *.iml
 /IGNORE_ME
+/elastic-start-local
 /logs/
 /venv/
 /contrib/docker-compose-example-elasticsearch/config/idx/_status.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,5 +30,5 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Documentation
 
 - User docs: https://fscrawler.readthedocs.io/
-- Source: `docs/source/` (reStructuredText, built by ReadTheDocs)
-- Build guide: `docs/source/dev/build.rst`
+- Source: `docs/source/` (MyST Markdown, built by ReadTheDocs)
+- Build guide: `docs/source/dev/build.md`

--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ This crawler helps to index binary documents such as PDF, Open Office, MS Office
 
 ## Latest versions
 
-Current "most stable" versions are:
+Current versions are:
 
 | Elasticsearch | FSCrawler    | Released   | Docs                                                                  |
 |---------------|--------------|------------|-----------------------------------------------------------------------|
+| 6.x, 7.x      | 2.9          | 2022-03-08 | [2.9](https://fscrawler.readthedocs.io/en/fscrawler-2.9/)             |
 | 7.x, 8.x, 9.x | 3.0-SNAPSHOT |            | [3.0-SNAPSHOT](https://fscrawler.readthedocs.io/en/latest/)           |
 
 ## Quick start

--- a/docs/source/admin/fs/index.md
+++ b/docs/source/admin/fs/index.md
@@ -76,85 +76,63 @@ bin/fscrawler test
 
 ## Example job file specification
 
-The job file (`~/.fscrawler/test/_settings.yaml`) for the job name `test` must comply to the following `yaml` specifications:
+`bin/fscrawler --setup` writes a fully commented example to
+`~/.fscrawler/{job}/_settings.yaml`. The job file for the job name `test`
+(`~/.fscrawler/test/_settings.yaml`) looks like:
 
 ```yaml
 # optional: the name of the crawler. Defaults to the job directory name.
 name: "test"
 
-# required
 fs:
-
-  # define a "local" file path crawler, if running inside a docker container this must be the path INSIDE the container (/tmp/es)
+  # available providers: local (default), ftp, ssh
+  provider: "local"
+  # inside Docker this must be the path INSIDE the container (/tmp/es)
   url: "/path/to/docs"
   follow_symlinks: false
   remove_deleted: true
   continue_on_error: false
+  update_rate: "15m"
 
-  # scan every 5 minutes for changes in url defined above
-  update_rate: "5m"
-
-  # optional: define includes and excludes; "~" and ".DS_Store" files are excluded by default if not defined below
+  # optional: "~" and ".DS_Store" files are excluded by default if not defined
   includes:
-  - "*.doc"
-  - "*.xls"
+    - "*.doc"
+    - "*.xls"
   excludes:
-  - "resume.doc"
+    - "resume.doc"
 
-  # optional: do not send big files to TIKA
   ignore_above: "512mb"
-
-  # special handling of JSON files, should only be used if ALL files are JSON
   json_support: false
   add_as_inner_object: false
-
-  # special handling of XML files, should only be used if ALL files are XML
   xml_support: false
 
-  # use MD5 from filename (instead of filename) if set to false
-  filename_as_id: true
+  # when true, the filename is used as _id (hash_algorithm is ignored)
+  filename_as_id: false
+  # new jobs from --setup use SHA-256; unset keeps MD5 for existing jobs
+  hash_algorithm: "SHA-256"
 
-  # include size ot file in index
   add_filesize: true
-
-  # inlcude user/group of file only if needed
   attributes_support: false
-
-  # collect ACL metadata when available
   acl_support: false
-
-  # do you REALLY want to store every file as a copy in the index ? Then set this to true
   store_source: false
-
-  # you may want to store (partial) content of the file (see indexed_chars)	 
   index_content: true
-
-  # how much data from the content of the file should be indexed (and stored inside the index), set to 0 if you need checksum, but no content at all to be indexed
-  #indexed_chars: "0"
   indexed_chars: "10000.0"
-
-  # usually file metadata will be stored in separate fields, if you want to keep the original set, set this to true
   raw_metadata: false
-
-  # optional: add checksum meta (requires index_content to be set to true)
+  # optional: hash of file content (independent from hash_algorithm)
   checksum: "MD5"
-
-  # recommmended, but will create another index
   index_folders: true
-
   lang_detect: false
 
-  ocr.pdf_strategy: noocr
-  #ocr:
-  #  language: "eng"
-  #  path: "/path/to/tesseract/if/not/available/in/PATH"
-  #  data_path: "/path/to/tesseract/tessdata/if/needed"
+  ocr:
+    enabled: true
+    language: "eng"
+    # default is auto: skip OCR on PDF pages that already contain text
+    pdf_strategy: auto
 
 # optional: add static metadata tags to documents
 tags:
-  metaFilename: "meta_tags.json" # default is ".meta.yml"
-  # optional: add static metadata to all indexed documents
-  staticMetaFilename: "/path/to/static_metadata.json"
+  metaFilename: ".meta.yml"
+  staticMetaFilename: "/path/to/static_metadata.yml"
 
 # optional: configure password lookup for protected documents
 passwords:
@@ -163,11 +141,7 @@ passwords:
     disk:
       url: "/path/to/password-sidecars"
 
-# optional: specify a crawler provider (default is "local")
-# available providers: "local", "ftp", "ssh"
-# provider: "ssh"
-
-# optional: only required if you want to SSH/FTP to another server to index documents from there
+# optional: only required for SSH/FTP
 server:
   hostname: "localhost"
   port: 22
@@ -175,27 +149,27 @@ server:
   password: "password"
   pem_path: "/path/to/pemfile"
 
-# required
 elasticsearch:
   urls:
-  - "https://127.0.0.1:9200"
+    - "https://127.0.0.1:9200"
   bulk_size: 1000
   flush_interval: "5s"
   byte_size: "10mb"
-  # choose one of the 2 following options:
-  # 1 - Using Api Key
   api_key: "VnVhQ2ZHY0JDZGJrUW0tZTVhT3g6dWkybHAyYXhUTm1zeWFrdzl0dk5udw=="
-  # 2 - Using username/password (not recommended / deprecated)
-  username: "elastic"
-  password: "password"
-  # optional, defaults to `name`-property
-  index: "test_docs"
-  # optional, defaults to "test_folders", used when es.index_folders is set to true
-  index_folder: "test_fold"
-  # optional, defaults to "true"
-  push_templates: "true"
-  # optional, defaults to "true", used with Elasticsearch 8.17+ with a trial or enterprise license
-  semantic_search: "true"
+  # username/password is deprecated; prefer api_key
+  # username: "elastic"
+  # password: "password"
+  # optional, defaults to <name>_docs — do not set this to the job name
+  # index: "test_docs"
+  # optional, defaults to <name>_folder
+  # index_folder: "test_folder"
+  push_templates: true
+  semantic_search: true
+
+kibana:
+  url: "http://127.0.0.1:5601"
+  push_dashboard: true
+
 # only used when started with --rest option
 rest:
   url: "http://127.0.0.1:8080"

--- a/docs/source/admin/fs/rest.md
+++ b/docs/source/admin/fs/rest.md
@@ -138,7 +138,7 @@ It will give you a response similar to:
 {
   "filename" : "test.txt",
   "ok" : true,
-  "url" : "http://127.0.0.1:9200/fscrawler-rest-tests_doc/_doc/dd18bf3a8ea2a3e53e2661c7fb53534"
+  "url" : "http://127.0.0.1:9200/fscrawler-rest-tests_docs/_doc/dd18bf3a8ea2a3e53e2661c7fb53534"
 }
 ```
 
@@ -150,15 +150,14 @@ The `url` represents the elasticsearch address of the indexed
 document. If you call:
 
 ```sh
-curl http://127.0.0.1:9200/fscrawler-rest-tests_doc/_doc/dd18bf3a8ea2a3e53e2661c7fb53534?pretty
+curl http://127.0.0.1:9200/fscrawler-rest-tests_docs/_doc/dd18bf3a8ea2a3e53e2661c7fb53534?pretty
 ```
 
 You will get back your document as it has been stored by elasticsearch:
 
 ```json
 {
-  "_index" : "fscrawler-rest-tests_doc",
-  "_type" : "_doc",
+  "_index" : "fscrawler-rest-tests_docs",
   "_id" : "dd18bf3a8ea2a3e53e2661c7fb53534",
   "_version" : 1,
   "found" : true,
@@ -237,7 +236,7 @@ will give
   },
   "filename" : "test.txt",
   "ok" : true,
-  "url" : "http://127.0.0.1:9200/fscrawler-rest-tests_doc/_doc/dd18bf3a8ea2a3e53e2661c7fb53534"
+  "url" : "http://127.0.0.1:9200/fscrawler-rest-tests_docs/_doc/dd18bf3a8ea2a3e53e2661c7fb53534"
 }
 ```
 

--- a/docs/source/admin/fs/simple.md
+++ b/docs/source/admin/fs/simple.md
@@ -9,7 +9,12 @@ name: "test"
 ```
 
 This will scan every 15 minutes all documents available in `/tmp/es`
-dir and will index them into `test_doc` index. It will connect to an
-elasticsearch cluster running on `127.0.0.1`, port `9200`.
+dir and will index them into the `test_docs` index. FSCrawler also creates
+a `test` alias so you can search with `GET test/_search`.
+
+It connects to Elasticsearch at `https://127.0.0.1:9200` by default. Use
+`elasticsearch.urls` if your cluster is elsewhere, and an API key to authenticate.
+With Elastic start-local, use `http://` instead of `https://`. See
+{ref}`elasticsearch-settings`.
 
 **Note**: `name` is a mandatory field.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -42,6 +42,7 @@ installation
 :maxdepth: 3
 
 user/getting_started
+user/upgrade
 user/tutorial
 user/llm-assistant
 user/options

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -1,6 +1,16 @@
 (installation)=
+# Installation
+
+Choose one of:
+
+* {ref}`docker` — pull the image from Docker Hub
+* {ref}`docker-compose` — Elasticsearch, Kibana, and FSCrawler together
+* {ref}`local-installation` — ZIP distribution on your machine
+
+Coming from 2.9? There is no in-place upgrade. See {ref}`upgrade-from-2.9`.
+
 (docker)=
-# Using docker
+## Using Docker
 
 Pull the Docker image from [Docker Hub](https://hub.docker.com/r/dadoonet/fscrawler):
 
@@ -21,7 +31,15 @@ docker pull dadoonet/fscrawler
 ````
 
 Let say your documents are located in `~/tmp` dir, and you want to store your FSCrawler jobs in `~/.fscrawler`.
-You can run FSCrawler with:
+On first run, create the job settings:
+
+```sh
+docker run -it --rm \
+     -v ~/.fscrawler:/root/.fscrawler \
+     dadoonet/fscrawler --setup
+```
+
+Then run FSCrawler with:
 
 ```sh
 docker run -it --rm \
@@ -34,7 +52,8 @@ docker run -it --rm \
 
  The configuration file is expected to be stored on your machine in `~/.fscrawler/fscrawler/_settings.yaml`.
  Remember to change the URL of your elasticsearch instance as the container won't be able to see it
- running under the default `127.0.0.1`. You will need to use the actual IP address of the host.
+ running under the default `127.0.0.1`. You will need to use the actual IP address of the host,
+ or `host.docker.internal` on Docker Desktop.
 
  Or use the `FSCRAWLER_ELASTICSEARCH_URLS` environment variable to set the elasticsearch URL.
  See {ref}`cli-options` for more information.
@@ -90,7 +109,7 @@ docker run -it --rm \
 See {ref}`cli-options` for more information.
 
 (docker-compose)=
-# Using docker compose
+## Using Docker Compose
 
 In this section, the following directory layout is assumed:
 
@@ -232,8 +251,13 @@ volumes:
 Copy your pdf/doc files into the `docs` directory and run the full stack, including FSCrawler with:
 
 ```sh
- docker-compose up
+docker-compose up
 ```
+
+This example does not mount `~/.fscrawler`. Job settings come from `FSCRAWLER_*` environment
+variables. The default job name is `fscrawler`, so documents are searchable on the `fscrawler`
+alias. Username and password match the Elastic user created by the stack; API keys are preferred
+in production. See {ref}`credentials`.
 
 When the job has finished indexing, you can check your documents in Elasticsearch with:
 
@@ -245,20 +269,8 @@ curl -u elastic:changeme "http://localhost:9200/fscrawler/_search"
 You will find this example in the `contrib/docker-compose-example-elasticsearch` project directory.
 ```
 
-# Running as a Service on Windows
-
-Create a `fscrawlerRunner.bat` as:
-
-```sh
-set JAVA_HOME=c:\Program Files\Java\jdk17.0.18
-set FS_JAVA_OPTS=-Xmx2g -Xms2g
-/Elastic/fscrawler/bin/fscrawler.bat --config_dir /Elastic/fscrawler data >> /Elastic/logs/fscrawler.log 2>&1
-```
-
-Then use `fscrawlerRunner.bat` to create your Windows service.
-
 (local-installation)=
-# Local installation
+## Local installation (ZIP)
 
 If you prefer to run FSCrawler from a ZIP distribution on your machine instead of Docker:
 
@@ -313,9 +325,23 @@ You can also download a **SNAPSHOT** version from [Sonatype Snapshots](https://c
 After extracting the ZIP, you get a directory with `bin/` (run scripts), `config/` (logging), `lib/` (core and
 dependencies), `external/` (optional JARs), and `logs/`. See {ref}`layout` for the full directory layout.
 
-## Optional libraries (external)
+Then continue with {ref}`getting-started`.
+
+### Optional libraries (external)
 
 You may need to add JARs to the `external` directory for some formats. For example, to support JPEG2000 (JPX/JP2)
 images in PDFs, add the `jai-imageio-jpeg2000` library: download it from
 [Maven Central](https://central.sonatype.com/search?q=g:com.github.jai-imageio) and put
 `jai-imageio-jpeg2000-1.4.0.jar` in the `external` directory.
+
+## Running as a Service on Windows
+
+Create a `fscrawlerRunner.bat` as:
+
+```sh
+set JAVA_HOME=c:\Program Files\Java\jdk17.0.18
+set FS_JAVA_OPTS=-Xmx2g -Xms2g
+/Elastic/fscrawler/bin/fscrawler.bat --config_dir /Elastic/fscrawler data >> /Elastic/logs/fscrawler.log 2>&1
+```
+
+Then use `fscrawlerRunner.bat` to create your Windows service.

--- a/docs/source/llms-txt.md
+++ b/docs/source/llms-txt.md
@@ -16,15 +16,16 @@ For copy-paste prompts to use with ChatGPT, Claude, or other assistants, see the
 
 - [Installation](https://fscrawler.readthedocs.io/en/latest/installation.html.md): Docker, ZIP distribution, and Docker Compose.
 - [Getting Started](https://fscrawler.readthedocs.io/en/latest/user/getting_started.html.md): First run with `--setup`, default paths, and a basic search example.
-- [Tutorial](https://fscrawler.readthedocs.io/en/latest/user/tutorial.html.md): End-to-end walkthrough with Elastic start-local, Docker, and Kibana ES|QL queries.
+- [Upgrading from 2.9](https://fscrawler.readthedocs.io/en/latest/user/upgrade.html.md): 3.0 is a fresh install; there is no in-place upgrade from 2.9.
+- [Tutorial](https://fscrawler.readthedocs.io/en/latest/user/tutorial.html.md): End-to-end walkthrough with Elastic start-local, Docker, and Kibana.
 - [LLM assistant](https://fscrawler.readthedocs.io/en/latest/user/llm-assistant.html.md): Ready-to-copy prompts for configuring FSCrawler with an AI assistant.
 
 ## User guide
 
 - [Crawler options](https://fscrawler.readthedocs.io/en/latest/user/options.html.md): Update rate, `--loop`, and `--restart`.
 - [Supported formats](https://fscrawler.readthedocs.io/en/latest/user/formats.html.md): Document types handled by Apache Tika.
-- [OCR](https://fscrawler.readthedocs.io/en/latest/user/ocr.html.md): Optical character recognition settings.
-- [REST API](https://fscrawler.readthedocs.io/en/latest/user/rest.html.md): Upload binary documents over HTTP.
+- [OCR](https://fscrawler.readthedocs.io/en/latest/user/ocr.html.md): Optical character recognition (Tesseract) and optional VLM OCR.
+- [REST API](https://fscrawler.readthedocs.io/en/latest/user/rest.html.md): Upload binary documents over HTTP; fetch from HTTP or S3.
 - [Tips and tricks](https://fscrawler.readthedocs.io/en/latest/user/tips.html.md): Docker, multi-machine setups, and common workarounds.
 
 ## Configuration reference
@@ -33,6 +34,7 @@ For copy-paste prompts to use with ChatGPT, Claude, or other assistants, see the
 - [SSH](https://fscrawler.readthedocs.io/en/latest/admin/fs/ssh.html.md): Remote crawling over SSH/SFTP.
 - [FTP](https://fscrawler.readthedocs.io/en/latest/admin/fs/ftp.html.md): Remote crawling over FTP.
 - [Elasticsearch settings](https://fscrawler.readthedocs.io/en/latest/admin/fs/elasticsearch.html.md): URLs, API key, SSL, indices, bulk settings, semantic search.
+- [Kibana settings](https://fscrawler.readthedocs.io/en/latest/admin/fs/kibana.html.md): Default dashboard on job startup (Kibana 9.5+).
 - [Password-protected documents](https://fscrawler.readthedocs.io/en/latest/admin/fs/passwords.html.md): Encrypted PDF and Office files.
 - [Document IDs](https://fscrawler.readthedocs.io/en/latest/admin/fs/document-ids.html.md): How document identifiers are built.
 - [Tags and metadata](https://fscrawler.readthedocs.io/en/latest/admin/fs/tags.html.md): Custom fields on indexed documents.
@@ -41,6 +43,7 @@ For copy-paste prompts to use with ChatGPT, Claude, or other assistants, see the
 
 ## Common pitfalls
 
+- There is no in-place upgrade from 2.9: install 3.0, recreate jobs with `--setup`, and reindex.
 - Use `elasticsearch.urls` (a list), not `nodes`. Unknown keys are silently ignored.
 - With Elastic start-local, use `http://` (not `https://`) for Elasticsearch.
 - Do not set `elasticsearch.index` to the same value as the job `name`; FSCrawler creates an alias with the job name.

--- a/docs/source/release/3.0.md
+++ b/docs/source/release/3.0.md
@@ -1,6 +1,11 @@
 (release-notes-3.0)=
 # Version 3.0
 
+```{important}
+There is no in-place upgrade from FSCrawler 2.9. Install 3.0, recreate jobs with
+`--setup`, and reindex. See {ref}`upgrade-from-2.9`.
+```
+
 ## Breaking changes
 
 - If you want to exclude a specific folder, you need to use a wildcard character at the end of the folder name.
@@ -63,8 +68,8 @@
   Model through an OpenAI-compatible endpoint (vLLM, Ollama, Azure OpenAI…), Anthropic Claude or Google
   Gemini, configured via a custom Tika configuration file. See {ref}`vlm-ocr`. The default FSCrawler
   parser chain is unchanged (Tesseract when available). Thanks to dadoonet.
-- Add option to set path to custom tika config file. See {ref}`local-fs-settings`. Thanks to iadcode for the orginal 
-XML implementation and to betofilippi for the switch to JSON.
+- Add option to set path to custom tika config file. See {ref}`local-fs-settings`. Thanks to iadcode for the original
+  XML implementation and to betofilippi for the switch to JSON.
   If your JSON configuration uses `default-parser`, exclude the VLM parser components unless you
   explicitly enable one — see {ref}`local-fs-settings` and {ref}`vlm-ocr`.
   **Note**: since the Apache Tika 4 upgrade, the configuration file must be a Tika JSON configuration —
@@ -84,17 +89,12 @@ XML implementation and to betofilippi for the switch to JSON.
 - Add support for pause/resume functionality with checkpoint persistence. The crawler can now be paused and resumed
   without losing progress. It also automatically recovers from network errors with exponential backoff retry.
   See {ref}`rest-service`. Thanks to dadoonet.
-<<<<<<< HEAD
 - HTTP retry backoff is configurable via `elasticsearch.retry_max_duration`,
   `elasticsearch.retry_initial_delay` and `elasticsearch.retry_max_delay`
   (defaults `5m` / `500ms` / `30s`). The same budget applies to `5xx`, `429`, and a
   cold-start `404` on `GET /`. See {ref}`http-retry-settings`. Thanks to dadoonet.
-=======
-- Document `_id` hashing is configurable via `fs.hash_algorithm` (any Java `MessageDigest` algorithm). See
-  {ref}`document-ids`. Closes [#2425](https://github.com/dadoonet/fscrawler/issues/2425). Thanks to dadoonet.
 - FSCrawler can create a default Kibana dashboard on job startup via the Kibana Dashboards API (Kibana 9.5+).
   See {ref}`kibana-settings`. Closes [#2477](https://github.com/dadoonet/fscrawler/issues/2477). Thanks to dadoonet.
->>>>>>> 1f2a11fc (feat(kibana): ✨ enable default dashboards with force push and Cloud/Serverless CI)
 
 ## Fix
 
@@ -124,8 +124,8 @@ XML implementation and to betofilippi for the switch to JSON.
 ## Updated
 
 - Files are now sorted by date with a reverse order. So the most recent files should be indexed first. Thanks to dadoonet.
-- Add full support for Elasticsearch [9.3.0](https://www.elastic.co/docs/solutions/search), [8.19.5](https://www.elastic.co/guide/en/elasticsearch/reference/8.19/index.html), [7.17.29](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/index.html). Thanks to dadoonet.
-- Update to [Tika 3.3.1](https://tika.apache.org/3.3.1/). Thanks to dadoonet.
+- Add full support for Elasticsearch [9.5.2](https://www.elastic.co/docs/solutions/search), [8.19.5](https://www.elastic.co/guide/en/elasticsearch/reference/8.19/index.html), [7.17.29](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/index.html). Thanks to dadoonet.
+- Update to [Tika 4.0.0](https://tika.apache.org/4.0.0/). Thanks to dadoonet.
 - The default alias name is now the job name and not forced to `fscrawler` anymore. Thanks to dadoonet.
 - The default REST endpoint is now running at `/` instead of `/fscrawler/`. Thanks to dadoonet.
 - Upgrade to Jackson 3.x. Closes [#2419](https://github.com/dadoonet/fscrawler/issues/2419). Thanks to dadoonet.

--- a/docs/source/release/index.md
+++ b/docs/source/release/index.md
@@ -4,7 +4,9 @@ It can happen that you need to upgrade a mapping or reindex an entire
 index before starting FSCrawler after a version upgrade. Read carefully
 the following update instructions.
 
-To update FSCrawler, just download the new version, unzip it in another
-directory and launch it as usual. It will still pick up settings from
-the configuration directory. Of course, you need to stop first the
-existing running instances.
+For a new install of the same major version, download the new ZIP, unzip it in
+another directory, stop the running instances, and start 3.0 as usual. It still
+reads settings from the configuration directory.
+
+From **2.9 to 3.0**, there is no in-place upgrade. Install 3.0, recreate jobs with
+`--setup`, and reindex. See {ref}`upgrade-from-2.9`.

--- a/docs/source/user/getting_started.md
+++ b/docs/source/user/getting_started.md
@@ -1,31 +1,58 @@
+(getting-started)=
 # Getting Started
 
-You need to have at least **Java** {{ java_version }} and have properly configured
-`JAVA_HOME` to point to your Java installation directory. For example
-on MacOS if you are using sdkman you can define in your `~/.bash_profile` file:
+The fastest way to try FSCrawler is the {ref}`tutorial`: Elastic
+[start-local](https://www.elastic.co/docs/deploy-manage/deploy/self-managed/local-development-installation-quickstart)
+plus the Docker image.
+
+This page is the local ZIP path.
+
+Coming from 2.9? There is no in-place upgrade. See {ref}`upgrade-from-2.9`.
+
+## Prerequisites
+
+* **Java** {{ java_version }} or later, with `JAVA_HOME` pointing at that JDK. For example on macOS
+  with sdkman, in `~/.bash_profile`:
 
 ```sh
 export JAVA_HOME="~/.sdkman/candidates/java/current"
 ```
 
-## Start FSCrawler
+* Elasticsearch 7.17+, 8.x, or 9.x, reachable from this machine. An **API key** is the recommended
+  way to authenticate. See {ref}`credentials`.
+* The FSCrawler ZIP. See {ref}`local-installation`.
 
-Start FSCrawler with:
+## Create a job
 
-```sh
-bin/fscrawler
-```
-
-FSCrawler will read a local file (default to `~/.fscrawler/fscrawler/_settings.yaml`). If the file does not exist,
-you can ask to create it using the `--setup` command.
+On first run, create the default job configuration:
 
 ```sh
 $ bin/fscrawler --setup
 17:40:33,905 INFO  [f.console] You can edit the settings in [~/.fscrawler/fscrawler/_settings.yaml]. Then, you can run again fscrawler without the --setup option.
 ```
 
-Create a directory named `/tmp/es` or `c:\tmp\es`, add some files
-you want to index in it and start again:
+Edit `~/.fscrawler/fscrawler/_settings.yaml`:
+
+```yaml
+name: "fscrawler"
+fs:
+  url: "/tmp/es"
+elasticsearch:
+  urls:
+    - "https://127.0.0.1:9200"
+  api_key: "YOUR_API_KEY"
+```
+
+Leave `elasticsearch.index` unset. FSCrawler indexes into `fscrawler_docs` and creates a
+`fscrawler` alias.
+
+```{note}
+The default Elasticsearch URL is `https://127.0.0.1:9200`. With Elastic start-local, use
+`http://127.0.0.1:9200` instead. Unknown keys such as `elasticsearch.nodes` are ignored.
+See {ref}`elasticsearch-settings`.
+```
+
+Create `/tmp/es` (or `c:\tmp\es` on Windows), add files to index, then start:
 
 ```sh
 $ bin/fscrawler
@@ -34,7 +61,7 @@ $ bin/fscrawler
 17:41:45,395 INFO  [f.p.e.c.f.FsParser] FS crawler started for [fscrawler] for [/tmp/es] every [15m]
 ```
 
-If you did not create the directory, FSCrawler will complain until you fix it:
+If the directory does not exist, FSCrawler warns until you create it:
 
 ```none
 17:41:45,396 INFO  [f.p.e.c.f.FsParser] Run #1: job [fscrawler]: starting...
@@ -43,20 +70,28 @@ If you did not create the directory, FSCrawler will complain until you fix it:
 
 ## Searching for docs
 
-This is a common use case in elasticsearch, we want to search for something! 😉
+Search on the job alias (`fscrawler` by default), not on a type name:
 
-```json
-// GET docs/doc/_search
+```none
+GET fscrawler/_search
 {
-  "query" : {
-    "query_string": {
-      "query": "I am searching for something!"
+  "query": {
+    "match": {
+      "content": "I am searching for something!"
     }
   }
 }
 ```
 
-See {ref}`search-examples` for more examples.
+In Kibana, you can also use ES|QL:
+
+```sql
+FROM fscrawler
+| WHERE content : "something"
+```
+
+See {ref}`search-examples` for more examples. If Kibana 9.5+ is running, FSCrawler can create a
+default dashboard on startup. See {ref}`kibana-settings`.
 
 ## Ignoring folders
 

--- a/docs/source/user/llm-assistant.md
+++ b/docs/source/user/llm-assistant.md
@@ -72,6 +72,7 @@ Important rules — do not get these wrong:
 1. Use `elasticsearch.urls` (a YAML list). The old `nodes` key is not supported; unknown keys are silently ignored.
 2. With Elastic start-local, use http:// (not https://) — start-local exposes HTTP on localhost only.
 3. Do not set `elasticsearch.index` to the same value as `name`. FSCrawler creates a search alias named after the job; a conflicting index name causes "alias name self-conflicts with index name".
+4. There is no in-place upgrade from FSCrawler 2.9. Recreate jobs with `--setup` and reindex.
 4. In Docker, 127.0.0.1 is the container itself. Use host.docker.internal (Linux: add --add-host=host.docker.internal:host-gateway) or the host machine IP to reach Elasticsearch on the host.
 5. Environment variables follow the pattern FSCRAWLER_* (see CLI options in the docs).
 

--- a/docs/source/user/tutorial.md
+++ b/docs/source/user/tutorial.md
@@ -1,4 +1,7 @@
+(tutorial)=
 # Tutorial
+
+Coming from 2.9? There is no in-place upgrade. See {ref}`upgrade-from-2.9`.
 
 This tutorial use case is:
 

--- a/docs/source/user/upgrade.md
+++ b/docs/source/user/upgrade.md
@@ -1,0 +1,50 @@
+(upgrade-from-2.9)=
+# Upgrading from 2.9
+
+FSCrawler 3.0 is a new major version. **There is no in-place upgrade from 2.9.**
+
+Install 3.0, recreate each job with `--setup`, and reindex. Do not start 3.0 against a 2.9
+configuration directory and do not copy a 2.9 `_settings.yaml` as-is.
+
+2.9 indices, mappings, and document `_id`s are not migrated. Keep the 2.9 deployment until you have
+verified 3.0, then remove the old indices when you no longer need them.
+
+## What to do
+
+1. Stop every FSCrawler 2.9 process.
+2. Install 3.0 (ZIP or Docker). See {ref}`installation`.
+3. Create jobs with `bin/fscrawler --setup` (or `--setup job_name`).
+4. Edit the generated `_settings.yaml`: `fs.url`, `elasticsearch.urls`, and an API key.
+5. Reindex from the filesystem (or re-upload through the REST `_document` endpoint).
+
+The fastest path for a new 3.0 install is the {ref}`tutorial`.
+
+## Why a 2.9 job file will not work
+
+A 2.9 `_settings.yaml` uses settings and defaults that 3.0 does not accept or no longer means the
+same thing. The main ones:
+
+| 2.9 | 3.0 |
+|-----|-----|
+| `elasticsearch.nodes` / `elasticsearch.nodes.url` | `elasticsearch.urls` (a list). Unknown keys are ignored and FSCrawler falls back to `https://127.0.0.1:9200`. |
+| Job folder created on first run | `fscrawler --setup` |
+| No job name lists existing jobs | `fscrawler --list` |
+| REST `_upload` | `_document` |
+| REST base path `/fscrawler/` | `/` |
+| Docker command includes `fscrawler` binary | image entrypoint; pass the job name only |
+| Tika XML config | Tika JSON config |
+| `server.protocol` | `fs.provider` (`local`, `ftp`, `ssh`) |
+| `fs.ocr.pdf_strategy` default `ocr_and_text` | default `auto` |
+| Basic auth | API keys (basic auth still works, but is deprecated) |
+| One distribution per Elasticsearch version | a single distribution |
+
+New jobs created with `--setup` set `fs.hash_algorithm` to `SHA-256`. 2.9 document `_id`s used MD5.
+Reindexing with 3.0 produces new ids.
+
+The default `fs.ocr.pdf_strategy` is now `auto`: OCR is skipped on PDF pages that already contain
+text. Set `ocr_and_text` if you need OCR on every page.
+
+Apache Tika 4 renamed several `meta.raw.*` keys. Queries, aggregations, and templates that depend on
+those names must be rewritten. See {ref}`release-notes-3.0`.
+
+The full list of changes is in {ref}`release-notes-3.0`.

--- a/llms.txt
+++ b/llms.txt
@@ -14,15 +14,16 @@ For copy-paste prompts to use with ChatGPT, Claude, or other assistants, see the
 
 - [Installation](https://fscrawler.readthedocs.io/en/latest/installation.html.md): Docker, ZIP distribution, and Docker Compose.
 - [Getting Started](https://fscrawler.readthedocs.io/en/latest/user/getting_started.html.md): First run with `--setup`, default paths, and a basic search example.
-- [Tutorial](https://fscrawler.readthedocs.io/en/latest/user/tutorial.html.md): End-to-end walkthrough with Elastic start-local, Docker, and Kibana ES|QL queries.
+- [Upgrading from 2.9](https://fscrawler.readthedocs.io/en/latest/user/upgrade.html.md): 3.0 is a fresh install; there is no in-place upgrade from 2.9.
+- [Tutorial](https://fscrawler.readthedocs.io/en/latest/user/tutorial.html.md): End-to-end walkthrough with Elastic start-local, Docker, and Kibana.
 - [LLM assistant](https://fscrawler.readthedocs.io/en/latest/user/llm-assistant.html.md): Ready-to-copy prompts for configuring FSCrawler with an AI assistant.
 
 ## User guide
 
 - [Crawler options](https://fscrawler.readthedocs.io/en/latest/user/options.html.md): Update rate, `--loop`, and `--restart`.
 - [Supported formats](https://fscrawler.readthedocs.io/en/latest/user/formats.html.md): Document types handled by Apache Tika.
-- [OCR](https://fscrawler.readthedocs.io/en/latest/user/ocr.html.md): Optical character recognition settings.
-- [REST API](https://fscrawler.readthedocs.io/en/latest/user/rest.html.md): Upload binary documents over HTTP.
+- [OCR](https://fscrawler.readthedocs.io/en/latest/user/ocr.html.md): Optical character recognition (Tesseract) and optional VLM OCR.
+- [REST API](https://fscrawler.readthedocs.io/en/latest/user/rest.html.md): Upload binary documents over HTTP; fetch from HTTP or S3.
 - [Tips and tricks](https://fscrawler.readthedocs.io/en/latest/user/tips.html.md): Docker, multi-machine setups, and common workarounds.
 
 ## Configuration reference
@@ -31,6 +32,7 @@ For copy-paste prompts to use with ChatGPT, Claude, or other assistants, see the
 - [SSH](https://fscrawler.readthedocs.io/en/latest/admin/fs/ssh.html.md): Remote crawling over SSH/SFTP.
 - [FTP](https://fscrawler.readthedocs.io/en/latest/admin/fs/ftp.html.md): Remote crawling over FTP.
 - [Elasticsearch settings](https://fscrawler.readthedocs.io/en/latest/admin/fs/elasticsearch.html.md): URLs, API key, SSL, indices, bulk settings, semantic search.
+- [Kibana settings](https://fscrawler.readthedocs.io/en/latest/admin/fs/kibana.html.md): Default dashboard on job startup (Kibana 9.5+).
 - [Password-protected documents](https://fscrawler.readthedocs.io/en/latest/admin/fs/passwords.html.md): Encrypted PDF and Office files.
 - [Document IDs](https://fscrawler.readthedocs.io/en/latest/admin/fs/document-ids.html.md): How document identifiers are built.
 - [Tags and metadata](https://fscrawler.readthedocs.io/en/latest/admin/fs/tags.html.md): Custom fields on indexed documents.
@@ -39,6 +41,7 @@ For copy-paste prompts to use with ChatGPT, Claude, or other assistants, see the
 
 ## Common pitfalls
 
+- There is no in-place upgrade from 2.9: install 3.0, recreate jobs with `--setup`, and reindex.
 - Use `elasticsearch.urls` (a list), not `nodes`. Unknown keys are silently ignored.
 - With Elastic start-local, use `http://` (not `https://`) for Elasticsearch.
 - Do not set `elasticsearch.index` to the same value as the job `name`; FSCrawler creates an alias with the job name.

--- a/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/settings/fscrawler-default.yaml
+++ b/settings/src/main/resources/fr/pilato/elasticsearch/crawler/fs/settings/fscrawler-default.yaml
@@ -75,8 +75,8 @@ fs:
   # optional: recommended, but will create another index
   #index_folders: true
 
-  # optional: the optional path to a specific external Tika Configuration file
-  #tika_config_path: "/path/to/tika-config.xml"
+  # optional: the optional path to a specific external Tika JSON configuration file
+  #tika_config_path: "/path/to/tika-config.json"
 
   # optional: the OCR Options
   #ocr:


### PR DESCRIPTION
## Summary
- Resolve the committed merge conflict in the 3.0 release notes and align versions (Tika 4.0.0, Elasticsearch 9.5.2)
- Document that 2.9 cannot be upgraded in place: install 3.0, recreate jobs with `--setup`, and reindex
- Fix Getting Started, installation (ZIP more visible), the job YAML example, REST samples, README, and `llms.txt`

## Test plan
- [ ] Preview `docs/source/user/upgrade.md` and confirm the "no in-place upgrade" message is unambiguous
- [ ] Walk through Getting Started and Installation headings; ZIP install should be easy to find
- [ ] Check the job example: `fs.provider`, `hash_algorithm`, Kibana, OCR `auto`
- [ ] Confirm 3.0 release notes render without conflict markers and mention Tika 4 / ES 9.5.2


Made with [Cursor](https://cursor.com)