### PR TITLE
Add Dev Containers for local IDE and Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,39 @@
+{
+  "name": "FSCrawler",
+  "image": "mcr.microsoft.com/devcontainers/java:25",
+  "features": {
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "none",
+      "installMaven": true,
+      "installGradle": false
+    },
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": true
+    }
+  },
+  "forwardPorts": [9200, 5601],
+  "portsAttributes": {
+    "9200": {
+      "label": "Elasticsearch",
+      "onAutoForward": "notify"
+    },
+    "5601": {
+      "label": "Kibana (optional)",
+      "onAutoForward": "silent"
+    }
+  },
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "vscjava.vscode-java-pack",
+        "vscjava.vscode-maven"
+      ],
+      "settings": {
+        "java.configuration.updateBuildConfiguration": "automatic",
+        "java.compile.nullAnalysis.mode": "automatic"
+      }
+    }
+  },
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/extract-es-version.sh
+++ b/.devcontainer/extract-es-version.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+POM="${1:-$ROOT_DIR/pom.xml}"
+
+if [[ ! -f "$POM" ]]; then
+  echo "pom.xml not found: $POM" >&2
+  exit 1
+fi
+
+# Prefer xmllint if available; fall back to sed for the first elasticsearch.version property.
+version=""
+if command -v xmllint >/dev/null 2>&1; then
+  version="$(xmllint --xpath "string(/*[local-name()='project']/*[local-name()='properties']/*[local-name()='elasticsearch.version'])" "$POM" 2>/dev/null || true)"
+fi
+
+if [[ -z "$version" ]]; then
+  version="$(sed -n 's/.*<elasticsearch\.version>\([^<][^<]*\)<\/elasticsearch\.version>.*/\1/p' "$POM" | head -n 1)"
+fi
+
+if [[ -z "$version" ]]; then
+  echo "Could not read elasticsearch.version from $POM" >&2
+  exit 1
+fi
+
+printf '%s\n' "$version"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+ES_DIR="$ROOT_DIR/IGNORE_ME/elastic-start-local"
+ES_URL="${ES_LOCAL_URL:-http://localhost:9200}"
+ES_PASSWORD="${ES_LOCAL_PASSWORD:-changeme}"
+
+echo "==> FSCrawler Dev Container post-create"
+
+mkdir -p "$ROOT_DIR/IGNORE_ME"
+
+es_up() {
+  curl -fsS -u "elastic:${ES_PASSWORD}" "$ES_URL" >/dev/null 2>&1 \
+    || curl -fsS "$ES_URL" >/dev/null 2>&1
+}
+
+if es_up; then
+  echo "==> Elasticsearch already reachable at $ES_URL — skipping start-local"
+else
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "ERROR: docker CLI not found. Docker-outside-of-Docker is required for start-local." >&2
+    exit 1
+  fi
+  if ! docker info >/dev/null 2>&1; then
+    echo "ERROR: cannot talk to Docker daemon (socket / permissions)." >&2
+    exit 1
+  fi
+
+  ES_VERSION="$("$ROOT_DIR/.devcontainer/extract-es-version.sh")"
+  echo "==> Starting Elasticsearch ${ES_VERSION} via start-local (ES-only) under IGNORE_ME/"
+
+  # If a previous install exists, prefer start.sh; otherwise bootstrap.
+  if [[ -x "$ES_DIR/start.sh" ]]; then
+    (cd "$ES_DIR" && ./start.sh)
+  else
+    curl -fsSL https://elastic.co/start-local \
+      | ES_LOCAL_PASSWORD="$ES_PASSWORD" ES_LOCAL_DIR="$ES_DIR" \
+        sh -s -- -v "$ES_VERSION" --esonly
+  fi
+
+  echo "==> Waiting for Elasticsearch at $ES_URL"
+  for i in $(seq 1 60); do
+    if es_up; then
+      echo "==> Elasticsearch is up"
+      break
+    fi
+    if [[ "$i" -eq 60 ]]; then
+      echo "ERROR: Elasticsearch did not become ready in time" >&2
+      exit 1
+    fi
+    sleep 2
+  done
+fi
+
+echo "==> Warming Maven dependencies (dependency:go-offline)"
+mvn -q dependency:go-offline -DskipTests
+
+echo
+echo "==> Ready."
+echo "    Build:  mvn clean package -DskipTests -Ddocker.skip"
+echo "    ITs vs start-local:"
+if [[ -f "$ES_DIR/.env" ]]; then
+  # shellcheck disable=SC1090
+  set -a
+  # shellcheck disable=SC1091
+  source "$ES_DIR/.env"
+  set +a
+  echo "      source IGNORE_ME/elastic-start-local/.env"
+  echo "      mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it \\"
+  echo "        -Dtests.cluster.url=http://localhost:9200 \\"
+  echo "        -Dtests.cluster.apiKey=\"\$ES_LOCAL_API_KEY\""
+else
+  echo "      (start-local .env not found yet — re-run post-create or start-local)"
+fi
+echo "    Optional Kibana: re-run start-local without --esonly (same ES_LOCAL_DIR / password / version)."

--- a/docs/source/dev/build.md
+++ b/docs/source/dev/build.md
@@ -6,6 +6,8 @@ Thanks to [JetBrains](https://www.jetbrains.com/?from=FSCrawler) for the Intelli
 
 [![Jet Brains](../jetbrains.png)](https://www.jetbrains.com/?from=FSCrawler)
 
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dadoonet/fscrawler)
+
 ```{contents}
 :backlinks: entry
 ```
@@ -18,6 +20,62 @@ Use git to clone the project locally:
 git clone git@github.com:dadoonet/fscrawler.git
 cd fscrawler
 ```
+
+## Dev Containers and GitHub Codespaces
+
+You can develop FSCrawler in [VS Code](https://code.visualstudio.com/) /
+[Cursor](https://cursor.com/) Dev Containers or in
+[GitHub Codespaces](https://github.com/features/codespaces) using the shared
+configuration under `.devcontainer/`.
+
+### Prerequisites (local Dev Containers)
+
+* Docker Desktop (or another Docker engine) on the host
+* VS Code / Cursor with the Dev Containers extension
+
+Open the repository and use **Reopen in Container**. For Codespaces, use the
+badge above or open a codespace from the GitHub UI.
+
+### What the container provides
+
+* JDK 25 and Maven
+* Docker-outside-of-Docker (required for Elastic [start-local](https://github.com/elastic/start-local))
+* After create, `post-create.sh`:
+  * Starts Elasticsearch **9.x** (version from `<elasticsearch.version>` in the root `pom.xml`) with start-local **ES-only** under `IGNORE_ME/elastic-start-local/`
+  * Uses password `changeme` for the `elastic` user
+  * Warms the local Maven repository (`dependency:go-offline`)
+
+Elasticsearch is then available at `http://localhost:9200`.
+
+### Build and test inside the container
+
+```shell
+mvn clean package -DskipTests -Ddocker.skip
+```
+
+To run integration tests against the start-local cluster instead of Testcontainers:
+
+```shell
+source IGNORE_ME/elastic-start-local/.env
+mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it \
+  -Dtests.cluster.url=http://localhost:9200 \
+  -Dtests.cluster.apiKey="$ES_LOCAL_API_KEY"
+```
+
+### Optional Kibana
+
+By default only Elasticsearch is started (`--esonly`). To also run Kibana, re-run
+start-local **without** `--esonly`, using the same directory, password, and version,
+for example:
+
+```shell
+ES_VERSION="$(./.devcontainer/extract-es-version.sh)"
+curl -fsSL https://elastic.co/start-local \
+  | ES_LOCAL_PASSWORD=changeme ES_LOCAL_DIR="$PWD/IGNORE_ME/elastic-start-local" \
+    sh -s -- -v "$ES_VERSION"
+```
+
+Kibana listens on `http://localhost:5601` when enabled.
 
 ## Build the artifact
 

--- a/docs/superpowers/plans/2026-09-04-devcontainers.md
+++ b/docs/superpowers/plans/2026-09-04-devcontainers.md
@@ -1,0 +1,466 @@
+# Dev Containers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a shared Dev Container (local VS Code/Cursor + GitHub Codespaces) with JDK 25, Maven, Docker-outside-of-Docker, Elasticsearch via start-local (ES-only), and docs with a Codespaces badge.
+
+**Architecture:** Microsoft `devcontainers/java:25` image plus Maven (via Java feature with `version: "none"`) and `docker-outside-of-docker`. `postCreateCommand` runs `.devcontainer/post-create.sh`, which starts Elastic start-local under `IGNORE_ME/` and warms Maven dependencies.
+
+**Tech Stack:** Dev Containers, JDK 25, Maven, Docker-outside-of-Docker, Elastic start-local, MyST Markdown docs
+
+**Spec:** `docs/superpowers/specs/2026-09-04-devcontainers-design.md`
+
+## Global Constraints
+
+- JDK **25** (`mcr.microsoft.com/devcontainers/java:25`)
+- Elasticsearch **9.x** from root `pom.xml` property `<elasticsearch.version>` (currently `9.5.2`)
+- start-local with `--esonly`, `ES_LOCAL_PASSWORD=changeme`, files under `IGNORE_ME/`
+- Docker-outside-of-Docker required; fail-fast if start-local cannot run
+- No versioned ES compose in `.devcontainer/`
+- Commit messages: `type(scope): emoji description` with detail bullets
+- Branch: `cursor/add-devcontainers-ab5d` (already exists)
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `.devcontainer/devcontainer.json` | Container image, features, ports, extensions, postCreate |
+| `.devcontainer/post-create.sh` | Idempotent ES start-local + Maven warm-up + usage hints |
+| `.devcontainer/extract-es-version.sh` | Read `<elasticsearch.version>` from root `pom.xml` |
+| `docs/source/dev/build.md` | Codespaces badge + Dev Containers section |
+
+---
+
+### Task 1: Extract Elasticsearch version from `pom.xml`
+
+**Files:**
+- Create: `.devcontainer/extract-es-version.sh`
+- Test: run the script against the real root `pom.xml` (no new Java test module)
+
+**Interfaces:**
+- Consumes: root `pom.xml` path (default: repo root `pom.xml`)
+- Produces: stdout = version string only (e.g. `9.5.2`); exit `0` on success, non-zero on failure
+
+- [ ] **Step 1: Write the script skeleton that fails until parsing works**
+
+Create `.devcontainer/extract-es-version.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+POM="${1:-$ROOT_DIR/pom.xml}"
+
+if [[ ! -f "$POM" ]]; then
+  echo "pom.xml not found: $POM" >&2
+  exit 1
+fi
+
+# Prefer xmllint if available; fall back to sed for the first elasticsearch.version property.
+version=""
+if command -v xmllint >/dev/null 2>&1; then
+  version="$(xmllint --xpath "string(/*[local-name()='project']/*[local-name()='properties']/*[local-name()='elasticsearch.version'])" "$POM" 2>/dev/null || true)"
+fi
+
+if [[ -z "$version" ]]; then
+  version="$(sed -n 's/.*<elasticsearch\.version>\([^<][^<]*\)<\/elasticsearch\.version>.*/\1/p' "$POM" | head -n 1)"
+fi
+
+if [[ -z "$version" ]]; then
+  echo "Could not read elasticsearch.version from $POM" >&2
+  exit 1
+fi
+
+printf '%s\n' "$version"
+```
+
+- [ ] **Step 2: Make executable and run against the real pom**
+
+```bash
+chmod +x .devcontainer/extract-es-version.sh
+./.devcontainer/extract-es-version.sh
+```
+
+Expected: prints `9.5.2` (or whatever `<elasticsearch.version>` is in root `pom.xml`).
+
+- [ ] **Step 3: Negative check — missing file fails**
+
+```bash
+./.devcontainer/extract-es-version.sh /tmp/does-not-exist-pom.xml ; echo exit:$?
+```
+
+Expected: non-zero exit and error on stderr.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .devcontainer/extract-es-version.sh
+git commit -m "$(cat <<'EOF'
+feat(devcontainer): ✨ add elasticsearch.version extractor for start-local
+
+- Read root pom.xml property for Dev Container post-create
+- Support xmllint with sed fallback
+EOF
+)"
+```
+
+---
+
+### Task 2: `post-create.sh` (start-local + Maven warm-up)
+
+**Files:**
+- Create: `.devcontainer/post-create.sh`
+- Consumes: `.devcontainer/extract-es-version.sh`
+
+**Interfaces:**
+- Consumes: `extract-es-version.sh` → version string; Docker CLI; network for start-local curl
+- Produces: `IGNORE_ME/elastic-start-local/` with running ES (or skip if already up); warmed local Maven repo; exit non-zero if start-local fails when ES is down
+
+- [ ] **Step 1: Create `.devcontainer/post-create.sh`**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+ES_DIR="$ROOT_DIR/IGNORE_ME/elastic-start-local"
+ES_URL="${ES_LOCAL_URL:-http://localhost:9200}"
+ES_PASSWORD="${ES_LOCAL_PASSWORD:-changeme}"
+
+echo "==> FSCrawler Dev Container post-create"
+
+mkdir -p "$ROOT_DIR/IGNORE_ME"
+
+es_up() {
+  curl -fsS -u "elastic:${ES_PASSWORD}" "$ES_URL" >/dev/null 2>&1 \
+    || curl -fsS "$ES_URL" >/dev/null 2>&1
+}
+
+if es_up; then
+  echo "==> Elasticsearch already reachable at $ES_URL — skipping start-local"
+else
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "ERROR: docker CLI not found. Docker-outside-of-Docker is required for start-local." >&2
+    exit 1
+  fi
+  if ! docker info >/dev/null 2>&1; then
+    echo "ERROR: cannot talk to Docker daemon (socket / permissions)." >&2
+    exit 1
+  fi
+
+  ES_VERSION="$("$ROOT_DIR/.devcontainer/extract-es-version.sh")"
+  echo "==> Starting Elasticsearch ${ES_VERSION} via start-local (ES-only) under IGNORE_ME/"
+
+  # If a previous install exists, prefer start.sh; otherwise bootstrap.
+  if [[ -x "$ES_DIR/start.sh" ]]; then
+    (cd "$ES_DIR" && ./start.sh)
+  else
+    curl -fsSL https://elastic.co/start-local \
+      | ES_LOCAL_PASSWORD="$ES_PASSWORD" ES_LOCAL_DIR="$ES_DIR" \
+        sh -s -- -v "$ES_VERSION" --esonly
+  fi
+
+  echo "==> Waiting for Elasticsearch at $ES_URL"
+  for i in $(seq 1 60); do
+    if es_up; then
+      echo "==> Elasticsearch is up"
+      break
+    fi
+    if [[ "$i" -eq 60 ]]; then
+      echo "ERROR: Elasticsearch did not become ready in time" >&2
+      exit 1
+    fi
+    sleep 2
+  done
+fi
+
+echo "==> Warming Maven dependencies (dependency:go-offline)"
+mvn -q dependency:go-offline -DskipTests
+
+echo
+echo "==> Ready."
+echo "    Build:  mvn clean package -DskipTests -Ddocker.skip"
+echo "    ITs vs start-local:"
+if [[ -f "$ES_DIR/.env" ]]; then
+  # shellcheck disable=SC1090
+  set -a
+  # shellcheck disable=SC1091
+  source "$ES_DIR/.env"
+  set +a
+  echo "      source IGNORE_ME/elastic-start-local/.env"
+  echo "      mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it \\"
+  echo "        -Dtests.cluster.url=http://localhost:9200 \\"
+  echo "        -Dtests.cluster.apiKey=\"\$ES_LOCAL_API_KEY\""
+else
+  echo "      (start-local .env not found yet — re-run post-create or start-local)"
+fi
+echo "    Optional Kibana: re-run start-local without --esonly (same ES_LOCAL_DIR / password / version)."
+```
+
+- [ ] **Step 2: Make executable and syntax-check**
+
+```bash
+chmod +x .devcontainer/post-create.sh
+bash -n .devcontainer/post-create.sh
+bash -n .devcontainer/extract-es-version.sh
+```
+
+Expected: no output (syntax OK).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .devcontainer/post-create.sh
+git commit -m "$(cat <<'EOF'
+feat(devcontainer): ✨ add post-create start-local and Maven warm-up
+
+- Start ES-only via Elastic start-local under IGNORE_ME/
+- Fail fast when Docker is unavailable; skip if ES already up
+- Run mvn dependency:go-offline and print IT hints
+EOF
+)"
+```
+
+---
+
+### Task 3: `devcontainer.json`
+
+**Files:**
+- Create: `.devcontainer/devcontainer.json`
+
+**Interfaces:**
+- Consumes: `.devcontainer/post-create.sh`
+- Produces: Dev Container / Codespaces definition (JDK 25, Maven, DooD, port 9200)
+
+- [ ] **Step 1: Create `.devcontainer/devcontainer.json`**
+
+```json
+{
+  "name": "FSCrawler",
+  "image": "mcr.microsoft.com/devcontainers/java:25",
+  "features": {
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "none",
+      "installMaven": true,
+      "installGradle": false
+    },
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": true
+    }
+  },
+  "forwardPorts": [9200, 5601],
+  "portsAttributes": {
+    "9200": {
+      "label": "Elasticsearch",
+      "onAutoForward": "notify"
+    },
+    "5601": {
+      "label": "Kibana (optional)",
+      "onAutoForward": "silent"
+    }
+  },
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "vscjava.vscode-java-pack",
+        "vscjava.vscode-maven"
+      ],
+      "settings": {
+        "java.configuration.updateBuildConfiguration": "automatic",
+        "java.compile.nullAnalysis.mode": "automatic"
+      }
+    }
+  },
+  "remoteUser": "vscode"
+}
+```
+
+- [ ] **Step 2: Validate JSON**
+
+```bash
+python3 -c 'import json; json.load(open(".devcontainer/devcontainer.json")); print("ok")'
+```
+
+Expected: `ok`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .devcontainer/devcontainer.json
+git commit -m "$(cat <<'EOF'
+feat(devcontainer): ✨ add Dev Container config for JDK 25 and Codespaces
+
+- Use microsoft/devcontainers java:25 with Maven and DooD
+- Forward ES 9200 and optional Kibana 5601
+- Wire postCreateCommand to start-local + Maven warm-up
+EOF
+)"
+```
+
+---
+
+### Task 4: Documentation (`build.md` + Codespaces badge)
+
+**Files:**
+- Modify: `docs/source/dev/build.md`
+
+**Interfaces:**
+- Documents Tasks 1–3 for contributors
+
+- [ ] **Step 1: Add Codespaces badge near the top of `docs/source/dev/build.md`**
+
+After the JetBrains thanks block (around lines 4–7), add:
+
+```markdown
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dadoonet/fscrawler)
+```
+
+- [ ] **Step 2: Add a Dev Containers / Codespaces section**
+
+Insert a new section after `## Clone the project` (or immediately before `## Build the artifact`) with:
+
+```markdown
+## Dev Containers and GitHub Codespaces
+
+You can develop FSCrawler in [VS Code](https://code.visualstudio.com/) /
+[Cursor](https://cursor.com/) Dev Containers or in
+[GitHub Codespaces](https://github.com/features/codespaces) using the shared
+configuration under `.devcontainer/`.
+
+### Prerequisites (local Dev Containers)
+
+* Docker Desktop (or another Docker engine) on the host
+* VS Code / Cursor with the Dev Containers extension
+
+Open the repository and use **Reopen in Container**. For Codespaces, use the
+badge above or open a codespace from the GitHub UI.
+
+### What the container provides
+
+* JDK 25 and Maven
+* Docker-outside-of-Docker (required for Elastic [start-local](https://github.com/elastic/start-local))
+* After create, `post-create.sh`:
+  * Starts Elasticsearch **9.x** (version from `<elasticsearch.version>` in the root `pom.xml`) with start-local **ES-only** under `IGNORE_ME/elastic-start-local/`
+  * Uses password `changeme` for the `elastic` user
+  * Warms the local Maven repository (`dependency:go-offline`)
+
+Elasticsearch is then available at `http://localhost:9200`.
+
+### Build and test inside the container
+
+```shell
+mvn clean package -DskipTests -Ddocker.skip
+```
+
+To run integration tests against the start-local cluster instead of Testcontainers:
+
+```shell
+source IGNORE_ME/elastic-start-local/.env
+mvn verify -pl fr.pilato.elasticsearch.crawler:fscrawler-it \
+  -Dtests.cluster.url=http://localhost:9200 \
+  -Dtests.cluster.apiKey="$ES_LOCAL_API_KEY"
+```
+
+### Optional Kibana
+
+By default only Elasticsearch is started (`--esonly`). To also run Kibana, re-run
+start-local **without** `--esonly`, using the same directory, password, and version,
+for example:
+
+```shell
+ES_VERSION="$(./.devcontainer/extract-es-version.sh)"
+curl -fsSL https://elastic.co/start-local \
+  | ES_LOCAL_PASSWORD=changeme ES_LOCAL_DIR="$PWD/IGNORE_ME/elastic-start-local" \
+    sh -s -- -v "$ES_VERSION"
+```
+
+Kibana listens on `http://localhost:5601` when enabled.
+```
+
+Match the surrounding MyST style (fenced shell blocks, `*` lists). Adjust wording only if needed for Sphinx/MyST consistency; do not invent settings keys.
+
+- [ ] **Step 3: Spot-check the section renders as valid MyST** (no unclosed fences)
+
+```bash
+# Count fences in the new section mentally / via editor; ensure even number of ``` lines in the file region
+python3 - <<'PY'
+from pathlib import Path
+text = Path("docs/source/dev/build.md").read_text()
+assert "codespaces.new/dadoonet/fscrawler" in text
+assert "Dev Containers and GitHub Codespaces" in text
+assert "start-local" in text
+print("doc checks ok")
+PY
+```
+
+Expected: `doc checks ok`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/source/dev/build.md
+git commit -m "$(cat <<'EOF'
+docs(devcontainer): 📝 document Dev Containers and Codespaces
+
+- Add Codespaces badge to build guide
+- Describe post-create, start-local ES-only, IT flags, optional Kibana
+EOF
+)"
+```
+
+---
+
+### Task 5: Final verification and PR update
+
+**Files:**
+- Review only (no new code unless fixes)
+
+- [ ] **Step 1: Verify all artifacts exist and are executable**
+
+```bash
+test -f .devcontainer/devcontainer.json
+test -x .devcontainer/post-create.sh
+test -x .devcontainer/extract-es-version.sh
+./.devcontainer/extract-es-version.sh | grep -E '^[0-9]+\.[0-9]+\.[0-9]+'
+python3 -c 'import json; json.load(open(".devcontainer/devcontainer.json"))'
+bash -n .devcontainer/post-create.sh
+```
+
+Expected: all succeed; version like `9.5.2`.
+
+- [ ] **Step 2: Push branch and update PR description**
+
+```bash
+git push -u origin cursor/add-devcontainers-ab5d
+```
+
+Update PR #2539 body to mark implementation complete and list the verification commands above.
+
+- [ ] **Step 3: Spec coverage self-check**
+
+Confirm each spec requirement maps to a task:
+
+| Spec item | Task |
+|-----------|------|
+| Local + Codespaces shared config | 3 |
+| JDK 25 + Maven + DooD | 3 |
+| start-local ES-only under IGNORE_ME | 2 |
+| Version from pom | 1 |
+| Maven go-offline | 2 |
+| Fail-fast on Docker | 2 |
+| Skip if ES up | 2 |
+| Docs + badge | 4 |
+| Optional Kibana documented | 4 |
+| No versioned ES compose in `.devcontainer/` | (none added) |
+
+---
+
+## Self-review (plan author)
+
+1. **Spec coverage:** All approved decisions covered in Tasks 1–5.
+2. **Placeholders:** None; scripts and JSON are complete.
+3. **Consistency:** `ES_DIR=IGNORE_ME/elastic-start-local`, password `changeme`, image `java:25`, IT module `fr.pilato.elasticsearch.crawler:fscrawler-it` match existing docs.

--- a/docs/superpowers/specs/2026-09-04-devcontainers-design.md
+++ b/docs/superpowers/specs/2026-09-04-devcontainers-design.md
@@ -1,0 +1,123 @@
+# Design: Dev Containers for FSCrawler
+
+**Date:** 2026-09-04  
+**Status:** Approved for implementation planning  
+**Scope:** Shared Dev Container config for local VS Code/Cursor and GitHub Codespaces
+
+## Goals
+
+- One-click / reopen-in-container environment for contributors
+- Same config works for **local Dev Containers** and **GitHub Codespaces**
+- JDK **25**, Maven, Git, and Docker-outside-of-Docker (DooD)
+- Elasticsearch **9.x** available after create via Elastic **start-local** (ES-only by default)
+- Document usage in `docs/source/dev/build.md` and add a Codespaces badge
+
+## Non-goals
+
+- Versioned Elasticsearch `docker-compose.yml` inside `.devcontainer/`
+- Docker-in-Docker as the primary story
+- Changing application Java code or default IT Testcontainers behavior
+- Auto-starting Kibana (optional, documented only)
+
+## Architecture
+
+```
+.devcontainer/
+  devcontainer.json    # VS Code / Cursor / Codespaces entrypoint
+  post-create.sh       # start-local + Maven dependency warm-up
+docs/source/dev/build.md   # Dev Containers / Codespaces section + badge
+```
+
+- **App container:** Microsoft Dev Containers Java feature stack with **JDK 25** and Maven
+- **Docker access:** `docker-outside-of-docker` feature (host Docker socket) so start-local can run
+- **Elasticsearch:** started in `postCreateCommand` via [start-local](https://github.com/elastic/start-local) under `IGNORE_ME/` (already gitignored)
+- **No** sibling compose service managed by Dev Containers for ES — start-local owns the generated compose / `.env`
+
+## Components
+
+### `devcontainer.json`
+
+- Base: Ubuntu + Dev Container feature `ghcr.io/devcontainers/features/java` with `version: "25"` and Maven enabled (or equivalent Microsoft Java 25 image if available and equivalent)
+- Features:
+  - `java` (JDK 25 + Maven)
+  - `docker-outside-of-docker`
+  - Git (via image/feature as needed)
+- `forwardPorts`: `9200` (Elasticsearch); document `5601` for optional Kibana
+- VS Code extensions: Extension Pack for Java, Maven for Java
+- `postCreateCommand`: `bash .devcontainer/post-create.sh`
+- `remoteUser`: default `vscode`
+
+### `post-create.sh`
+
+1. Ensure `IGNORE_ME/` exists
+2. If Elasticsearch already responds on `http://localhost:9200` → skip start-local
+3. Otherwise run start-local with:
+   - `ES_LOCAL_PASSWORD=changeme`
+   - `ES_LOCAL_DIR=IGNORE_ME/elastic-start-local` (or equivalent under `IGNORE_ME/`)
+   - `-v <elasticsearch.version from pom.xml>` (pin to current default, e.g. `9.5.2`)
+   - `--esonly`
+4. Warm Maven deps: `mvn -q dependency:go-offline -DskipTests` (or closest practical equivalent used by the project)
+5. Print how to run ITs against the cluster using `tests.cluster.url` and `tests.cluster.apiKey` from `IGNORE_ME/elastic-start-local/.env` (`ES_LOCAL_API_KEY`)
+
+### Kibana (optional)
+
+- Not started by default
+- Document: re-run start-local **without** `--esonly` (same version / password / dir) when Kibana is needed
+
+### Version pinning
+
+- JDK: **25**
+- Elasticsearch: **9.x**, aligned with `<elasticsearch.version>` in root `pom.xml`
+- Script should read the version from `pom.xml` when practical; otherwise keep a clearly marked constant updated with that property
+
+## Developer workflow
+
+1. Open repo in Dev Container or Codespaces
+2. Wait for `post-create.sh` (start-local + Maven warm-up)
+3. Build: `mvn clean package -DskipTests -Ddocker.skip` (or full build as needed)
+4. Integration tests against start-local:
+
+```bash
+source IGNORE_ME/elastic-start-local/.env
+mvn verify ... -Dtests.cluster.url=http://localhost:9200 -Dtests.cluster.apiKey="$ES_LOCAL_API_KEY"
+```
+
+(Exact Maven module flags follow existing project docs.)
+
+## Documentation
+
+Update `docs/source/dev/build.md`:
+
+- Codespaces badge pointing at this repository
+- Section explaining Dev Containers / Codespaces
+- Prerequisites (Docker on the host for local Dev Containers)
+- What `post-create` does
+- How to run builds and ITs against start-local
+- How to enable Kibana optionally
+
+## Error handling / edge cases
+
+- **ES already running:** skip start-local; do not fail create
+- **start-local / Docker failure:** fail clearly with a message that Docker socket / DooD is required; leave Maven warm-up optional to still run if ES failed (prefer fail-fast on ES if DooD is broken, so contributors notice early)
+- **Network required** on first create to download start-local and Maven artifacts
+- **Codespaces create time:** Maven `go-offline` may be slow; acceptable per product decision
+- Generated start-local files must stay under `IGNORE_ME/` and never be committed
+
+## Testing / verification for this change
+
+- Static review of `.devcontainer/*` and docs
+- Where possible in the agent environment: shellcheck-style sanity, JSON validity, dry-run of version extraction from `pom.xml`
+- Full Codespaces boot is not required to merge; manual smoke by maintainer is enough for v1
+
+## Decisions log
+
+| Topic | Choice |
+|-------|--------|
+| Target | Local Dev Containers + Codespaces |
+| JDK | 25 |
+| ES | 9.x via start-local `--esonly` |
+| Docker in container | DooD (socket), for start-local |
+| Kibana | Optional, documented |
+| Maven warm-up | Yes (`dependency:go-offline`) |
+| Docs | `build.md` + Codespaces badge |
+| Image approach | Microsoft Dev Containers Java features (approach 1) |

--- a/docs/superpowers/specs/2026-09-04-devcontainers-design.md
+++ b/docs/superpowers/specs/2026-09-04-devcontainers-design.md
@@ -97,8 +97,8 @@ Update `docs/source/dev/build.md`:
 
 ## Error handling / edge cases
 
-- **ES already running:** skip start-local; do not fail create
-- **start-local / Docker failure:** fail clearly with a message that Docker socket / DooD is required; leave Maven warm-up optional to still run if ES failed (prefer fail-fast on ES if DooD is broken, so contributors notice early)
+- **ES already running:** skip start-local; continue with Maven warm-up
+- **start-local / Docker failure:** exit non-zero with a clear message that Docker socket / DooD is required (fail-fast; do not hide a broken Docker setup behind a successful Maven warm-up)
 - **Network required** on first create to download start-local and Maven artifacts
 - **Codespaces create time:** Maven `go-offline` may be slow; acceptable per product decision
 - Generated start-local files must stay under `IGNORE_ME/` and never be committed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a shared Dev Container configuration so contributors can develop FSCrawler in VS Code, Cursor, or GitHub Codespaces with JDK 25, Maven, Docker-outside-of-Docker, and Elasticsearch via Elastic [start-local](https://github.com/elastic/start-local) (ES-only by default).

**Status:** Implementation complete (Tasks 1–4).

## Changes

### `.devcontainer/`

- **`devcontainer.json`** — Microsoft Java 25 image, Maven, Docker-outside-of-Docker, port forwards for Elasticsearch (`9200`) and optional Kibana (`5601`), Java/Maven VS Code extensions, `postCreateCommand`.
- **`post-create.sh`** — Ensures `IGNORE_ME/` exists; skips start-local if Elasticsearch is already up; otherwise bootstraps or reuses start-local under `IGNORE_ME/elastic-start-local/` with password `changeme` and version from `pom.xml` (`--esonly`); warms Maven with `dependency:go-offline`; prints IT command using `ES_LOCAL_API_KEY`.
- **`extract-es-version.sh`** — Reads `<elasticsearch.version>` from root `pom.xml` (xmllint or sed fallback).

### Documentation

- **`docs/source/dev/build.md`** — Codespaces badge, Dev Containers / Codespaces section (prerequisites, post-create behavior, build/IT commands, optional Kibana).

### Design & plan

- Spec: `docs/superpowers/specs/2026-09-04-devcontainers-design.md`
- Plan: `docs/superpowers/plans/2026-09-04-devcontainers.md`

## Verification (automated)

All checks passed on branch `cursor/add-devcontainers-ab5d`:

```bash
test -f .devcontainer/devcontainer.json
test -x .devcontainer/post-create.sh
test -x .devcontainer/extract-es-version.sh
./.devcontainer/extract-es-version.sh | grep -E '^[0-9]+\.[0-9]+\.[0-9]+'   # → 9.5.2
python3 -c 'import json; json.load(open(".devcontainer/devcontainer.json"))'
bash -n .devcontainer/post-create.sh
```

## Test plan

- [x] `extract-es-version.sh` prints `<elasticsearch.version>` from root `pom.xml` (`9.5.2`)
- [x] Validate `devcontainer.json` JSON
- [x] `bash -n` on `post-create.sh`
- [x] Doc checks for Codespaces badge + Dev Containers section
- [ ] Smoke (manual): Reopen in Container / Codespaces — post-create starts ES on `:9200` and warms Maven deps

## Spec coverage

| Requirement | Done |
|-------------|------|
| Shared local + Codespaces config | ✅ |
| JDK 25 + Maven + DooD | ✅ |
| start-local ES-only under `IGNORE_ME/` | ✅ |
| ES version from `pom.xml` | ✅ |
| Maven `dependency:go-offline` | ✅ |
| Fail-fast if Docker unavailable | ✅ |
| Skip start-local if ES already up | ✅ |
| Docs + Codespaces badge | ✅ |
| Optional Kibana documented (not auto-started) | ✅ |
| No versioned ES compose in `.devcontainer/` | ✅ |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06d0a-028b-77a0-a92e-6154891aab5d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06d0a-028b-77a0-a92e-6154891aab5d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

