### PR TITLE
Stop SNAPSHOT Docker builds from moving latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ index ([mirrored in the repo](llms.txt)) and clean Markdown versions of every do
 ### Version in preparation
 
 [![Latest SNAPSHOT](https://img.shields.io/github/v/release/dadoonet/fscrawler?include_prereleases&label=Latest%20SNAPSHOT)](https://github.com/dadoonet/fscrawler/releases)
-![Docker Image Version (latest build)](https://img.shields.io/docker/v/dadoonet/fscrawler?label=latest%20build)
-![Docker Image Size (latest build)](https://img.shields.io/docker/image-size/dadoonet/fscrawler?label=latest%20build%20size)
+![Docker Image Version (snapshot)](https://img.shields.io/docker/v/dadoonet/fscrawler/snapshot?label=snapshot)
+![Docker Image Size (snapshot)](https://img.shields.io/docker/image-size/dadoonet/fscrawler/snapshot?label=snapshot%20size)
 ![GitHub commits since latest release](https://img.shields.io/github/commits-since/dadoonet/fscrawler/latest/main)
 ![GitHub last commit](https://img.shields.io/github/last-commit/dadoonet/fscrawler)
 [![Build](https://github.com/dadoonet/fscrawler/actions/workflows/maven.yml/badge.svg)](https://github.com/dadoonet/fscrawler/actions/workflows/maven.yml)
@@ -110,8 +110,8 @@ index ([mirrored in the repo](llms.txt)) and clean Markdown versions of every do
 
 [![GitHub Release](https://img.shields.io/github/v/release/dadoonet/fscrawler?label=Latest%20release)](https://github.com/dadoonet/fscrawler/releases/latest)
 ![GitHub Release Date](https://img.shields.io/github/release-date/dadoonet/fscrawler)
-![Docker Image Version](https://img.shields.io/docker/v/dadoonet/fscrawler?sort=semver&label=docker%20image%20version)
-![Docker Image Size](https://img.shields.io/docker/image-size/dadoonet/fscrawler?sort=semver&label=docker%20image%20size)
+![Docker Image Version](https://img.shields.io/docker/v/dadoonet/fscrawler/latest?label=docker%20latest)
+![Docker Image Size](https://img.shields.io/docker/image-size/dadoonet/fscrawler/latest?label=docker%20latest%20size)
 
 ### Build & quality
 

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -31,8 +31,8 @@
         <docker.noocr.dockerFile>${project.basedir}/src/main/docker/Dockerfile</docker.noocr.dockerFile>
         <docker.noocr.assembly.descriptor>${project.basedir}/src/main/assembly/assembly.xml</docker.noocr.assembly.descriptor>
         <docker.noocr.assembly.mode>tgz</docker.noocr.assembly.mode>
-        <!-- We use this tag to make easy using docker pull dadoonet/fscrawler:noocr -->
-        <docker.noocr.tags.0>noocr</docker.noocr.tags.0>
+        <!-- SNAPSHOT: snapshot-noocr. Release (-Prelease): noocr. -->
+        <docker.noocr.tags.0>${docker.noocr.alias.tag}</docker.noocr.tags.0>
         <docker.noocr.buildx.platforms.0>linux/amd64</docker.noocr.buildx.platforms.0>
         <docker.noocr.buildx.platforms.1>linux/arm64</docker.noocr.buildx.platforms.1>
 
@@ -44,9 +44,9 @@
         <docker.ocr.assembly.descriptor>${docker.noocr.assembly.descriptor}</docker.ocr.assembly.descriptor>
         <docker.ocr.assembly.mode>${docker.noocr.assembly.mode}</docker.ocr.assembly.mode>
         <docker.ocr.args.langsPkg>imagemagick tesseract-ocr tesseract-ocr-all</docker.ocr.args.langsPkg>
-        <!-- The ocr version will be the default one for anyone trying docker pull dadoonet/fscrawler:VERSION -->
+        <!-- :VERSION always. Floating alias is snapshot on SNAPSHOT builds, latest on -Prelease. -->
         <docker.ocr.tags.0>${project.version}</docker.ocr.tags.0>
-        <docker.ocr.tags.1>latest</docker.ocr.tags.1>
+        <docker.ocr.tags.1>${docker.ocr.alias.tag}</docker.ocr.tags.1>
         <docker.ocr.buildx.platforms.0>linux/amd64</docker.ocr.buildx.platforms.0>
         <docker.ocr.buildx.platforms.1>linux/arm64</docker.ocr.buildx.platforms.1>
 

--- a/distribution/src/test/java/fr/pilato/elasticsearch/crawler/fs/distribution/DockerImageTagsTest.java
+++ b/distribution/src/test/java/fr/pilato/elasticsearch/crawler/fs/distribution/DockerImageTagsTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
+ */
+package fr.pilato.elasticsearch.crawler.fs.distribution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@code latest} / {@code noocr} are floating tags for the last stable release. SNAPSHOT builds must not move them;
+ * they use {@code snapshot} / {@code snapshot-noocr} instead.
+ */
+class DockerImageTagsTest extends AbstractFSCrawlerTestCase {
+
+    @Test
+    void distributionPomDelegatesFloatingTagsToParentAliasProperties() throws Exception {
+        String distPom = Files.readString(Path.of("pom.xml"));
+        assertThat(xmlProperty(distPom, "docker.ocr.tags.0"))
+                .as("the version tag stays on the SNAPSHOT or release version")
+                .isEqualTo("${project.version}");
+        assertThat(xmlProperty(distPom, "docker.ocr.tags.1"))
+                .as("SNAPSHOT must not hardcode latest; the parent alias switches snapshot vs latest")
+                .isEqualTo("${docker.ocr.alias.tag}");
+        assertThat(xmlProperty(distPom, "docker.noocr.tags.0"))
+                .as("SNAPSHOT must not hardcode noocr; the parent alias switches snapshot-noocr vs noocr")
+                .isEqualTo("${docker.noocr.alias.tag}");
+    }
+
+    @Test
+    void snapshotAliasTagsAreSnapshotNotLatest() throws Exception {
+        String parentPom = Files.readString(repoRoot().resolve("pom.xml"));
+        String defaultProperties = parentPom.substring(0, parentPom.indexOf("<profiles>"));
+        assertThat(xmlProperty(defaultProperties, "docker.ocr.alias.tag"))
+                .as("untagged SNAPSHOT builds publish the snapshot alias, not latest")
+                .isEqualTo("snapshot");
+        assertThat(xmlProperty(defaultProperties, "docker.noocr.alias.tag")).isEqualTo("snapshot-noocr");
+        assertThat(defaultProperties)
+                .as("latest must not be a default OCR floating tag")
+                .doesNotContain("<docker.ocr.alias.tag>latest</docker.ocr.alias.tag>");
+    }
+
+    @Test
+    void releaseProfileMovesLatestAndNoocr() throws Exception {
+        String releaseProfile = releaseProfileXml(Files.readString(repoRoot().resolve("pom.xml")));
+        assertThat(xmlProperty(releaseProfile, "docker.ocr.alias.tag"))
+                .as("-Prelease must make docker pull dadoonet/fscrawler resolve to this release")
+                .isEqualTo("latest");
+        assertThat(xmlProperty(releaseProfile, "docker.noocr.alias.tag")).isEqualTo("noocr");
+    }
+
+    @Test
+    void installationDocsDescribeLatestAsStableRelease() throws Exception {
+        String installation =
+                Files.readString(repoRoot().resolve("docs").resolve("source").resolve("installation.md"));
+        assertThat(installation)
+                .as("users must be told that untagged / latest is the last stable release")
+                .contains("last **stable** release")
+                .contains("`snapshot`")
+                .contains("`snapshot-noocr`")
+                .contains("{{ docker_image_tag }}");
+    }
+
+    private static Path repoRoot() {
+        return Path.of("..").toAbsolutePath().normalize();
+    }
+
+    private static String releaseProfileXml(String parentPom) {
+        Matcher matcher = Pattern.compile("<profile>\\s*<id>release</id>.*?</profile>", Pattern.DOTALL)
+                .matcher(parentPom);
+        assertThat(matcher.find())
+                .as("parent POM must define a release profile")
+                .isTrue();
+        return matcher.group();
+    }
+
+    private static String xmlProperty(String xml, String name) {
+        Matcher matcher = Pattern.compile("<" + Pattern.quote(name) + ">([^<]*)</" + Pattern.quote(name) + ">")
+                .matcher(xml);
+        assertThat(matcher.find()).as("missing <%s> in:%n%s", name, xml).isTrue();
+        return matcher.group(1);
+    }
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,6 +51,9 @@ version = read_version(full_version=False)
 # The full version, including alpha/beta/rc tags.
 release = read_version()
 
+# Docker Hub: untagged / latest is the last stable release. SNAPSHOT docs pin :snapshot.
+docker_image_tag = ':snapshot' if release.endswith('-SNAPSHOT') else ''
+
 githubReleasesUrl = "https://github.com/dadoonet/fscrawler/releases"
 downloadUrl = "%s/download/fscrawler-%s/fscrawler-%s.zip" % (githubReleasesUrl, release, release)
 
@@ -303,5 +306,6 @@ myst_substitutions = {
     'GitHub': f'[GitHub Releases]({githubReleasesUrl})',
     'downloadUrl': downloadUrl,
     'java_version': java_version,
+    'docker_image_tag': docker_image_tag,
 }
 # End of conf.py

--- a/docs/source/dev/build.md
+++ b/docs/source/dev/build.md
@@ -301,6 +301,30 @@ you can manually use the `docker.skip` option:
 mvn package -Ddocker.skip
 ```
 
+## Docker Hub tags
+
+Each image is published under a version tag (`{{ release }}` / `{{ release }}-ocr` /
+`{{ release }}-noocr`) plus a **floating** alias:
+
+| Build | OCR alias | No-OCR alias |
+|---|---|---|
+| SNAPSHOT (`main`, no extra profile) | `snapshot` | `snapshot-noocr` |
+| Release (`-Prelease`) | `latest` | `noocr` |
+
+`docker pull dadoonet/fscrawler` therefore always means the last **stable** release.
+Do not retag `latest` from a SNAPSHOT push.
+
+To point `latest` at an already published release without rebuilding (multi-arch
+manifest, amd64 + arm64), copy the existing tag:
+
+```shell
+docker buildx imagetools create --tag dadoonet/fscrawler:latest dadoonet/fscrawler:3.0
+docker buildx imagetools create --tag dadoonet/fscrawler:noocr dadoonet/fscrawler:3.0-noocr
+```
+
+`docker tag` + `docker push` on a single machine would drop the other architecture.
+Docker Hub's UI is not a reliable way to copy a multi-platform manifest.
+
 ## DockerHub publication
 
 To publish the latest build to [DockerHub](https://hub.docker.com/r/dadoonet/fscrawler/) you can manually

--- a/docs/source/dev/release.md
+++ b/docs/source/dev/release.md
@@ -63,7 +63,10 @@ is running: Maven and git mutations are already bound to that path.
 * Tag the version
 * Prepare release notes from `docs/source/release/{version}.md` and GitHub API
 * Push Docker images to [Docker Hub](https://hub.docker.com/r/dadoonet/fscrawler/)
-  (`mvn deploy` with `skipPublishing=true` on every module — nothing is published to Maven Central)
+  (`mvn deploy` with `skipPublishing=true` on every module — nothing is published to Maven Central).
+  `-Prelease` moves the floating tags `latest` (OCR) and `noocr` onto this version.
+  SNAPSHOT pushes to `main` use `snapshot` / `snapshot-noocr` instead and must not
+  overwrite `latest`.
 * Prepare the next SNAPSHOT version, update the README "Latest versions" table
   (HTML comment markers `<!-- release-versions:start -->` / `<!-- release-versions:end -->`),
   and point `.github/dependabot.yml` at the GitHub milestone titled like that SNAPSHOT

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -12,18 +12,43 @@ Coming from 2.9? There is no in-place upgrade. See {ref}`upgrade-from-2.9`.
 (docker)=
 ## Using Docker
 
-Pull the Docker image from [Docker Hub](https://hub.docker.com/r/dadoonet/fscrawler):
+Pull the Docker image from [Docker Hub](https://hub.docker.com/r/dadoonet/fscrawler).
+
+`latest` (the default when you omit the tag) is the **last stable release**, with OCR.
+SNAPSHOT builds from `main` use the `snapshot` tag instead, matching GitHub pre-releases
+which are never GitHub's "Latest" release.
+
+| Tag | Image |
+|---|---|
+| `latest` (or untagged) | Last **stable** release, with OCR |
+| `noocr` | Last **stable** release, without OCR |
+| `snapshot` | Current SNAPSHOT (`main`), with OCR |
+| `snapshot-noocr` | Current SNAPSHOT, without OCR |
+| `{{ release }}`, `{{ release }}-noocr` | This documentation version |
+| `3.0`, `3.0-noocr`, `3.1-SNAPSHOT`, … | A specific version |
 
 ```sh
-docker pull dadoonet/fscrawler
+docker pull dadoonet/fscrawler{{ docker_image_tag }}
 ```
+
+````{ifconfig} release.endswith('-SNAPSHOT')
+```{warning}
+These docs describe a **SNAPSHOT** build. `docker pull dadoonet/fscrawler` (no tag) still
+pulls the last **stable** release. To run this SNAPSHOT:
+
+```sh
+docker pull dadoonet/fscrawler:snapshot
+# or: docker pull dadoonet/fscrawler:{{ release }}
+```
+```
+````
 
 ````{note}
 
  This image is very big (500+mb) as it contains [Tesseract](https://tesseract-ocr.github.io/tessdoc/) and
  all the [trained language data](https://tesseract-ocr.github.io/tessdoc/Data-Files.html).
  If you don't want to use OCR at all, you can use a smaller image (around 230mb) by pulling instead
- `dadoonet/fscrawler:noocr`:
+ `dadoonet/fscrawler:noocr` (last stable) or `dadoonet/fscrawler:snapshot-noocr` (SNAPSHOT):
 
  ```shell
  docker pull dadoonet/fscrawler:noocr
@@ -36,7 +61,7 @@ On first run, create the job settings:
 ```sh
 docker run -it --rm \
      -v ~/.fscrawler:/root/.fscrawler \
-     dadoonet/fscrawler --setup
+     dadoonet/fscrawler{{ docker_image_tag }} --setup
 ```
 
 Then run FSCrawler with:
@@ -45,7 +70,7 @@ Then run FSCrawler with:
 docker run -it --rm \
      -v ~/.fscrawler:/root/.fscrawler \
      -v ~/tmp:/tmp/es:ro \
-     dadoonet/fscrawler
+     dadoonet/fscrawler{{ docker_image_tag }}
 ```
 
 ```{note}
@@ -67,7 +92,7 @@ docker run -it --rm \
      -v ~/.fscrawler:/root/.fscrawler \
      -v ~/tmp:/tmp/es:ro \
      -v "$PWD/external:/usr/share/fscrawler/external" \
-     dadoonet/fscrawler
+     dadoonet/fscrawler{{ docker_image_tag }}
 ```
 
 If you want to use the {ref}`rest-service`, don't forget to also expose the port:
@@ -77,7 +102,7 @@ docker run -it --rm \
      -v ~/.fscrawler:/root/.fscrawler \
      -v ~/tmp:/tmp/es:ro \
      -p 8080:8080 \
-     dadoonet/fscrawler
+     dadoonet/fscrawler{{ docker_image_tag }}
 ```
 
 If you want to change the log level for FSCrawler, you can run:
@@ -88,7 +113,7 @@ docker run -it --rm \
      -v ~/tmp:/tmp/es:ro \
      -v ~/logs:/root/logs \
      -e FS_JAVA_OPTS="-DLOG_LEVEL=debug -DDOC_LEVEL=debug" \
-     dadoonet/fscrawler
+     dadoonet/fscrawler{{ docker_image_tag }}
 ```
 
 And you can read the logs from the `~/logs` directory:
@@ -103,7 +128,7 @@ You can pass all the CLI options to the docker container as well:
 docker run -it --rm \
      -v ~/.fscrawler:/root/.fscrawler \
      -v ~/tmp:/tmp/es:ro \
-     dadoonet/fscrawler job_name --restart --loop 1
+     dadoonet/fscrawler{{ docker_image_tag }} job_name --restart --loop 1
 ```
 
 See {ref}`cli-options` for more information.

--- a/docs/source/user/llm-assistant.md
+++ b/docs/source/user/llm-assistant.md
@@ -65,7 +65,7 @@ docker run -it --rm \
   -v /path/to/docs:/tmp/es:ro \
   -e FSCRAWLER_ELASTICSEARCH_URLS=http://host.docker.internal:9200 \
   -e FSCRAWLER_ELASTICSEARCH_API_KEY="your-api-key" \
-  dadoonet/fscrawler
+  dadoonet/fscrawler{{ docker_image_tag }}
 ```
 
 Important rules — do not get these wrong:

--- a/docs/source/user/tutorial.md
+++ b/docs/source/user/tutorial.md
@@ -54,10 +54,11 @@ echo "$ES_LOCAL_API_KEY"
 
 ### Start FSCrawler with Docker
 
-* Pull the FSCrawler image. See {ref}`docker` for details (including the smaller `noocr` variant):
+* Pull the FSCrawler image. See {ref}`docker` for details (including the smaller `noocr` variant).
+  On SNAPSHOT docs this is `:snapshot`; on a released version it is untagged (`latest`):
 
 ```sh
-docker pull dadoonet/fscrawler
+docker pull dadoonet/fscrawler{{ docker_image_tag }}
 ```
 
 * Create a job named `resumes`:
@@ -65,7 +66,7 @@ docker pull dadoonet/fscrawler
 ```sh
 docker run -it --rm \
   -v ~/.fscrawler:/root/.fscrawler \
-  dadoonet/fscrawler --setup resumes
+  dadoonet/fscrawler{{ docker_image_tag }} --setup resumes
 ```
 
 * Edit `~/.fscrawler/resumes/_settings.yaml` so the crawler reads documents from `/tmp/es` **inside** the
@@ -93,7 +94,7 @@ docker run -it --rm \
   -e FSCRAWLER_ELASTICSEARCH_URLS=http://host.docker.internal:9200 \
   -e FSCRAWLER_ELASTICSEARCH_API_KEY="${ES_LOCAL_API_KEY}" \
   -e FSCRAWLER_KIBANA_URL=http://host.docker.internal:5601 \
-  dadoonet/fscrawler resumes
+  dadoonet/fscrawler{{ docker_image_tag }} resumes
 ```
 
 ```{note}
@@ -136,7 +137,7 @@ FSCrawler should index all the documents inside your directory. Then continue wi
    -e FSCRAWLER_ELASTICSEARCH_URLS=http://host.docker.internal:9200 \
    -e FSCRAWLER_ELASTICSEARCH_API_KEY="${ES_LOCAL_API_KEY}" \
    -e FSCRAWLER_KIBANA_URL=http://host.docker.internal:5601 \
-   dadoonet/fscrawler resumes --restart
+   dadoonet/fscrawler{{ docker_image_tag }} resumes --restart
  ```
 ````
 

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,11 @@
         <java.compiler.version>17</java.compiler.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <!-- Floating Docker Hub tags. SNAPSHOT builds must not move latest/noocr;
+             -Prelease (see the release profile) switches these to the stable aliases. -->
+        <docker.ocr.alias.tag>snapshot</docker.ocr.alias.tag>
+        <docker.noocr.alias.tag>snapshot-noocr</docker.noocr.alias.tag>
     </properties>
 
     <dependencyManagement>
@@ -1272,8 +1277,9 @@
         <profile>
             <id>release</id>
             <properties>
-                <!-- The ocr version will be the default one for anyone trying docker pull dadoonet/fscrawler -->
-                <docker.ocr.tags.1>latest</docker.ocr.tags.1>
+                <!-- docker pull dadoonet/fscrawler (and :noocr) resolve to this release -->
+                <docker.ocr.alias.tag>latest</docker.ocr.alias.tag>
+                <docker.noocr.alias.tag>noocr</docker.noocr.alias.tag>
             </properties>
             <build>
                 <plugins>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`latest` and `noocr` are now floating tags for the **last stable release**, not the current SNAPSHOT. This matches GitHub (`--prerelease --latest=false`) and Docker Hub convention.

## What changed

- SNAPSHOT builds (`main`) publish `snapshot` / `snapshot-noocr` (plus version tags like `3.1-SNAPSHOT`).
- `-Prelease` still moves `latest` (OCR) and `noocr` onto that version.
- Docs (installation, tutorial, build, release) describe the tags. SNAPSHOT docs pin `{{ docker_image_tag }}` to `:snapshot`.

## After merge: retag 3.0 as latest on Docker Hub

Stopping SNAPSHOT from pushing `latest` does **not** move the existing Hub tag. `latest` currently still points at the last SNAPSHOT that was pushed. Copy the multi-arch 3.0 manifests (do **not** use the Docker Hub UI or a single-arch `docker tag`/`push`):

```sh
docker login
docker buildx imagetools create --tag dadoonet/fscrawler:latest dadoonet/fscrawler:3.0
docker buildx imagetools create --tag dadoonet/fscrawler:noocr dadoonet/fscrawler:3.0-noocr
```

Verify:

```sh
docker buildx imagetools inspect dadoonet/fscrawler:latest
docker buildx imagetools inspect dadoonet/fscrawler:3.0
```

The two inspect outputs should share the same manifest digest. `snapshot` appears on Hub at the next `main` SNAPSHOT deploy.

## Test plan

- [x] `DockerImageTagsTest` failed on current `latest` hardcoded tags, then passed
- [x] `mvn help:evaluate` — default `docker.ocr.tags.1=snapshot`, `-Prelease` → `latest`; same for `noocr` / `snapshot-noocr`
- [x] `mvn test -pl distribution -am -DskipIntegTests -Ddocker.skip`
- [x] `mvn spotless:check -pl distribution,docs -am`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5303ae5-e919-4198-8c96-353f8b906eb2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5303ae5-e919-4198-8c96-353f8b906eb2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

