### PR TITLE
Publish SNAPSHOT GitHub ZIP as fscrawler-x.y.zip

### DIFF
--- a/distribution/src/test/java/fr/pilato/elasticsearch/crawler/fs/distribution/ReleaseProcessScriptTest.java
+++ b/distribution/src/test/java/fr/pilato/elasticsearch/crawler/fs/distribution/ReleaseProcessScriptTest.java
@@ -186,6 +186,12 @@ class ReleaseProcessScriptTest extends AbstractFSCrawlerTestCase {
                 .contains("publish_snapshot_prerelease.py")
                 .contains("contents: write")
                 .doesNotContain("CENTRAL_TOKEN");
+        String publisher = Files.readString(repoRoot().resolve("scripts").resolve("publish_snapshot_prerelease.py"));
+        assertThat(publisher)
+                .as("GitHub download URLs use the file basename, not gh's # display label")
+                .contains("stage_github_zip")
+                .contains("maven_zip_name")
+                .doesNotContain("#{asset_name");
     }
 
     @Test

--- a/docs/source/dev/release.md
+++ b/docs/source/dev/release.md
@@ -181,7 +181,12 @@ Every push to `main` runs `.github/workflows/maven.yml`, which:
 * Pushes Docker images to Docker Hub
 * Publishes (or overwrites) a public GitHub **pre-release** tagged
   `fscrawler-{version}` (for example `fscrawler-3.1-SNAPSHOT`) with the asset
-  `fscrawler-3.1-SNAPSHOT.zip`
+  `fscrawler-3.1-SNAPSHOT.zip`. Maven still builds
+  `distribution/target/fscrawler-distribution-{version}.zip`; the publisher
+  copies it to that friendly name before `gh release upload`, because GitHub
+  download URLs use the file basename (`gh`'s `file#label` syntax only sets a
+  display label). A leftover `fscrawler-distribution-{version}.zip` asset is
+  deleted on refresh.
 
 SNAPSHOT pre-releases are **not** GPG-signed. Only stable GitHub releases include
 `.asc` and `.sha256`.

--- a/scripts/publish_snapshot_prerelease.py
+++ b/scripts/publish_snapshot_prerelease.py
@@ -4,14 +4,20 @@
 Used by .github/workflows/maven.yml on every push to main. The pre-release tag is
 fscrawler-{version} (for example fscrawler-3.1-SNAPSHOT). Stable releases created
 by release.sh delete that pre-release once the final GitHub release is confirmed.
+
+Maven builds ``fscrawler-distribution-{version}.zip``. GitHub download URLs use the
+uploaded file's basename; ``gh``'s ``file#label`` syntax only sets a display label.
+The publisher therefore copies the ZIP to ``fscrawler-{version}.zip`` before upload.
 """
 
 from __future__ import annotations
 
 import argparse
 import os
+import shutil
 import subprocess
 import sys
+from collections.abc import Sequence
 from pathlib import Path
 
 
@@ -23,8 +29,25 @@ def asset_name(version: str) -> str:
     return f"fscrawler-{version}.zip"
 
 
+def maven_zip_name(version: str) -> str:
+    return f"fscrawler-distribution-{version}.zip"
+
+
 def release_tag(version: str) -> str:
     return f"fscrawler-{version}"
+
+
+def github_zip_path(zip_path: str, version: str) -> str:
+    """Path whose basename is the GitHub download asset name."""
+    return str(Path(zip_path).with_name(asset_name(version)))
+
+
+def stage_github_zip(source: Path, version: str) -> Path:
+    """Copy the Maven ZIP to ``fscrawler-{version}.zip`` next to it when needed."""
+    dest = source.with_name(asset_name(version))
+    if source.resolve() != dest.resolve():
+        shutil.copy2(source, dest)
+    return dest
 
 
 def snapshot_notes(target: str) -> str:
@@ -40,15 +63,16 @@ def plan(
     zip_path: str,
     target: str,
     exists: bool,
+    existing_assets: Sequence[str] = (),
 ) -> list[list[str]]:
     if not version.endswith("-SNAPSHOT"):
         return []
 
     tag = release_tag(version)
-    asset = f"{zip_path}#{asset_name(version)}"
+    asset = github_zip_path(zip_path, version)
     notes = snapshot_notes(target)
     if exists:
-        return [
+        commands: list[list[str]] = [
             ["gh", "release", "upload", tag, asset, "--clobber"],
             [
                 "gh",
@@ -63,6 +87,10 @@ def plan(
                 notes,
             ],
         ]
+        legacy = maven_zip_name(version)
+        if legacy in existing_assets:
+            commands.insert(1, ["gh", "release", "delete-asset", tag, legacy, "--yes"])
+        return commands
     return [
         [
             "gh",
@@ -90,6 +118,18 @@ def release_exists(tag: str) -> bool:
         text=True,
     )
     return result.returncode == 0
+
+
+def release_asset_names(tag: str) -> list[str]:
+    result = subprocess.run(
+        ["gh", "release", "view", tag, "--json", "assets", "--jq", ".assets[].name"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
 
 def current_maven_version(root: Path) -> str:
@@ -124,11 +164,12 @@ def main(argv: list[str] | None = None) -> None:
         print(f"Version {version} is not a SNAPSHOT — skipping GitHub pre-release.")
         return
 
-    zip_path = args.zip_path or str(
-        root / "distribution" / "target" / f"fscrawler-distribution-{version}.zip"
-    )
-    if not args.dry_run and not Path(zip_path).is_file():
-        raise SnapshotPrereleaseError(f"Distribution ZIP not found: {zip_path}")
+    zip_path = args.zip_path or str(root / "distribution" / "target" / maven_zip_name(version))
+    source = Path(zip_path)
+    if not args.dry_run:
+        if not source.is_file():
+            raise SnapshotPrereleaseError(f"Distribution ZIP not found: {zip_path}")
+        zip_path = str(stage_github_zip(source, version))
 
     target = args.target
     if not target:
@@ -141,7 +182,14 @@ def main(argv: list[str] | None = None) -> None:
         ).stdout.strip()
 
     exists = False if args.dry_run else release_exists(release_tag(version))
-    commands = plan(version=version, zip_path=zip_path, target=target, exists=exists)
+    existing_assets = release_asset_names(release_tag(version)) if exists else ()
+    commands = plan(
+        version=version,
+        zip_path=zip_path,
+        target=target,
+        exists=exists,
+        existing_assets=existing_assets,
+    )
     for cmd in commands:
         print("+ " + " ".join(cmd))
         if args.dry_run:

--- a/scripts/tests/test_publish_snapshot_prerelease.py
+++ b/scripts/tests/test_publish_snapshot_prerelease.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import random
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -14,12 +15,25 @@ sys.path.insert(0, str(SCRIPTS_DIR))
 import publish_snapshot_prerelease as publisher  # noqa: E402
 
 
+def uploaded_zip_basenames(commands: list[list[str]]) -> list[str]:
+    """GitHub asset names are file basenames; ``#`` is only a display label."""
+    names: list[str] = []
+    for cmd in commands:
+        for part in cmd:
+            path = part.split("#", 1)[0]
+            if path.endswith(".zip"):
+                names.append(Path(path).name)
+    return names
+
+
 class PublishSnapshotPrereleaseTest(unittest.TestCase):
     def setUp(self) -> None:
         rng = random.Random()
         self.version = f"{rng.randint(3, 9)}.{rng.randint(0, 20)}-SNAPSHOT"
         self.sha = "".join(rng.choice("abcdef0123456789") for _ in range(12))
         self.zip_path = f"/tmp/fscrawler-distribution-{self.version}.zip"
+        self.friendly_name = f"fscrawler-{self.version}.zip"
+        self.legacy_name = f"fscrawler-distribution-{self.version}.zip"
 
     def test_skips_non_snapshot_versions(self) -> None:
         released = self.version.removesuffix("-SNAPSHOT")
@@ -47,7 +61,20 @@ class PublishSnapshotPrereleaseTest(unittest.TestCase):
         self.assertIn("--prerelease", create)
         self.assertIn("--latest=false", create)
         self.assertIn(self.sha, create)
-        self.assertTrue(any(f"#{publisher.asset_name(self.version)}" in part for part in create))
+        self.assertEqual(uploaded_zip_basenames(commands), [self.friendly_name])
+
+    def test_github_download_url_uses_file_basename_not_hash_label(self) -> None:
+        commands = publisher.plan(
+            version=self.version,
+            zip_path=self.zip_path,
+            target=self.sha,
+            exists=False,
+        )
+        names = uploaded_zip_basenames(commands)
+        self.assertEqual(names, [self.friendly_name])
+        self.assertNotIn(self.legacy_name, names)
+        flat = " ".join(" ".join(cmd) for cmd in commands)
+        self.assertNotIn(f"#{self.friendly_name}", flat)
 
     def test_clobbers_existing_prerelease_zip(self) -> None:
         commands = publisher.plan(
@@ -63,9 +90,50 @@ class PublishSnapshotPrereleaseTest(unittest.TestCase):
         self.assertIn("--prerelease", flat)
         self.assertIn(self.sha, flat)
         self.assertNotIn("gh release create", flat)
+        self.assertEqual(uploaded_zip_basenames(commands), [self.friendly_name])
 
-    def test_asset_display_name_is_friendly_zip(self) -> None:
-        self.assertEqual(publisher.asset_name(self.version), f"fscrawler-{self.version}.zip")
+    def test_clobber_deletes_legacy_maven_artifact_asset(self) -> None:
+        commands = publisher.plan(
+            version=self.version,
+            zip_path=self.zip_path,
+            target=self.sha,
+            exists=True,
+            existing_assets=[self.legacy_name, self.friendly_name],
+        )
+        delete = next(cmd for cmd in commands if cmd[:3] == ["gh", "release", "delete-asset"])
+        self.assertIn(self.legacy_name, delete)
+        self.assertIn("--yes", delete)
+
+    def test_clobber_skips_delete_when_legacy_asset_absent(self) -> None:
+        commands = publisher.plan(
+            version=self.version,
+            zip_path=self.zip_path,
+            target=self.sha,
+            exists=True,
+            existing_assets=[self.friendly_name],
+        )
+        self.assertFalse(any(cmd[:3] == ["gh", "release", "delete-asset"] for cmd in commands))
+
+    def test_asset_name_is_friendly_zip(self) -> None:
+        self.assertEqual(publisher.asset_name(self.version), self.friendly_name)
+        self.assertEqual(publisher.maven_zip_name(self.version), self.legacy_name)
+
+    def test_stage_github_zip_copies_to_friendly_filename(self) -> None:
+        payload = bytes(random.randrange(256) for _ in range(random.randint(16, 64)))
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / self.legacy_name
+            source.write_bytes(payload)
+            staged = publisher.stage_github_zip(source, self.version)
+            self.assertEqual(staged.name, self.friendly_name)
+            self.assertEqual(staged.read_bytes(), payload)
+            self.assertTrue(source.is_file())
+
+    def test_stage_github_zip_is_noop_when_already_friendly(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / self.friendly_name
+            source.write_bytes(b"zip")
+            staged = publisher.stage_github_zip(source, self.version)
+            self.assertEqual(staged.resolve(), source.resolve())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The SNAPSHOT GitHub pre-release currently attaches `fscrawler-distribution-3.1-SNAPSHOT.zip`, so the download URL is:

`https://github.com/dadoonet/fscrawler/releases/download/fscrawler-3.1-SNAPSHOT/fscrawler-distribution-3.1-SNAPSHOT.zip`

Docs and `wget` expect:

`https://github.com/dadoonet/fscrawler/releases/download/fscrawler-3.1-SNAPSHOT/fscrawler-3.1-SNAPSHOT.zip`

**Cause:** `gh release upload path#label` only sets a display label. GitHub download URLs use the uploaded file’s basename. The SNAPSHOT publisher uploaded the Maven artifact as-is. Stable `release.sh` already copies the ZIP to `fscrawler-{version}.zip` first.

**Fix:**
- Copy `fscrawler-distribution-{version}.zip` to `fscrawler-{version}.zip` before `gh` upload
- Delete leftover `fscrawler-distribution-{version}.zip` assets when refreshing the pre-release

**Test plan:**
- [x] Python tests fail on the Maven basename (`scripts/tests/test_publish_snapshot_prerelease.py`)
- [x] Same tests pass after the copy/rename
- [x] `python3 scripts/publish_snapshot_prerelease.py --dry-run` prints `/tmp/fscrawler-3.1-SNAPSHOT.zip`
- [x] `mvn test -pl distribution -am -DskipIntegTests -Dtest=ReleaseProcessScriptTest,UpdateReadmeVersionsTest -Ddocker.skip`
- [x] PR CI: build, unit tests, Linux ITs, Elastic Cloud, Serverless, Docker, docs — pass
- [ ] `it-windows` timed out in `FsCrawlerImplAllDocumentsIT.startCrawling` (waited 5m for 40 docs). Unrelated flake against Elastic Cloud; same job has failed on recent unrelated PRs. Re-run that job from the Actions UI if needed.
- [ ] Next push to `main` (or `workflow_dispatch` of `maven.yml`) publishes `fscrawler-3.1-SNAPSHOT.zip` and removes the old asset

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2bedb77-0a8a-4bfb-9308-8be759bff75a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2bedb77-0a8a-4bfb-9308-8be759bff75a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

