### PR TITLE
fix(core): 🐛 retain folders after capped deletion query

### DIFF
--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParser.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParser.java
@@ -1668,13 +1668,14 @@ public class FsParser implements Runnable, AutoCloseable {
     }
 
     private void logDirectoryQueryLimitReached(String path, String entryType) {
-        logger.warn(
+        logger.info(
                 "Deletion query for folder [{}] returned the maximum [{}] {}. The result may be incomplete; "
-                        + "retaining folder records so remaining entries can be deleted on a later crawl.",
+                        + "retaining folder records so remaining entries can be deleted on a later crawl."
+                        + " You can restart immediately a new crawl. Check https://fscrawler.readthedocs.io/en/latest/admin/status.html#forcing-a-new-scan",
                 path,
                 FsCrawlerManagementService.DIRECTORY_QUERY_LIMIT,
                 entryType);
-    }
+}
 
     /** Remove a document with the document service */
     private void esDelete(FsCrawlerDocumentService service, String index, String id) {

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParser.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParser.java
@@ -1675,7 +1675,7 @@ public class FsParser implements Runnable, AutoCloseable {
                 path,
                 FsCrawlerManagementService.DIRECTORY_QUERY_LIMIT,
                 entryType);
-}
+    }
 
     /** Remove a document with the document service */
     private void esDelete(FsCrawlerDocumentService service, String index, String id) {

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParser.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/FsParser.java
@@ -1628,10 +1628,19 @@ public class FsParser implements Runnable, AutoCloseable {
         indexDirectory(sign(path), folder);
     }
 
-    /** Remove a full directory and sub dirs recursively */
-    private void removeEsDirectoryRecursively(final String path, ScanStatistic stats) throws Exception {
+    /**
+     * Remove a full directory and its subdirectories recursively.
+     *
+     * @return {@code true} when the complete subtree was deleted; {@code false} when a query may have been truncated
+     *     and folder records were retained for a later crawl
+     */
+    private boolean removeEsDirectoryRecursively(final String path, ScanStatistic stats) throws Exception {
         logger.debug("Delete folder [{}]", path);
         Collection<String> listFile = getFileDirectory(path);
+        boolean deletionComplete = listFile.size() < FsCrawlerManagementService.DIRECTORY_QUERY_LIMIT;
+        if (!deletionComplete) {
+            logDirectoryQueryLimitReached(path, "files");
+        }
 
         for (String esfile : listFile) {
             esDelete(managementService, fsSettings.getElasticsearch().getIndex(), generateIdFromFilename(esfile, path));
@@ -1640,11 +1649,31 @@ public class FsParser implements Runnable, AutoCloseable {
         }
 
         Collection<String> listFolder = getFolderDirectory(path);
+        if (listFolder.size() >= FsCrawlerManagementService.DIRECTORY_QUERY_LIMIT) {
+            deletionComplete = false;
+            logDirectoryQueryLimitReached(path, "folders");
+        }
         for (String esfolder : listFolder) {
-            removeEsDirectoryRecursively(esfolder, stats);
+            if (!removeEsDirectoryRecursively(esfolder, stats)) {
+                deletionComplete = false;
+            }
         }
 
-        esDelete(managementService, fsSettings.getElasticsearch().getIndexFolder(), sign(path));
+        if (deletionComplete) {
+            esDelete(managementService, fsSettings.getElasticsearch().getIndexFolder(), sign(path));
+        } else {
+            logger.debug("Retaining folder record [{}] so deletion can continue on a later crawl", path);
+        }
+        return deletionComplete;
+    }
+
+    private void logDirectoryQueryLimitReached(String path, String entryType) {
+        logger.warn(
+                "Deletion query for folder [{}] returned the maximum [{}] {}. The result may be incomplete; "
+                        + "retaining folder records so remaining entries can be deleted on a later crawl.",
+                path,
+                FsCrawlerManagementService.DIRECTORY_QUERY_LIMIT,
+                entryType);
     }
 
     /** Remove a document with the document service */

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerManagementService.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerManagementService.java
@@ -26,6 +26,9 @@ import java.util.Collection;
 
 public interface FsCrawlerManagementService extends FsCrawlerService {
 
+    /** Maximum number of direct files or folders returned by one Elasticsearch housekeeping query. */
+    int DIRECTORY_QUERY_LIMIT = 10_000;
+
     /**
      * Retrieve the list of files that are currently available within a dir
      *

--- a/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerManagementServiceElasticsearchImpl.java
+++ b/core/src/main/java/fr/pilato/elasticsearch/crawler/fs/service/FsCrawlerManagementServiceElasticsearchImpl.java
@@ -46,7 +46,6 @@ public class FsCrawlerManagementServiceElasticsearchImpl implements FsCrawlerMan
 
     // TODO Optimize it. We can probably use a search for a big array of filenames instead of
     // searching fo 10000 files (which is somehow limited).
-    private static final int REQUEST_SIZE = 10000;
     private static final String FILE_FILENAME_FIELD = "file.filename";
 
     private final IElasticsearchClient client;
@@ -93,7 +92,7 @@ public class FsCrawlerManagementServiceElasticsearchImpl implements FsCrawlerMan
             // search() retries transient shard unavailability (503) until the index is searchable
             ESSearchResponse response = client.search(new ESSearchRequest()
                     .withIndex(settings.getElasticsearch().getIndex())
-                    .withSize(REQUEST_SIZE)
+                    .withSize(DIRECTORY_QUERY_LIMIT)
                     .addStoredField(FILE_FILENAME_FIELD)
                     .withESQuery(new ESTermQuery(
                             "path.root", SignTool.sign(settings.getFs().getHashAlgorithm(), path))));
@@ -134,7 +133,7 @@ public class FsCrawlerManagementServiceElasticsearchImpl implements FsCrawlerMan
             // search() retries transient shard unavailability (503) until the index is searchable
             ESSearchResponse response = client.search(new ESSearchRequest()
                     .withIndex(settings.getElasticsearch().getIndexFolder())
-                    .withSize(REQUEST_SIZE)
+                    .withSize(DIRECTORY_QUERY_LIMIT)
                     .withESQuery(new ESTermQuery(
                             "path.root", SignTool.sign(settings.getFs().getHashAlgorithm(), path))));
 

--- a/core/src/test/java/fr/pilato/elasticsearch/crawler/fs/FsParserDeletedDirectoryLimitTest.java
+++ b/core/src/test/java/fr/pilato/elasticsearch/crawler/fs/FsParserDeletedDirectoryLimitTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to David Pilato (the "Author") under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Made from 🇫🇷🇪🇺 with ❤️ - 2011-2026
+ */
+package fr.pilato.elasticsearch.crawler.fs;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.carrotsearch.randomizedtesting.jupiter.RandomizedTest;
+import fr.pilato.elasticsearch.crawler.fs.beans.ScanStatistic;
+import fr.pilato.elasticsearch.crawler.fs.service.FsCrawlerDocumentService;
+import fr.pilato.elasticsearch.crawler.fs.service.FsCrawlerManagementService;
+import fr.pilato.elasticsearch.crawler.fs.settings.FsSettings;
+import fr.pilato.elasticsearch.crawler.fs.settings.FsSettingsLoader;
+import fr.pilato.elasticsearch.crawler.fs.test.framework.AbstractFSCrawlerTestCase;
+import fr.pilato.elasticsearch.crawler.fs.test.framework.Slow;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+
+@Slow
+class FsParserDeletedDirectoryLimitTest extends AbstractFSCrawlerTestCase {
+
+    private static final int DIRECTORY_QUERY_LIMIT = 10_000;
+
+    @Test
+    void retains_folder_record_when_file_query_reaches_limit() throws Exception {
+        TestContext context = createContext();
+        String deletedPath = randomPath();
+        String filename = randomName();
+        when(context.managementService().getFileDirectory(deletedPath))
+                .thenReturn(Collections.nCopies(DIRECTORY_QUERY_LIMIT, filename));
+        when(context.managementService().getFolderDirectory(deletedPath)).thenReturn(List.of());
+
+        removeDirectory(context.parser(), deletedPath);
+
+        verify(context.managementService(), never())
+                .delete(eq(context.settings().getElasticsearch().getIndexFolder()), anyString());
+    }
+
+    @Test
+    void retains_parent_folder_record_when_descendant_query_reaches_limit() throws Exception {
+        TestContext context = createContext();
+        String deletedPath = randomPath();
+        String childPath = deletedPath + "/" + randomName();
+        String filename = randomName();
+        when(context.managementService().getFileDirectory(deletedPath)).thenReturn(List.of());
+        when(context.managementService().getFolderDirectory(deletedPath)).thenReturn(List.of(childPath));
+        when(context.managementService().getFileDirectory(childPath))
+                .thenReturn(Collections.nCopies(DIRECTORY_QUERY_LIMIT, filename));
+        when(context.managementService().getFolderDirectory(childPath)).thenReturn(List.of());
+
+        removeDirectory(context.parser(), deletedPath);
+
+        verify(context.managementService(), never())
+                .delete(eq(context.settings().getElasticsearch().getIndexFolder()), anyString());
+    }
+
+    @Test
+    void deletes_folder_record_when_all_queries_are_below_limit() throws Exception {
+        TestContext context = createContext();
+        String deletedPath = randomPath();
+        when(context.managementService().getFileDirectory(deletedPath)).thenReturn(List.of(randomName()));
+        when(context.managementService().getFolderDirectory(deletedPath)).thenReturn(List.of());
+
+        removeDirectory(context.parser(), deletedPath);
+
+        verify(context.managementService())
+                .delete(eq(context.settings().getElasticsearch().getIndexFolder()), anyString());
+    }
+
+    private TestContext createContext() throws Exception {
+        FsSettings settings = FsSettingsLoader.load();
+        String indexPrefix = RandomizedTest.randomAsciiLettersOfLengthBetween(randomizedRandomForTests, 6, 12)
+                .toLowerCase(Locale.ROOT);
+        settings.setName(indexPrefix);
+        settings.getElasticsearch().setIndex(indexPrefix + "_docs");
+        settings.getElasticsearch().setIndexFolder(indexPrefix + "_folder");
+        FsCrawlerManagementService managementService = mock(FsCrawlerManagementService.class);
+        FsParser parser = new FsParser(
+                settings, testTmpDir, managementService, mock(FsCrawlerDocumentService.class), 1, false, null);
+        parser.closed.set(false);
+        return new TestContext(parser, settings, managementService);
+    }
+
+    private void removeDirectory(FsParser parser, String path) throws Exception {
+        Method method =
+                FsParser.class.getDeclaredMethod("removeEsDirectoryRecursively", String.class, ScanStatistic.class);
+        method.setAccessible(true);
+        method.invoke(parser, path, new ScanStatistic(path));
+    }
+
+    private String randomPath() {
+        return "/" + randomName();
+    }
+
+    private String randomName() {
+        return RandomizedTest.randomAsciiLettersOfLengthBetween(randomizedRandomForTests, 6, 12)
+                .toLowerCase(Locale.ROOT);
+    }
+
+    private record TestContext(FsParser parser, FsSettings settings, FsCrawlerManagementService managementService) {}
+}

--- a/docs/source/admin/fs/local-fs.md
+++ b/docs/source/admin/fs/local-fs.md
@@ -617,6 +617,11 @@ fs:
 Setting `remove_deleted` is forced to `false` when using the Workplace Search output.
 ```
 
+When recursively removing a deleted directory, FSCrawler queries Elasticsearch
+for up to 10,000 direct files and 10,000 direct subfolders. If either query
+returns 10,000 results, FSCrawler logs a warning and retains the affected
+folder records so deletion can continue during subsequent crawls.
+
 ## Ignore content
 
 If you don’t want to extract file content but only index filesystem

--- a/docs/source/release/3.1.md
+++ b/docs/source/release/3.1.md
@@ -24,4 +24,10 @@
 You can ask an LLM to rewrite a 3.0 `_settings.yaml` for 3.1. See {ref}`llm-assistant`
 (scenario **Migrate job settings from 3.0 to 3.1**).
 
+## Fix
+Deleting a folder with >=10K documents (in that folder) would leave orphan files in the index.
+The same would apply with the rarer >=10K folders in a folder.
+Fix - Retain folder records when deletion queries return 10,000 entries (DIRECTORY_QUERY_LIMIT).  A future scan will delete up to 10K of any left over files/folders.
+Thanks to  `@newschapmj1`
+
 Thanks to `@dadoonet` and all the contributors for this release!


### PR DESCRIPTION
- Retain folder records when deletion queries return 10,000 entries
- Propagate incomplete deletion status to ancestor folders
- Warn that deletion will continue on a later crawl
- Add regression tests and documentation