### PR TITLE
Fix MyST substitutions and ifconfig in the docs

### DIFF
--- a/distribution/src/test/java/fr/pilato/elasticsearch/crawler/fs/distribution/DockerImageTagsTest.java
+++ b/distribution/src/test/java/fr/pilato/elasticsearch/crawler/fs/distribution/DockerImageTagsTest.java
@@ -80,7 +80,7 @@ class DockerImageTagsTest extends AbstractFSCrawlerTestCase {
                 .contains("last **stable** release")
                 .contains("`snapshot`")
                 .contains("`snapshot-noocr`")
-                .contains("{{ docker_image_tag }}");
+                .contains("|docker_image|");
     }
 
     private static Path repoRoot() {

--- a/distribution/src/test/java/fr/pilato/elasticsearch/crawler/fs/distribution/ReleaseProcessScriptTest.java
+++ b/distribution/src/test/java/fr/pilato/elasticsearch/crawler/fs/distribution/ReleaseProcessScriptTest.java
@@ -209,9 +209,9 @@ class ReleaseProcessScriptTest extends AbstractFSCrawlerTestCase {
         String installation =
                 Files.readString(repoRoot().resolve("docs").resolve("source").resolve("installation.md"));
         assertThat(installation)
-                .contains("{{ downloadUrl }}")
+                .contains("{{ download_link }}")
                 .contains("{{ GitHub }}")
-                .contains("fscrawler-{{ release }}.zip")
+                .contains("fscrawler-|release|.zip")
                 .doesNotContain("{{ Maven_Central }}")
                 .doesNotContain("{{ Sonatype }}")
                 .doesNotContain("{{ Download_URL }}");
@@ -232,8 +232,8 @@ class ReleaseProcessScriptTest extends AbstractFSCrawlerTestCase {
                 Files.readString(repoRoot().resolve("docs").resolve("source").resolve("installation.md"));
         assertThat(installation)
                 .contains("gpg --verify")
-                .contains("{{ downloadUrl }}.asc")
-                .contains("{{ downloadUrl }}.sha256")
+                .contains("|downloadUrl|.asc")
+                .contains("|downloadUrl|.sha256")
                 .contains("sha256sum")
                 .contains("EDEC15CE428D7527CF87E998C7E192835B0ABB2E");
         String keys = Files.readString(repoRoot().resolve("KEYS"));

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,7 +52,11 @@ version = read_version(full_version=False)
 release = read_version()
 
 # Docker Hub: untagged / latest is the last stable release. SNAPSHOT docs pin :snapshot.
-docker_image_tag = ':snapshot' if release.endswith('-SNAPSHOT') else ''
+_is_snapshot = release.endswith('-SNAPSHOT')
+docker_image = 'dadoonet/fscrawler:snapshot' if _is_snapshot else 'dadoonet/fscrawler'
+docker_image_noocr = (
+    'dadoonet/fscrawler:snapshot-noocr' if _is_snapshot else 'dadoonet/fscrawler:noocr'
+)
 
 githubReleasesUrl = "https://github.com/dadoonet/fscrawler/releases"
 downloadUrl = "%s/download/fscrawler-%s/fscrawler-%s.zip" % (githubReleasesUrl, release, release)
@@ -258,6 +262,8 @@ rst_prolog = rst_prolog + """
 .. |GitHub| replace:: GitHub Releases
 .. |downloadUrl| replace:: {fmt_downloadUrl}
 .. |java_version| replace:: {fmt_java_version}
+.. |docker_image| replace:: {fmt_docker_image}
+.. |docker_image_noocr| replace:: {fmt_docker_image_noocr}
 
 .. _Tika: https://tika.apache.org/{fmt_tika_version}/
 .. _ES: https://www.elastic.co/elasticsearch
@@ -279,7 +285,9 @@ fmt_downloadUrl=downloadUrl,
 fmt_githubReleasesUrl=githubReleasesUrl,
 fmt_es_stack_version=es_stack_version,
 fmt_fscrawler_version=release,
-fmt_java_version=java_version
+fmt_java_version=java_version,
+fmt_docker_image=docker_image,
+fmt_docker_image_noocr=docker_image_noocr,
 )
 
 _tika_version = config.get('3rdParty', 'TikaVersion')
@@ -305,7 +313,12 @@ myst_substitutions = {
     'JPEG2000_version': f'[jai-imageio-jpeg2000:{_jpeg_version}](https://repo1.maven.org/maven2/com/github/jai-imageio/jai-imageio-jpeg2000/{_jpeg_version}/)',
     'GitHub': f'[GitHub Releases]({githubReleasesUrl})',
     'downloadUrl': downloadUrl,
+    'download_link': f'[FSCrawler {release}]({downloadUrl})',
     'java_version': java_version,
-    'docker_image_tag': docker_image_tag,
+    'docker_image': docker_image,
+    'docker_image_noocr': docker_image_noocr,
+    'docker_image_noocr_code': f'`{docker_image_noocr}`',
+    'release_docker_tags': f'`{release}`, `{release}-noocr`',
+    'release_image_tags': f'`{release}` / `{release}-ocr` / `{release}-noocr`',
 }
 # End of conf.py

--- a/docs/source/dev/build.md
+++ b/docs/source/dev/build.md
@@ -303,8 +303,7 @@ mvn package -Ddocker.skip
 
 ## Docker Hub tags
 
-Each image is published under a version tag (`{{ release }}` / `{{ release }}-ocr` /
-`{{ release }}-noocr`) plus a **floating** alias:
+Each image is published under a version tag ({{ release_image_tags }}) plus a **floating** alias:
 
 | Build | OCR alias | No-OCR alias |
 |---|---|---|

--- a/docs/source/dev/doc.md
+++ b/docs/source/dev/doc.md
@@ -53,6 +53,30 @@ Your note content here.
 ```
 ````
 
+Conditional blocks (`{ifconfig}`) and admonitions that wrap a code sample must use
+[colon fences](https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#code-fences)
+(`::::{ifconfig}` / `:::{warning}`). A backtick-fenced `{ifconfig}` is closed by the first
+nested ` ``` ` of the same length, so the rest of the block leaks into the page.
+Do not put Markdown headings inside `{ifconfig}` (they close the directive); use a
+`{rubric}` if you need a title in the conditional block.
+
+MyST substitutions such as {{ release }} work in prose only. They are **not** expanded inside
+fenced or inline code. For versioned commands, use a Sphinx `{code-block}` with
+`:substitutions:` and RST `|name|` placeholders (see `sphinx-substitution-extensions`):
+
+````
+```{code-block} sh
+:substitutions:
+
+docker pull |docker_image|
+wget |downloadUrl|
+unzip fscrawler-|release|.zip
+```
+````
+
+`|release|` is Sphinx's built-in. `|docker_image|`, `|docker_image_noocr|`, and
+`|downloadUrl|` are defined in `docs/source/conf.py`.
+
 To update the requirements file if you changed the `requirements.in` file, run:
 
 ```

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,11 +1,11 @@
 # Welcome to FSCrawler's documentation!
 
-````{ifconfig} release.endswith('-SNAPSHOT')
-```{warning}
+::::{ifconfig} release.endswith('-SNAPSHOT')
+:::{warning}
 This documentation is for the version of FSCrawler currently under development.
 Were you looking for <a href="../fscrawler-2.9/">the documentation of the latest stable version</a>?
-```
-````
+:::
+::::
 
 Welcome to the FS Crawler for {{ ES }}.
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -24,53 +24,62 @@ which are never GitHub's "Latest" release.
 | `noocr` | Last **stable** release, without OCR |
 | `snapshot` | Current SNAPSHOT (`main`), with OCR |
 | `snapshot-noocr` | Current SNAPSHOT, without OCR |
-| `{{ release }}`, `{{ release }}-noocr` | This documentation version |
+| {{ release_docker_tags }} | This documentation version |
 | `3.0`, `3.0-noocr`, `3.1-SNAPSHOT`, … | A specific version |
 
-```sh
-docker pull dadoonet/fscrawler{{ docker_image_tag }}
+```{code-block} sh
+:substitutions:
+
+docker pull |docker_image|
 ```
 
-````{ifconfig} release.endswith('-SNAPSHOT')
-```{warning}
+::::{ifconfig} release.endswith('-SNAPSHOT')
+:::{warning}
 These docs describe a **SNAPSHOT** build. `docker pull dadoonet/fscrawler` (no tag) still
 pulls the last **stable** release. To run this SNAPSHOT:
 
-```sh
+```{code-block} sh
+:substitutions:
+
 docker pull dadoonet/fscrawler:snapshot
-# or: docker pull dadoonet/fscrawler:{{ release }}
+# or: docker pull dadoonet/fscrawler:|release|
 ```
+:::
+::::
+
+::::{note}
+This image is very big (500+mb) as it contains [Tesseract](https://tesseract-ocr.github.io/tessdoc/) and
+all the [trained language data](https://tesseract-ocr.github.io/tessdoc/Data-Files.html).
+If you don't want to use OCR at all, you can use a smaller image (around 230mb) by pulling
+{{ docker_image_noocr_code }} instead:
+
+```{code-block} sh
+:substitutions:
+
+docker pull |docker_image_noocr|
 ```
-````
-
-````{note}
-
- This image is very big (500+mb) as it contains [Tesseract](https://tesseract-ocr.github.io/tessdoc/) and
- all the [trained language data](https://tesseract-ocr.github.io/tessdoc/Data-Files.html).
- If you don't want to use OCR at all, you can use a smaller image (around 230mb) by pulling instead
- `dadoonet/fscrawler:noocr` (last stable) or `dadoonet/fscrawler:snapshot-noocr` (SNAPSHOT):
-
- ```shell
- docker pull dadoonet/fscrawler:noocr
- ```
-````
+::::
 
 Let say your documents are located in `~/tmp` dir, and you want to store your FSCrawler jobs in `~/.fscrawler`.
 On first run, create the job settings:
 
-```sh
+```{code-block} sh
+:substitutions:
+
 docker run -it --rm \
      -v ~/.fscrawler:/root/.fscrawler \
-     dadoonet/fscrawler{{ docker_image_tag }} --setup
+     |docker_image| --setup
 ```
 
 Then run FSCrawler with:
 
-```sh
+```{code-block} sh
+:substitutions:
+
 docker run -it --rm \
      -v ~/.fscrawler:/root/.fscrawler \
      -v ~/tmp:/tmp/es:ro \
-     dadoonet/fscrawler{{ docker_image_tag }}
+     |docker_image|
 ```
 
 ```{note}
@@ -87,33 +96,39 @@ docker run -it --rm \
 If you need to add a 3rd party library (jar) or your Tika custom jar, you can put it in a `external` directory and
 mount it as well:
 
-```sh
+```{code-block} sh
+:substitutions:
+
 docker run -it --rm \
      -v ~/.fscrawler:/root/.fscrawler \
      -v ~/tmp:/tmp/es:ro \
      -v "$PWD/external:/usr/share/fscrawler/external" \
-     dadoonet/fscrawler{{ docker_image_tag }}
+     |docker_image|
 ```
 
 If you want to use the {ref}`rest-service`, don't forget to also expose the port:
 
-```sh
+```{code-block} sh
+:substitutions:
+
 docker run -it --rm \
      -v ~/.fscrawler:/root/.fscrawler \
      -v ~/tmp:/tmp/es:ro \
      -p 8080:8080 \
-     dadoonet/fscrawler{{ docker_image_tag }}
+     |docker_image|
 ```
 
 If you want to change the log level for FSCrawler, you can run:
 
-```sh
+```{code-block} sh
+:substitutions:
+
 docker run -it --rm \
      -v ~/.fscrawler:/root/.fscrawler \
      -v ~/tmp:/tmp/es:ro \
      -v ~/logs:/root/logs \
      -e FS_JAVA_OPTS="-DLOG_LEVEL=debug -DDOC_LEVEL=debug" \
-     dadoonet/fscrawler{{ docker_image_tag }}
+     |docker_image|
 ```
 
 And you can read the logs from the `~/logs` directory:
@@ -124,11 +139,13 @@ tail -f ~/logs/documents.log
 
 You can pass all the CLI options to the docker container as well:
 
-```sh
+```{code-block} sh
+:substitutions:
+
 docker run -it --rm \
      -v ~/.fscrawler:/root/.fscrawler \
      -v ~/tmp:/tmp/es:ro \
-     dadoonet/fscrawler{{ docker_image_tag }} job_name --restart --loop 1
+     |docker_image| job_name --restart --loop 1
 ```
 
 See {ref}`cli-options` for more information.
@@ -298,49 +315,54 @@ You will find this example in the `contrib/docker-compose-example-elasticsearch`
 ## Local installation (ZIP)
 
 If you prefer to run FSCrawler from a ZIP distribution on your machine instead of Docker,
-download [FSCrawler {{ release }}]({{ downloadUrl }})
+download {{ download_link }}
 from {{ GitHub }}:
 
-```sh
-wget {{ downloadUrl }}
-unzip fscrawler-{{ release }}.zip
-cd fscrawler-distribution-{{ release }}
+```{code-block} sh
+:substitutions:
+
+wget |downloadUrl|
+unzip fscrawler-|release|.zip
+cd fscrawler-distribution-|release|
 ```
 
-````{ifconfig} release.endswith('-SNAPSHOT')
-```{warning}
+::::{ifconfig} release.endswith('-SNAPSHOT')
+:::{warning}
 This is a **SNAPSHOT** build. The ZIP is overwritten on every push to `main`.
 SNAPSHOT pre-releases are **not** GPG-signed. Stable versions (with `.asc` and SHA-256)
 are listed on the same {{ GitHub }} page.
-```
-````
+:::
+::::
 
-````{ifconfig} release == version
-```{tip}
+::::{ifconfig} release == version
+:::{tip}
 This is a **stable** version. Development SNAPSHOT builds are published as GitHub pre-releases on the same
 {{ GitHub }} page.
-```
+:::
 
 (verify-zip)=
-### Verify the ZIP
+```{rubric} Verify the ZIP
+```
 
 Stable releases attach a GPG signature and a SHA-256 checksum next to the ZIP.
 
-```sh
-wget {{ downloadUrl }}
-wget {{ downloadUrl }}.asc
-wget {{ downloadUrl }}.sha256
-sha256sum -c fscrawler-{{ release }}.zip.sha256
-# macOS: shasum -a 256 -c fscrawler-{{ release }}.zip.sha256
+```{code-block} sh
+:substitutions:
+
+wget |downloadUrl|
+wget |downloadUrl|.asc
+wget |downloadUrl|.sha256
+sha256sum -c fscrawler-|release|.zip.sha256
+# macOS: shasum -a 256 -c fscrawler-|release|.zip.sha256
 gpg --import KEYS
 # or: gpg --keyserver hkps://keys.openpgp.org --recv-keys EDEC15CE428D7527CF87E998C7E192835B0ABB2E
-gpg --verify fscrawler-{{ release }}.zip.asc fscrawler-{{ release }}.zip
+gpg --verify fscrawler-|release|.zip.asc fscrawler-|release|.zip
 ```
 
 The signing key is **David Pilato** `<david@pilato.fr>`, fingerprint
 `EDEC 15CE 428D 7527 CF87 E998 C7E1 9283 5B0A BB2E`.
 `KEYS` lives at the root of the [git repository](https://github.com/dadoonet/fscrawler/blob/main/KEYS).
-````
+::::
 
 After extracting the ZIP, you get a directory with `bin/` (run scripts), `config/` (logging), `lib/` (core and
 dependencies), `external/` (optional JARs), and `logs/`. See {ref}`layout` for the full directory layout.

--- a/docs/source/user/llm-assistant.md
+++ b/docs/source/user/llm-assistant.md
@@ -31,7 +31,9 @@ Include as much context as you can in your follow-up message:
 
 Copy everything inside the block below and paste it into your LLM. Then add your question at the end.
 
-````
+````{code-block} text
+:substitutions:
+
 You are helping me configure FSCrawler, a Java file system crawler that extracts text from binary documents (PDF, MS Office, images, etc.) with Apache Tika and indexes them into Elasticsearch 7.x, 8.x, or 9.x.
 
 Official documentation: https://fscrawler.readthedocs.io/en/latest/
@@ -65,7 +67,7 @@ docker run -it --rm \
   -v /path/to/docs:/tmp/es:ro \
   -e FSCRAWLER_ELASTICSEARCH_URLS=http://host.docker.internal:9200 \
   -e FSCRAWLER_ELASTICSEARCH_API_KEY="your-api-key" \
-  dadoonet/fscrawler{{ docker_image_tag }}
+  |docker_image|
 ```
 
 Important rules — do not get these wrong:

--- a/docs/source/user/tutorial.md
+++ b/docs/source/user/tutorial.md
@@ -57,16 +57,20 @@ echo "$ES_LOCAL_API_KEY"
 * Pull the FSCrawler image. See {ref}`docker` for details (including the smaller `noocr` variant).
   On SNAPSHOT docs this is `:snapshot`; on a released version it is untagged (`latest`):
 
-```sh
-docker pull dadoonet/fscrawler{{ docker_image_tag }}
+```{code-block} sh
+:substitutions:
+
+docker pull |docker_image|
 ```
 
 * Create a job named `resumes`:
 
-```sh
+```{code-block} sh
+:substitutions:
+
 docker run -it --rm \
   -v ~/.fscrawler:/root/.fscrawler \
-  dadoonet/fscrawler{{ docker_image_tag }} --setup resumes
+  |docker_image| --setup resumes
 ```
 
 * Edit `~/.fscrawler/resumes/_settings.yaml` so the crawler reads documents from `/tmp/es` **inside** the
@@ -85,7 +89,9 @@ fs:
   From a Docker container, Elasticsearch and Kibana on the host are reached via `host.docker.internal`
   (not `127.0.0.1`):
 
-```sh
+```{code-block} sh
+:substitutions:
+
 # From the elastic-start-local directory, or after: source elastic-start-local/.env
 docker run -it --rm \
   --add-host=host.docker.internal:host-gateway \
@@ -94,7 +100,7 @@ docker run -it --rm \
   -e FSCRAWLER_ELASTICSEARCH_URLS=http://host.docker.internal:9200 \
   -e FSCRAWLER_ELASTICSEARCH_API_KEY="${ES_LOCAL_API_KEY}" \
   -e FSCRAWLER_KIBANA_URL=http://host.docker.internal:5601 \
-  dadoonet/fscrawler{{ docker_image_tag }} resumes
+  |docker_image| resumes
 ```
 
 ```{note}
@@ -124,22 +130,23 @@ Use `http://` (not `https://`) with `start-local`. Copy the API key value from `
 FSCrawler should index all the documents inside your directory. Then continue with
 [Open the default dashboard](#open-the-default-dashboard).
 
-````{note}
+::::{note}
+If you want to start again reindexing from scratch instead of monitoring the changes, stop FSCrawler, restart it
+with the `--restart` option:
 
- If you want to start again reindexing from scratch instead of monitoring the changes, stop FSCrawler, restart it
- with the `--restart` option:
+```{code-block} sh
+:substitutions:
 
- ```bash
- docker run -it --rm \
-   --add-host=host.docker.internal:host-gateway \
-   -v ~/.fscrawler:/root/.fscrawler \
-   -v ~/resumes:/tmp/es:ro \
-   -e FSCRAWLER_ELASTICSEARCH_URLS=http://host.docker.internal:9200 \
-   -e FSCRAWLER_ELASTICSEARCH_API_KEY="${ES_LOCAL_API_KEY}" \
-   -e FSCRAWLER_KIBANA_URL=http://host.docker.internal:5601 \
-   dadoonet/fscrawler{{ docker_image_tag }} resumes --restart
- ```
-````
+docker run -it --rm \
+  --add-host=host.docker.internal:host-gateway \
+  -v ~/.fscrawler:/root/.fscrawler \
+  -v ~/resumes:/tmp/es:ro \
+  -e FSCRAWLER_ELASTICSEARCH_URLS=http://host.docker.internal:9200 \
+  -e FSCRAWLER_ELASTICSEARCH_API_KEY="${ES_LOCAL_API_KEY}" \
+  -e FSCRAWLER_KIBANA_URL=http://host.docker.internal:5601 \
+  |docker_image| resumes --restart
+```
+::::
 
 ## Alternative: manual installation
 

--- a/scripts/tests/test_docs_myst_markup.py
+++ b/scripts/tests/test_docs_myst_markup.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Guards for MyST markup that ReadTheDocs silently mis-renders.
+
+MyST does not expand ``{{ name }}`` inside fenced or inline code, and a
+backtick-fenced ``{ifconfig}`` is closed by the first nested `` ``` `` of the
+same length — which leaks or drops the rest of the block.
+"""
+
+from __future__ import annotations
+
+import random
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCS_SOURCE = REPO_ROOT / "docs" / "source"
+
+# Gestalt / Jinja triple-brace placeholders (e.g. {{{_tmp_fingerprint}}}) are
+# not MyST substitutions. Require a non-brace before {{ and a letter after.
+MUSTACHE = re.compile(r"(?<!\{)\{\{\s*([A-Za-z][A-Za-z0-9_]*)\s*\}\}")
+FENCE_OPEN = re.compile(r"^(?P<indent> *)(?P<ticks>`{3,}|~{3,})(?P<info>.*)$")
+BACKTICK_IFCONFIG = re.compile(r"^ *`{3,}\{ifconfig\}")
+
+
+def _markdown_pages() -> list[Path]:
+    pages = sorted(DOCS_SOURCE.rglob("*.md"))
+    if not pages:
+        raise FileNotFoundError(f"no Markdown pages under {DOCS_SOURCE}")
+    return pages
+
+
+def _is_code_fence(info: str) -> bool:
+    """True for ```sh / {code-block}; false for {note} / {ifconfig} / {warning}."""
+    stripped = info.strip()
+    if stripped.startswith("{code-block}") or stripped.startswith("{code}"):
+        return True
+    return not stripped.startswith("{")
+
+
+def _fenced_blocks(text: str) -> list[tuple[int, str, str]]:
+    """Return (start_line, info_string, body) for each fence, including nested ones.
+
+    A shorter backtick fence inside a longer one does not close the outer fence
+    (CommonMark), so `` ```sh `` inside `` ````{note} `` is its own block.
+    """
+    lines = text.splitlines()
+    blocks: list[tuple[int, str, str]] = []
+    stack: list[dict] = []
+    for i, line in enumerate(lines):
+        match = FENCE_OPEN.match(line)
+        if match:
+            ticks = match.group("ticks")
+            marker = ticks[0]
+            info = match.group("info").strip()
+            if stack:
+                top = stack[-1]
+                if marker == top["marker"] and len(ticks) >= top["len"]:
+                    blocks.append((top["start"], top["info"], "\n".join(top["body"])))
+                    stack.pop()
+                    continue
+            stack.append(
+                {
+                    "marker": marker,
+                    "len": len(ticks),
+                    "start": i + 1,
+                    "info": info,
+                    "body": [],
+                }
+            )
+            continue
+        if stack:
+            stack[-1]["body"].append(line)
+    for leftover in stack:
+        blocks.append((leftover["start"], leftover["info"], "\n".join(leftover["body"])))
+    return blocks
+
+
+def _inline_code_spans(text: str) -> list[str]:
+    """Inline `code` after fenced blocks have been blanked, so fences are ignored."""
+    lines = text.splitlines(keepends=True)
+    blanked: list[str] = []
+    i = 0
+    while i < len(lines):
+        match = FENCE_OPEN.match(lines[i].rstrip("\n"))
+        if match:
+            ticks = match.group("ticks")
+            marker = ticks[0]
+            blanked.append("\n")
+            i += 1
+            while i < len(lines):
+                closer = FENCE_OPEN.match(lines[i].rstrip("\n"))
+                if (
+                    closer
+                    and closer.group("ticks")[0] == marker
+                    and len(closer.group("ticks")) >= len(ticks)
+                ):
+                    blanked.append("\n")
+                    i += 1
+                    break
+                blanked.append("\n")
+                i += 1
+            continue
+        blanked.append(lines[i])
+        i += 1
+    return re.findall(r"`([^`\n]+)`", "".join(blanked))
+
+
+class DocsMystMarkupTest(unittest.TestCase):
+    def setUp(self) -> None:
+        rng = random.Random()
+        self.pages = _markdown_pages()
+        self.assertGreater(len(self.pages), rng.randint(3, 8))
+
+    def test_myst_substitutions_are_not_inside_fenced_or_inline_code(self) -> None:
+        failures: list[str] = []
+        for page in self.pages:
+            rel = page.relative_to(REPO_ROOT)
+            text = page.read_text(encoding="utf-8")
+            for start, info, body in _fenced_blocks(text):
+                if not _is_code_fence(info):
+                    continue
+                found = MUSTACHE.findall(body)
+                if found:
+                    names = ", ".join(sorted(set(found)))
+                    failures.append(
+                        f"{rel}:{start} fenced block ({info!r}) contains {{{{ {names} }}}}"
+                    )
+            for span in _inline_code_spans(text):
+                found = MUSTACHE.findall(span)
+                if found:
+                    names = ", ".join(sorted(set(found)))
+                    failures.append(
+                        f"{rel} inline code `{span}` contains {{{{ {names} }}}}"
+                    )
+        self.assertEqual(
+            failures,
+            [],
+            "MyST {{ substitutions }} are not expanded inside code. Use a "
+            "{code-block} with :substitutions: and |name| (see installation.md "
+            "docker-compose example), or a substitution whose value already "
+            "includes the backticks.",
+        )
+
+    def test_ifconfig_uses_colon_fences(self) -> None:
+        failures: list[str] = []
+        for page in self.pages:
+            rel = page.relative_to(REPO_ROOT)
+            for lineno, line in enumerate(page.read_text(encoding="utf-8").splitlines(), 1):
+                if BACKTICK_IFCONFIG.match(line):
+                    failures.append(
+                        f"{rel}:{lineno} {{ifconfig}} opened with backticks. "
+                        "Use colon fences (::::{ifconfig}) so nested ``` "
+                        "admonitions and code blocks do not close the directive."
+                    )
+        self.assertEqual(failures, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The latest Read the Docs build of [installation.html](https://fscrawler.readthedocs.io/en/latest/installation.html) left `{{ release }}` / `{{ docker_image_tag }}` literal, and the SNAPSHOT `{ifconfig}` warning did not wrap its nested code sample.

## Cause

1. **MyST `{{ name }}` is not expanded inside fenced or inline code.** Docker/ZIP samples used `{{ docker_image_tag }}` in ` ```sh ` fences and `` `{{ release }}` `` in the tag table. The docker-compose example already used the working pattern (`{code-block}` + `:substitutions:` + `|FSCrawler_version|`).
2. **A backtick-fenced `{ifconfig}` is closed by the first nested ` ``` ` of the same length.** The SNAPSHOT Docker warning nested ` ```sh ` inside ` ```{warning} ` inside ` ````{ifconfig} `, so the block was mis-parsed. A Markdown heading inside `{ifconfig}` also closes the directive, which is why **Verify the ZIP** leaked onto SNAPSHOT docs.

## Fix

- Versioned commands now use `{code-block}` with `:substitutions:` and RST `|docker_image|` / `|release|` / `|downloadUrl|`.
- `{ifconfig}` / nested admonitions use colon fences (`::::{ifconfig}` / `:::{warning}`).
- **Verify the ZIP** stays in the stable-only block via a `{rubric}` (no heading).
- Markup is guarded by `scripts/tests/test_docs_myst_markup.py` (picked up by `UpdateReadmeVersionsTest`).

Local `sphinx-build -W` now renders `docker pull dadoonet/fscrawler:snapshot` and `3.1-SNAPSHOT` in the tag table, with the SNAPSHOT warning containing its pull commands.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99f83470-6712-4e92-a9e9-49f5689ee652?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99f83470-6712-4e92-a9e9-49f5689ee652&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

