### PR TITLE
fix(distribution): flatten POM for Maven Central ZIP-only publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 target
+.flattened-pom.xml
 docs/build
 /.settings
 /.classpath

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -9,6 +9,12 @@
 
     <artifactId>fscrawler-distribution</artifactId>
     <name>FSCrawler ZIP Distribution</name>
+    <url>https://github.com/dadoonet/fscrawler/</url>
+    <scm>
+        <connection>scm:git:git@github.com:dadoonet/fscrawler.git</connection>
+        <developerConnection>scm:git:git@github.com:dadoonet/fscrawler.git</developerConnection>
+        <url>scm:git:git@github.com:dadoonet/fscrawler.git</url>
+    </scm>
 
     <properties>
         <!-- Global configuration parameters for docker -->
@@ -58,6 +64,11 @@
         <dependency>
             <groupId>fr.pilato.elasticsearch.crawler</groupId>
             <artifactId>fscrawler-elasticsearch-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>fr.pilato.elasticsearch.crawler</groupId>
+            <artifactId>fscrawler-test-framework</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -139,22 +150,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <!-- There is no unit test, so we can skip that execution -->
-                        <id>unit-tests</id>
-                        <phase>none</phase>
-                    </execution>
-                    <execution>
-                        <!-- There is no integration test, so we can skip that execution -->
-                        <id>integration-tests</id>
-                        <phase>none</phase>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
 
@@ -203,6 +198,33 @@
                             <goal>single</goal>
                         </goals>
                         <phase>package</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Flatten the POM so Maven Central can validate it without publishing
+                 fscrawler-parent. Only this ZIP artifact is deployed; a thin child POM
+                 fails Central checks (missing OSS metadata and unresolved versions). -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <configuration>
+                    <flattenMode>oss</flattenMode>
+                    <updatePomFile>true</updatePomFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <phase>clean</phase>
                     </execution>
                 </executions>
             </plugin>

--- a/distribution/src/test/java/fr/pilato/elasticsearch/crawler/fs/distribution/FlattenedDistributionPomTest.java
+++ b/distribution/src/test/java/fr/pilato/elasticsearch/crawler/fs/distribution/FlattenedDistributionPomTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
+ */
+package fr.pilato.elasticsearch.crawler.fs.distribution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Maven Central validates the deployed distribution POM in isolation. It must not rely on {@code fscrawler-parent}
+ * being published.
+ */
+class FlattenedDistributionPomTest extends AbstractFSCrawlerTestCase {
+
+    private static final Pattern CLI_VERSION =
+            Pattern.compile("<artifactId>fscrawler-cli</artifactId>\\s*<version>[^<]+</version>", Pattern.DOTALL);
+    private static final Pattern ES_CLIENT_VERSION = Pattern.compile(
+            "<artifactId>fscrawler-elasticsearch-client</artifactId>\\s*<version>[^<]+</version>", Pattern.DOTALL);
+
+    @Test
+    void flattenedPomIsSelfContainedForMavenCentral() throws Exception {
+        Path flattenedPom = Path.of(".flattened-pom.xml");
+        assertThat(flattenedPom)
+                .as("flatten-maven-plugin must write .flattened-pom.xml during process-resources")
+                .exists();
+
+        String xml = Files.readString(flattenedPom);
+        assertThat(xml).doesNotContain("<parent>");
+        assertThat(xml).contains("<groupId>fr.pilato.elasticsearch.crawler</groupId>");
+        assertThat(xml).contains("<artifactId>fscrawler-distribution</artifactId>");
+        assertThat(xml).contains("<description>");
+        assertThat(xml).contains("<url>https://github.com/dadoonet/fscrawler/</url>");
+        assertThat(xml).contains("<licenses>");
+        assertThat(xml).contains("<scm>");
+        assertThat(xml).contains("<url>scm:git:git@github.com:dadoonet/fscrawler.git</url>");
+        assertThat(xml).contains("<developers>");
+        assertThat(xml).containsPattern(CLI_VERSION);
+        assertThat(xml).containsPattern(ES_CLIENT_VERSION);
+    }
+}

--- a/distribution/src/test/java/fr/pilato/elasticsearch/crawler/fs/distribution/ReleaseScriptFilteredResourcesTest.java
+++ b/distribution/src/test/java/fr/pilato/elasticsearch/crawler/fs/distribution/ReleaseScriptFilteredResourcesTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
+ */
+package fr.pilato.elasticsearch.crawler.fs.distribution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@code distribution/test-scripts/} is generated outside {@code target/}, so {@code mvn clean} does not remove it. The
+ * release script must regenerate it on version bumps and restore it on rollback, otherwise a failed release leaves
+ * {@code FSCRAWLER_VERSION=3.0} on the SNAPSHOT branch.
+ */
+class ReleaseScriptFilteredResourcesTest extends AbstractFSCrawlerTestCase {
+
+    @Test
+    void versionBumpRegeneratesDistributionTestScripts() throws Exception {
+        String regenerate = functionBody(readReleaseScript(), "regenerate_filtered_resources");
+        assertThat(regenerate)
+                .as("set_project_version must run generate-test-resources so test-scripts get the new version")
+                .contains("generate-test-resources");
+    }
+
+    @Test
+    void rollbackRestoresDistributionTestScripts() throws Exception {
+        String rollback = functionBody(readReleaseScript(), "rollback_from_state_file");
+        assertThat(rollback)
+                .as("--rollback must restore leftover filtered test-scripts before leaving the release branch")
+                .contains("distribution/test-scripts");
+        assertThat(rollback)
+                .as("--rollback must re-filter resources against the restored SNAPSHOT POMs")
+                .contains("regenerate_filtered_resources");
+    }
+
+    private static String readReleaseScript() throws Exception {
+        Path script = Path.of("..", "release.sh");
+        assertThat(script)
+                .as("release.sh must be reachable from the distribution module basedir")
+                .exists();
+        return Files.readString(script);
+    }
+
+    private static String functionBody(String script, String name) {
+        String header = name + "() {";
+        int start = script.indexOf(header);
+        assertThat(start).as("function %s() must exist in release.sh", name).isGreaterThanOrEqualTo(0);
+        int end = script.indexOf("\n}", start);
+        assertThat(end).as("function %s() must have a closing brace", name).isGreaterThan(start);
+        return script.substring(start, end + 2);
+    }
+}

--- a/docs/source/dev/release.md
+++ b/docs/source/dev/release.md
@@ -25,7 +25,9 @@ Run `./release.sh --help` for the full list of options.
 `--rollback`
 : Undoes a local or failed release using the `release/.release` state file (under the
   gitignored `release/` directory). Deletes the local release branch and tag, checks out
-  the original branch, and removes `release/.release`.
+  the original branch, restores leftover filtered files (notably
+  `distribution/test-scripts/`, which lives outside `target/`), re-filters them against
+  the restored SNAPSHOT POMs, and removes `release/.release`.
 
 Typical local rehearsal:
 
@@ -51,7 +53,11 @@ works even when the build fails midway.
 * Build the final artifacts using the `release` profile (javadoc, sources, GPG signing)
 * Tag the version
 * Prepare release notes from `docs/source/release/{version}.md` and GitHub API
-* Deploy to [Maven Central](https://central.sonatype.com/) using the `central-publishing-maven-plugin`
+* Deploy **only** `fscrawler-distribution` to [Maven Central](https://central.sonatype.com/)
+  using the `central-publishing-maven-plugin`. Other modules set `skipPublishing=true`.
+  `flatten-maven-plugin` (`flattenMode=oss`) writes a self-contained POM (no parent,
+  OSS metadata inlined, dependency versions resolved) so Central can validate the ZIP
+  artifact without publishing `fscrawler-parent`.
 * Prepare the next SNAPSHOT version
 * Commit the change
 * Merge the release branch into the branch you started from

--- a/pom.xml
+++ b/pom.xml
@@ -998,6 +998,11 @@
                     </executions>
                 </plugin>
                 <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>flatten-maven-plugin</artifactId>
+                    <version>1.8.0</version>
+                </plugin>
+                <plugin>
                     <groupId>org.sonatype.central</groupId>
                     <artifactId>central-publishing-maven-plugin</artifactId>
                     <version>0.11.0</version>

--- a/release.sh
+++ b/release.sh
@@ -401,6 +401,11 @@ rollback_from_state_file() {
 	info "  release branch:  ${RELEASE_BRANCH}"
 	info "  release tag:     ${RELEASE_TAG}"
 
+	# Discard leftover filtered copies (outside target/) before switching branches.
+	# git checkout keeps uncommitted files when both branches have the same blob,
+	# which is how FSCRAWLER_VERSION=3.0 survived onto the SNAPSHOT branch.
+	restore_filtered_working_tree
+
 	local current_branch
 	current_branch="$(git -C "${ROOT_DIR}" rev-parse --abbrev-ref HEAD)"
 
@@ -437,9 +442,22 @@ rollback_from_state_file() {
 		info "Release tag ${RELEASE_TAG} not found (already removed)."
 	fi
 
+	# Restore again from the original branch HEAD, then re-filter so
+	# distribution/test-scripts matches the SNAPSHOT POMs.
+	restore_filtered_working_tree
+	if [[ -z "${LOG_FILE}" ]]; then
+		LOG_FILE="/dev/null"
+	fi
+	regenerate_filtered_resources
+
 	disable_release_tracking
 	clear_release_state
 	success "Rollback complete — back on ${ORIGINAL_BRANCH}."
+}
+
+restore_filtered_working_tree() {
+	log "Restoring filtered resources from HEAD (distribution/test-scripts)"
+	git_cmd restore --worktree --source=HEAD -- "distribution/test-scripts" || true
 }
 
 # ---------------------------------------------------------------------------
@@ -604,8 +622,10 @@ set_project_version() {
 }
 
 regenerate_filtered_resources() {
-	log "Regenerating filtered documentation resources"
-	mvn_run clean process-resources
+	log "Regenerating filtered resources (docs, contrib, distribution/test-scripts)"
+	# generate-test-resources is required: distribution/test-scripts is bound to that
+	# phase and lives outside target/, so mvn clean does not remove it.
+	mvn_run clean generate-test-resources
 }
 
 build_release() {


### PR DESCRIPTION
## Summary

- Flatten `fscrawler-distribution` with `flatten-maven-plugin` (`oss`) so Maven Central can validate the ZIP-only artifact without publishing `fscrawler-parent` (missing OSS metadata and unresolved dependency versions).
- Version bumps now regenerate `distribution/test-scripts/` via `generate-test-resources` (that file lives outside `target/`).
- `--rollback` restores leftover filtered scripts from HEAD, then re-filters them against the restored SNAPSHOT POMs.

## Test plan

- [x] `mvn test -pl distribution -am -DskipIntegTests -Ddocker.skip -Dtest=ReleaseScriptFilteredResourcesTest,FlattenedDistributionPomTest`
- [ ] After merge, re-run `./release.sh` for 3.0 (prefer JDK 21)


Made with [Cursor](https://cursor.com)