### PR TITLE
Add tests for fs.continue_on_error (#331)

### DIFF
--- a/core/src/test/java/fr/pilato/elasticsearch/crawler/fs/FsParserContinueOnErrorTest.java
+++ b/core/src/test/java/fr/pilato/elasticsearch/crawler/fs/FsParserContinueOnErrorTest.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
+ */
+package fr.pilato.elasticsearch.crawler.fs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.carrotsearch.randomizedtesting.jupiter.RandomizedTest;
+import fr.pilato.elasticsearch.crawler.fs.beans.Doc;
+import fr.pilato.elasticsearch.crawler.fs.beans.FileAbstractModel;
+import fr.pilato.elasticsearch.crawler.fs.beans.ScanStatistic;
+import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
+import fr.pilato.elasticsearch.crawler.fs.settings.FsSettingsLoader;
+import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
+import fr.pilato.elasticsearch.crawler.plugins.FsCrawlerExtensionFsProvider;
+import fr.pilato.elasticsearch.crawler.plugins.FsCrawlerPluginException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for <a href="https://github.com/dadoonet/fscrawler/issues/331">#331</a>: {@code fs.continue_on_error} skips
+ * a file that cannot be opened instead of aborting the crawl.
+ */
+class FsParserContinueOnErrorTest extends AbstractFSCrawlerTestCase {
+
+    @Test
+    void skips_unreadable_file_when_continue_on_error_enabled() throws Exception {
+        Object result = indexUnreadableFile(true);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void rethrows_when_continue_on_error_disabled() {
+        assertThatThrownBy(() -> indexUnreadableFile(false))
+                .isInstanceOf(InvocationTargetException.class)
+                .hasCauseInstanceOf(FsCrawlerPluginException.class);
+    }
+
+    private Object indexUnreadableFile(boolean continueOnError) throws Exception {
+        FsSettings fsSettings = FsSettingsLoader.load();
+        fsSettings.setName(jobName);
+        fsSettings.getFs().setContinueOnError(continueOnError);
+
+        String filename = RandomizedTest.randomAsciiLettersOfLengthBetween(randomizedRandomForTests, 6, 12)
+                        .toLowerCase(Locale.ROOT)
+                + ".txt";
+        String dirname = testTmpDir.toString();
+        byte[] content = RandomizedTest.randomAsciiLettersOfLengthBetween(randomizedRandomForTests, 10, 20)
+                .getBytes(StandardCharsets.UTF_8);
+        FileAbstractModel child = new FileAbstractModel(
+                filename,
+                true,
+                Instant.now(),
+                Instant.now(),
+                Instant.now(),
+                "txt",
+                dirname,
+                dirname + "/" + filename,
+                content.length,
+                null,
+                null,
+                0,
+                null,
+                null);
+
+        FsParser parser = new FsParser(fsSettings, testTmpDir, null, null, 1, false, new UnreadableFileFsProvider());
+        Method indexFileWithStreams = FsParser.class.getDeclaredMethod(
+                "indexFileWithStreams",
+                FileAbstractModel.class,
+                ScanStatistic.class,
+                String.class,
+                FileAbstractModel.class,
+                int.class);
+        indexFileWithStreams.setAccessible(true);
+        return indexFileWithStreams.invoke(parser, child, new ScanStatistic(dirname), dirname, null, 0);
+    }
+
+    /**
+     * Mimics a local-FS permission denied: {@code FileInputStream} fails with {@link java.io.FileNotFoundException},
+     * which {@code FsLocalPlugin} wraps in {@link FsCrawlerPluginException}.
+     */
+    private static class UnreadableFileFsProvider implements FsCrawlerExtensionFsProvider {
+        @Override
+        public void start(FsSettings fsSettings, Map<String, Object> overlay) {
+            // Stub: no overlay to apply.
+        }
+
+        @Override
+        public void stop() {
+            // Stub: no background work.
+        }
+
+        @Override
+        public String getType() {
+            return "unreadable-fs";
+        }
+
+        @Override
+        public InputStream readFile() {
+            throw new FsCrawlerPluginException("not used");
+        }
+
+        @Override
+        public Doc createDocument() {
+            throw new FsCrawlerPluginException("not used");
+        }
+
+        @Override
+        public boolean supportsCrawling() {
+            return true;
+        }
+
+        @Override
+        public void closeConnection() {
+            // Stub: no remote connection.
+        }
+
+        @Override
+        public boolean exists(String directory) {
+            return true;
+        }
+
+        @Override
+        public Collection<FileAbstractModel> getFiles(String directory) {
+            return List.of();
+        }
+
+        @Override
+        public InputStream getInputStream(FileAbstractModel file) {
+            throw new FsCrawlerPluginException("Can not get input stream for " + file.getFullpath());
+        }
+
+        @Override
+        public void closeInputStream(InputStream inputStream) {
+            // Stub: no stream was opened.
+        }
+
+        @Override
+        public void close() {
+            // Stub: no resources.
+        }
+    }
+}

--- a/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestContinueOnErrorIT.java
+++ b/integration-tests/src/test/java/fr/pilato/elasticsearch/crawler/fs/test/integration/elasticsearch/FsCrawlerTestContinueOnErrorIT.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
+ */
+package fr.pilato.elasticsearch.crawler.fs.test.integration.elasticsearch;
+
+import com.carrotsearch.randomizedtesting.jupiter.RandomizedTest;
+import fr.pilato.elasticsearch.crawler.fs.client.ESSearchRequest;
+import fr.pilato.elasticsearch.crawler.fs.client.ESSearchResponse;
+import fr.pilato.elasticsearch.crawler.fs.client.ESTermQuery;
+import fr.pilato.elasticsearch.crawler.fs.framework.FsCrawlerUtil;
+import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
+import fr.pilato.elasticsearch.crawler.fs.test.integration.AbstractFsCrawlerITCase;
+import java.io.FileInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumSet;
+import java.util.Locale;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for <a href="https://github.com/dadoonet/fscrawler/issues/331">#331</a>: crawling continues after a
+ * permission denied error when {@code fs.continue_on_error} is true.
+ */
+class FsCrawlerTestContinueOnErrorIT extends AbstractFsCrawlerITCase {
+    private static final Logger logger = LogManager.getLogger();
+
+    @Test
+    void continue_on_error() throws Exception {
+        Assumptions.assumeThat(
+                        FileSystems.getDefault().supportedFileAttributeViews().contains("posix"))
+                .describedAs("This test can only run on Posix systems")
+                .isTrue();
+
+        String readableName = RandomizedTest.randomAsciiLettersOfLengthBetween(randomizedRandomForTests, 6, 12)
+                        .toLowerCase(Locale.ROOT)
+                + ".txt";
+        String unreadableName = "z_"
+                + RandomizedTest.randomAsciiLettersOfLengthBetween(randomizedRandomForTests, 6, 12)
+                        .toLowerCase(Locale.ROOT)
+                + ".txt";
+        String readableContent = RandomizedTest.randomAsciiLettersOfLengthBetween(randomizedRandomForTests, 20, 80);
+        String unreadableContent = RandomizedTest.randomAsciiLettersOfLengthBetween(randomizedRandomForTests, 20, 80);
+
+        Files.deleteIfExists(currentTestResourceDir.resolve("roottxtfile.txt"));
+        Path readableFile = currentTestResourceDir.resolve(readableName);
+        Path unreadableFile = currentTestResourceDir.resolve(unreadableName);
+        Files.writeString(readableFile, readableContent, StandardCharsets.UTF_8);
+        Files.writeString(unreadableFile, unreadableContent, StandardCharsets.UTF_8);
+
+        logger.info(" ---> Removing all permissions from [{}]", unreadableFile);
+        Files.getFileAttributeView(unreadableFile, PosixFileAttributeView.class)
+                .setPermissions(EnumSet.noneOf(PosixFilePermission.class));
+
+        // Root (and some containers) can still open mode 000 files. Skip rather than assert a false positive.
+        boolean readableAsCurrentUser;
+        try (FileInputStream in = new FileInputStream(unreadableFile.toFile())) {
+            in.read();
+            readableAsCurrentUser = true;
+        } catch (Exception e) {
+            readableAsCurrentUser = false;
+        }
+        Assumptions.assumeThat(readableAsCurrentUser)
+                .describedAs("Opening the unreadable file must fail (not running as root)")
+                .isFalse();
+
+        FsSettings fsSettings = createTestSettings();
+        fsSettings.getFs().setContinueOnError(true);
+        crawler = startCrawler(fsSettings);
+
+        String docsIndex = getCrawlerName() + FsCrawlerUtil.INDEX_SUFFIX_DOCS;
+        countTestHelper(new ESSearchRequest().withIndex(docsIndex), 1L, currentTestResourceDir);
+
+        ESSearchResponse readableHits = client.search(
+                new ESSearchRequest().withIndex(docsIndex).withESQuery(new ESTermQuery("file.filename", readableName)));
+        Assertions.assertThat(readableHits.getTotalHits()).isEqualTo(1L);
+
+        ESSearchResponse unreadableHits = client.search(new ESSearchRequest()
+                .withIndex(docsIndex)
+                .withESQuery(new ESTermQuery("file.filename", unreadableName)));
+        Assertions.assertThat(unreadableHits.getTotalHits()).isZero();
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #331.

Adds coverage for `fs.continue_on_error`, which had no behavioural test (only settings parsing).

**Unit (`FsParserContinueOnErrorTest`)**
- Stub FS provider throws `FsCrawlerPluginException` on open (same wrap as local FS permission denied)
- `continue_on_error: true` → `indexFileWithStreams` returns null (file skipped)
- `continue_on_error: false` → exception is rethrown

**IT (`FsCrawlerTestContinueOnErrorIT`)**
- POSIX `chmod 000` on one file, another file remains readable
- Skips when not POSIX, or when the current user can still open mode `000` (root)
- Expects only the readable file in Elasticsearch

Draft for review before merge.

**Test plan**
- [x] `mvn test -pl core -am -DskipIntegTests -Dtest=FsParserContinueOnErrorTest`
- [x] `mvn verify -pl integration-tests -am -DskipUnitTests -Dit.test=FsCrawlerTestContinueOnErrorIT#continue_on_error`
- [x] Red-checked the unit skip test by temporarily always-throwing in `FsParser.indexFileWithStreams`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-476679ab-a359-48a1-9237-0102268ce414?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-476679ab-a359-48a1-9237-0102268ce414&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

